### PR TITLE
test+fix(cluster): T-6 Raft FSM + replication — 2 data races fixed

### DIFF
--- a/Levara/docs/testing-logs/2026-04-15-cluster.txt
+++ b/Levara/docs/testing-logs/2026-04-15-cluster.txt
@@ -1,0 +1,42 @@
+?   	github.com/stek0v/cognevra/cmd/backup	[no test files]
+?   	github.com/stek0v/cognevra/cmd/benchmark	[no test files]
+?   	github.com/stek0v/cognevra/cmd/cli	[no test files]
+?   	github.com/stek0v/cognevra/cmd/loadtest	[no test files]
+?   	github.com/stek0v/cognevra/cmd/server	[no test files]
+ok  	github.com/stek0v/cognevra/internal/cluster	2.061s
+ok  	github.com/stek0v/cognevra/internal/grpc	1.957s
+?   	github.com/stek0v/cognevra/internal/http	[no test files]
+?   	github.com/stek0v/cognevra/internal/metrics	[no test files]
+ok  	github.com/stek0v/cognevra/internal/store	25.734s
+ok  	github.com/stek0v/cognevra/pipeline	3.913s
+ok  	github.com/stek0v/cognevra/pkg/aggregator	2.544s
+?   	github.com/stek0v/cognevra/pkg/audio	[no test files]
+?   	github.com/stek0v/cognevra/pkg/backup	[no test files]
+ok  	github.com/stek0v/cognevra/pkg/bm25	3.456s
+ok  	github.com/stek0v/cognevra/pkg/chunker	3.875s
+?   	github.com/stek0v/cognevra/pkg/classify	[no test files]
+ok  	github.com/stek0v/cognevra/pkg/community	4.315s
+ok  	github.com/stek0v/cognevra/pkg/embed	4.802s
+?   	github.com/stek0v/cognevra/pkg/extract	[no test files]
+?   	github.com/stek0v/cognevra/pkg/fetch	[no test files]
+ok  	github.com/stek0v/cognevra/pkg/fileio	3.263s
+?   	github.com/stek0v/cognevra/pkg/git	[no test files]
+ok  	github.com/stek0v/cognevra/pkg/graph	3.421s
+ok  	github.com/stek0v/cognevra/pkg/graphdb	2.614s
+ok  	github.com/stek0v/cognevra/pkg/graphrank	2.791s
+?   	github.com/stek0v/cognevra/pkg/graphstore	[no test files]
+ok  	github.com/stek0v/cognevra/pkg/ingest	3.100s
+ok  	github.com/stek0v/cognevra/pkg/llm	3.491s
+ok  	github.com/stek0v/cognevra/pkg/llm/mock	3.110s
+ok  	github.com/stek0v/cognevra/pkg/llmcache	3.166s
+ok  	github.com/stek0v/cognevra/pkg/llmproxy	2.874s
+ok  	github.com/stek0v/cognevra/pkg/observe	3.180s
+ok  	github.com/stek0v/cognevra/pkg/ontology	2.974s
+ok  	github.com/stek0v/cognevra/pkg/orchestrator	3.143s
+ok  	github.com/stek0v/cognevra/pkg/rerank	3.003s
+ok  	github.com/stek0v/cognevra/pkg/router	3.237s
+ok  	github.com/stek0v/cognevra/pkg/storage	3.155s
+ok  	github.com/stek0v/cognevra/pkg/temporal	3.078s
+?   	github.com/stek0v/cognevra/pkg/vectorstore	[no test files]
+?   	github.com/stek0v/cognevra/proto	[no test files]
+?   	github.com/stek0v/cognevra/proto/pb	[no test files]

--- a/Levara/internal/cluster/direct_test.go
+++ b/Levara/internal/cluster/direct_test.go
@@ -1,0 +1,127 @@
+package cluster
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stek0v/cognevra/internal/store"
+)
+
+// T-6: DirectNode is the single-node path (no Raft); it must forward all
+// operations to the embedded store.Levara AND trigger replication when a
+// ReplicationServer is attached and has active replicas.
+
+func newDirectNode(t testing.TB, dim int, withRepl bool) (*DirectNode, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "levara-direct-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := store.NewLevara(dim, dir+"/meta.bin")
+	if err != nil {
+		os.RemoveAll(dir)
+		t.Fatal(err)
+	}
+	dn := &DirectNode{DB: db}
+	if withRepl {
+		dn.Repl = NewReplicationServer("primary", nil, db)
+	}
+	return dn, func() {
+		_ = db.Close()
+		os.RemoveAll(dir)
+	}
+}
+
+func TestDirectNode_InsertSearchDelete(t *testing.T) {
+	dn, cleanup := newDirectNode(t, 2, false)
+	defer cleanup()
+
+	if err := dn.Insert("x", []float32{1, 0}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := dn.Insert("y", []float32{0, 1}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Search returns something (may be empty if HNSW indexer is still running)
+	results := dn.Search([]float32{1, 0}, 2)
+	if results == nil {
+		t.Error("Search returned nil slice")
+	}
+
+	if err := dn.Delete("x"); err != nil {
+		t.Fatal(err)
+	}
+	if dn.DB.Count() != 1 {
+		t.Errorf("Count after Delete = %d, want 1", dn.DB.Count())
+	}
+}
+
+func TestDirectNode_BatchInsertDelete(t *testing.T) {
+	dn, cleanup := newDirectNode(t, 2, false)
+	defer cleanup()
+
+	errs := dn.BatchInsert([]store.BatchItem{
+		{ID: "a", Vector: []float32{1, 0}},
+		{ID: "b", Vector: []float32{0, 1}},
+		{ID: "c", Vector: []float32{1, 1}},
+	})
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("BatchInsert[%d]: %v", i, err)
+		}
+	}
+	if dn.DB.Count() != 3 {
+		t.Errorf("post-BatchInsert Count = %d, want 3", dn.DB.Count())
+	}
+
+	errs = dn.BatchDelete([]string{"a", "c"})
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("BatchDelete[%d]: %v", i, err)
+		}
+	}
+	if dn.DB.Count() != 1 {
+		t.Errorf("post-BatchDelete Count = %d, want 1", dn.DB.Count())
+	}
+}
+
+// TestDirectNode_BroadcastOnlyWhenReplicasAttached verifies that DirectNode
+// does NOT call Broadcast when ReplicaCount is zero — the conditional in
+// Insert/Delete/Batch* paths guards against unnecessary work (and, more
+// importantly, Broadcast holding rs.mu RLock on a hot write path).
+func TestDirectNode_BroadcastOnlyWhenReplicasAttached(t *testing.T) {
+	dn, cleanup := newDirectNode(t, 2, true) // withRepl = true
+	defer cleanup()
+
+	// Zero replicas attached yet. Broadcast must NOT run, which means seq
+	// must stay at 0.
+	if err := dn.Insert("a", []float32{1, 0}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := dn.Delete("a"); err != nil {
+		t.Fatal(err)
+	}
+	if seq := dn.Repl.seq.Load(); seq != 0 {
+		t.Errorf("seq = %d, want 0 (no replicas => no broadcast)", seq)
+	}
+
+	// Attach a replica and repeat: now Broadcast should fire.
+	ch := dn.Repl.AddReplica("r1")
+	if err := dn.Insert("b", []float32{1, 1}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if seq := dn.Repl.seq.Load(); seq != 1 {
+		t.Errorf("after 1 Insert with replica attached, seq = %d, want 1", seq)
+	}
+
+	// Drain the replica channel so the test doesn't leave a buffered entry.
+	select {
+	case e := <-ch:
+		if e.ID != "b" {
+			t.Errorf("broadcast entry ID = %q, want b", e.ID)
+		}
+	default:
+		t.Error("expected one entry in replica channel")
+	}
+}

--- a/Levara/internal/cluster/fsm_test.go
+++ b/Levara/internal/cluster/fsm_test.go
@@ -1,0 +1,287 @@
+package cluster
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/raft"
+	"github.com/stek0v/cognevra/internal/store"
+)
+
+// T-6 regression tests for the Raft FSM layer. The Apply / Snapshot / Restore
+// contract is what lets Levara survive a leader change: if any path here
+// regresses, cluster membership silently diverges — hard to detect live, easy
+// to catch in unit tests.
+
+func newFSMWithDB(t testing.TB, dim int) (*FSM, *store.Levara, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "levara-fsm-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := store.NewLevara(dim, dir+"/meta.bin")
+	if err != nil {
+		os.RemoveAll(dir)
+		t.Fatal(err)
+	}
+	return NewFSM(db), db, func() {
+		_ = db.Close()
+		os.RemoveAll(dir)
+	}
+}
+
+// mkApply wraps a Command in a raft.Log so Apply can decode it.
+func mkApply(t testing.TB, f *FSM, cmd Command) any {
+	t.Helper()
+	data, err := json.Marshal(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return f.Apply(&raft.Log{Data: data})
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Command JSON round-trip — any schema drift breaks replication silently.
+// ──────────────────────────────────────────────────────────────────
+
+func TestCommand_JSONRoundtrip_Insert(t *testing.T) {
+	src := Command{
+		Op:     "insert",
+		Id:     "rec-1",
+		Vector: []float32{0.1, 0.2, 0.3},
+		Data:   json.RawMessage(`{"title":"hello"}`),
+	}
+	raw, _ := json.Marshal(src)
+	var got Command
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Op != src.Op || got.Id != src.Id || len(got.Vector) != 3 {
+		t.Errorf("roundtrip lost fields: %+v", got)
+	}
+	if string(got.Data) != `{"title":"hello"}` {
+		t.Errorf("Data = %s", got.Data)
+	}
+}
+
+func TestCommand_JSONRoundtrip_BatchInsert(t *testing.T) {
+	src := Command{
+		Op: "batch_insert",
+		Records: []BatchRecord{
+			{Id: "a", Vector: []float32{1}, Data: json.RawMessage(`{"n":1}`)},
+			{Id: "b", Vector: []float32{2}, Data: json.RawMessage(`{"n":2}`)},
+		},
+	}
+	raw, _ := json.Marshal(src)
+	var got Command
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Records) != 2 || got.Records[0].Id != "a" || got.Records[1].Id != "b" {
+		t.Errorf("records lost: %+v", got.Records)
+	}
+}
+
+func TestCommand_JSONRoundtrip_BatchDelete(t *testing.T) {
+	src := Command{Op: "batch_delete", IDs: []string{"a", "b", "c"}}
+	raw, _ := json.Marshal(src)
+	var got Command
+	_ = json.Unmarshal(raw, &got)
+	if len(got.IDs) != 3 {
+		t.Errorf("IDs = %v", got.IDs)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────
+// FSM.Apply — happy paths
+// ──────────────────────────────────────────────────────────────────
+
+func TestFSM_Apply_Insert(t *testing.T) {
+	f, db, cleanup := newFSMWithDB(t, 4)
+	defer cleanup()
+
+	result := mkApply(t, f, Command{
+		Op:     "insert",
+		Id:     "x",
+		Vector: []float32{1, 2, 3, 4},
+		Data:   json.RawMessage(`{"k":"v"}`),
+	})
+	if result != nil {
+		t.Errorf("Apply insert returned %v, want nil", result)
+	}
+	if db.Count() != 1 {
+		t.Errorf("Count = %d, want 1", db.Count())
+	}
+}
+
+func TestFSM_Apply_BatchInsert(t *testing.T) {
+	f, db, cleanup := newFSMWithDB(t, 2)
+	defer cleanup()
+
+	result := mkApply(t, f, Command{
+		Op: "batch_insert",
+		Records: []BatchRecord{
+			{Id: "r1", Vector: []float32{1, 0}, Data: json.RawMessage(`null`)},
+			{Id: "r2", Vector: []float32{0, 1}, Data: json.RawMessage(`null`)},
+			{Id: "r3", Vector: []float32{1, 1}, Data: json.RawMessage(`null`)},
+		},
+	})
+	if result != nil {
+		t.Errorf("batch_insert returned %v, want nil", result)
+	}
+	if db.Count() != 3 {
+		t.Errorf("Count = %d, want 3", db.Count())
+	}
+}
+
+func TestFSM_Apply_Delete(t *testing.T) {
+	f, db, cleanup := newFSMWithDB(t, 2)
+	defer cleanup()
+
+	mkApply(t, f, Command{Op: "insert", Id: "doomed", Vector: []float32{1, 2}})
+	if db.Count() != 1 {
+		t.Fatal("pre-delete Count != 1")
+	}
+
+	result := mkApply(t, f, Command{Op: "delete", Id: "doomed"})
+	if result != nil {
+		t.Errorf("delete returned %v, want nil", result)
+	}
+	if db.Count() != 0 {
+		t.Errorf("Count = %d, want 0", db.Count())
+	}
+}
+
+func TestFSM_Apply_BatchDelete(t *testing.T) {
+	f, db, cleanup := newFSMWithDB(t, 2)
+	defer cleanup()
+	for _, id := range []string{"a", "b", "c"} {
+		mkApply(t, f, Command{Op: "insert", Id: id, Vector: []float32{1, 0}})
+	}
+	result := mkApply(t, f, Command{Op: "batch_delete", IDs: []string{"a", "c"}})
+	if result != nil {
+		t.Errorf("batch_delete returned %v", result)
+	}
+	if db.Count() != 1 {
+		t.Errorf("Count = %d, want 1 (b survives)", db.Count())
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────
+// FSM.Apply — error paths
+// ──────────────────────────────────────────────────────────────────
+
+func TestFSM_Apply_UnknownOp(t *testing.T) {
+	f, _, cleanup := newFSMWithDB(t, 2)
+	defer cleanup()
+	result := mkApply(t, f, Command{Op: "frobnicate"})
+	err, ok := result.(error)
+	if !ok {
+		t.Fatalf("want error, got %T: %v", result, result)
+	}
+	if !strings.Contains(err.Error(), "unknown command") {
+		t.Errorf("err = %v, want 'unknown command'", err)
+	}
+}
+
+func TestFSM_Apply_MalformedJSON(t *testing.T) {
+	f, _, cleanup := newFSMWithDB(t, 2)
+	defer cleanup()
+	result := f.Apply(&raft.Log{Data: []byte(`{"op":`)}) // truncated
+	err, ok := result.(error)
+	if !ok {
+		t.Fatalf("want error, got %T", result)
+	}
+	if !strings.Contains(err.Error(), "unmarshal") {
+		t.Errorf("err = %v, want 'unmarshal'", err)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Snapshot + Restore round-trip — leader change resilience
+// ──────────────────────────────────────────────────────────────────
+
+// inMemorySink implements raft.SnapshotSink for tests.
+type inMemorySink struct {
+	buf      bytes.Buffer
+	canceled bool
+	closed   bool
+}
+
+func (s *inMemorySink) Write(p []byte) (int, error) { return s.buf.Write(p) }
+func (s *inMemorySink) Close() error                { s.closed = true; return nil }
+func (s *inMemorySink) ID() string                  { return "test-snapshot" }
+func (s *inMemorySink) Cancel() error               { s.canceled = true; return nil }
+
+func TestFSM_SnapshotRestore_Roundtrip(t *testing.T) {
+	f1, db1, cleanup1 := newFSMWithDB(t, 3)
+	defer cleanup1()
+
+	for i, id := range []string{"a", "b", "c"} {
+		mkApply(t, f1, Command{
+			Op: "insert", Id: id,
+			Vector: []float32{float32(i), float32(i + 1), float32(i + 2)},
+			Data:   json.RawMessage(`"` + id + `"`),
+		})
+	}
+	if db1.Count() != 3 {
+		t.Fatalf("pre-snapshot count = %d", db1.Count())
+	}
+
+	// Capture snapshot
+	snap, err := f1.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sink := &inMemorySink{}
+	if err := snap.Persist(sink); err != nil {
+		t.Fatal(err)
+	}
+	if !sink.closed || sink.canceled {
+		t.Errorf("sink state closed=%v canceled=%v, want closed=true canceled=false",
+			sink.closed, sink.canceled)
+	}
+	snap.Release()
+
+	// Restore into a fresh FSM — mimics a replica catching up from leader.
+	f2, db2, cleanup2 := newFSMWithDB(t, 3)
+	defer cleanup2()
+
+	// Pre-insert into the second DB to verify Restore wipes existing state.
+	mkApply(t, f2, Command{Op: "insert", Id: "pre-existing", Vector: []float32{9, 9, 9}})
+	if db2.Count() != 1 {
+		t.Fatal("pre-restore sanity failed")
+	}
+
+	if err := f2.Restore(io.NopCloser(bytes.NewReader(sink.buf.Bytes()))); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	if db2.Count() != 3 {
+		t.Errorf("restored Count = %d, want 3 (pre-existing should be wiped)", db2.Count())
+	}
+	for _, id := range []string{"a", "b", "c"} {
+		if _, _, ok := db2.Get(id); !ok {
+			t.Errorf("id %q missing after Restore", id)
+		}
+	}
+	if _, _, ok := db2.Get("pre-existing"); ok {
+		t.Error("pre-existing record survived Restore — Clear not called")
+	}
+}
+
+func TestFSM_Restore_CorruptData(t *testing.T) {
+	f, _, cleanup := newFSMWithDB(t, 2)
+	defer cleanup()
+	err := f.Restore(io.NopCloser(bytes.NewReader([]byte(`{not valid json`))))
+	if err == nil {
+		t.Fatal("Restore on corrupt data should error")
+	}
+	if !strings.Contains(err.Error(), "unmarshal") {
+		t.Errorf("err = %v, want 'unmarshal'", err)
+	}
+}

--- a/Levara/internal/cluster/replication.go
+++ b/Levara/internal/cluster/replication.go
@@ -17,6 +17,7 @@ import (
 	"math"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -33,14 +34,19 @@ type WALEntry struct {
 }
 
 // ReplicationServer streams WAL entries to replicas.
+//
+// seq uses atomic.Uint64 rather than living under mu because Broadcast holds
+// only mu.RLock — concurrent Broadcasts would otherwise race on the sequence
+// increment and produce duplicate Seq values, breaking replicas' gap
+// detection. See TestReplicationServer_Broadcast_ConcurrentNoLostSeq.
 type ReplicationServer struct {
-	mu        sync.RWMutex
-	wal       *store.WAL
-	db        *store.Levara
-	listeners map[string]chan WALEntry // replicaID → entry channel
-	seq       uint64
-	nodeID    string
-	role      string // "primary" or "replica"
+	mu          sync.RWMutex
+	wal         *store.WAL
+	db          *store.Levara
+	listeners   map[string]chan WALEntry // replicaID → entry channel
+	seq         atomic.Uint64
+	nodeID      string
+	role        string // "primary" or "replica"
 	primaryAddr string // for replicas: address of primary
 }
 
@@ -85,10 +91,9 @@ func (rs *ReplicationServer) SetPrimaryAddr(addr string) {
 
 // Broadcast sends a WAL entry to all connected replicas.
 func (rs *ReplicationServer) Broadcast(entry WALEntry) {
+	entry.Seq = rs.seq.Add(1)
 	rs.mu.RLock()
 	defer rs.mu.RUnlock()
-	rs.seq++
-	entry.Seq = rs.seq
 	for rid, ch := range rs.listeners {
 		select {
 		case ch <- entry:
@@ -193,7 +198,7 @@ func (rs *ReplicationServer) HandleClusterState(w http.ResponseWriter, r *http.R
 		"primary_addr":  rs.PrimaryAddr(),
 		"replicas":      replicas,
 		"replica_count": len(replicas),
-		"wal_seq":       rs.seq,
+		"wal_seq":       rs.seq.Load(),
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(state)

--- a/Levara/internal/cluster/replication_test.go
+++ b/Levara/internal/cluster/replication_test.go
@@ -1,0 +1,196 @@
+package cluster
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// T-6 tests for the replication fan-out layer.
+//
+// The most important invariant here is sequence monotonicity: each WAL entry
+// that Broadcast emits must carry a unique, strictly-increasing Seq, otherwise
+// replicas can't detect gaps or order entries correctly. Concurrent Broadcast
+// calls must not race on seq — this test locks that in.
+
+func TestReplicationServer_Role(t *testing.T) {
+	rs := NewReplicationServer("n1", nil, nil)
+	if rs.Role() != "primary" {
+		t.Errorf("default Role = %q, want primary", rs.Role())
+	}
+	rs.SetRole("replica")
+	if rs.Role() != "replica" {
+		t.Errorf("after SetRole, Role = %q, want replica", rs.Role())
+	}
+}
+
+func TestReplicationServer_PrimaryAddr(t *testing.T) {
+	rs := NewReplicationServer("n1", nil, nil)
+	if rs.PrimaryAddr() != "" {
+		t.Errorf("default PrimaryAddr = %q, want empty", rs.PrimaryAddr())
+	}
+	rs.SetPrimaryAddr("10.0.0.1:8080")
+	if rs.PrimaryAddr() != "10.0.0.1:8080" {
+		t.Errorf("PrimaryAddr = %q", rs.PrimaryAddr())
+	}
+}
+
+func TestReplicationServer_AddRemoveReplica(t *testing.T) {
+	rs := NewReplicationServer("n1", nil, nil)
+	if got := rs.ReplicaCount(); got != 0 {
+		t.Errorf("initial ReplicaCount = %d, want 0", got)
+	}
+
+	ch := rs.AddReplica("r1")
+	if ch == nil {
+		t.Fatal("AddReplica returned nil channel")
+	}
+	if got := rs.ReplicaCount(); got != 1 {
+		t.Errorf("after AddReplica, count = %d, want 1", got)
+	}
+
+	rs.AddReplica("r2")
+	if got := rs.ReplicaCount(); got != 2 {
+		t.Errorf("after 2nd AddReplica, count = %d, want 2", got)
+	}
+
+	rs.RemoveReplica("r1")
+	if got := rs.ReplicaCount(); got != 1 {
+		t.Errorf("after RemoveReplica, count = %d, want 1", got)
+	}
+
+	// The channel returned for r1 should be closed after RemoveReplica.
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Error("channel for removed replica returned a value, not closed signal")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("channel for removed replica not closed within 100ms")
+	}
+
+	rs.RemoveReplica("r1") // idempotent: no panic on already-removed
+}
+
+func TestReplicationServer_Broadcast_EmptyListeners(t *testing.T) {
+	// Broadcast with zero replicas must not panic and must not block.
+	rs := NewReplicationServer("n1", nil, nil)
+	done := make(chan struct{})
+	go func() {
+		rs.Broadcast(WALEntry{Op: 1, ID: "x"})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Broadcast on empty listeners blocked")
+	}
+}
+
+func TestReplicationServer_Broadcast_AssignsMonotonicSeq(t *testing.T) {
+	rs := NewReplicationServer("n1", nil, nil)
+	ch := rs.AddReplica("r1")
+
+	for i := 0; i < 5; i++ {
+		rs.Broadcast(WALEntry{Op: 1, ID: "x"})
+	}
+
+	for i := uint64(1); i <= 5; i++ {
+		select {
+		case e := <-ch:
+			if e.Seq != i {
+				t.Errorf("entry %d: Seq = %d, want %d", i, e.Seq, i)
+			}
+		case <-time.After(200 * time.Millisecond):
+			t.Fatalf("channel empty at iteration %d", i)
+		}
+	}
+}
+
+// TestReplicationServer_Broadcast_ConcurrentNoLostSeq is the regression test
+// for the Broadcast race: before the fix, two goroutines calling Broadcast
+// both held mu.RLock and incremented rs.seq unprotected, producing duplicate
+// Seq values (and dropping the "monotonic unique" invariant that replicas
+// rely on for gap detection).
+//
+// Under -race this surfaces as a DATA RACE on rs.seq; without -race it
+// surfaces as duplicate Seq values in the emitted stream.
+func TestReplicationServer_Broadcast_ConcurrentNoLostSeq(t *testing.T) {
+	rs := NewReplicationServer("n1", nil, nil)
+	ch := rs.AddReplica("r1")
+
+	const (
+		goroutines  = 8
+		perRoutine  = 25
+		totalEmits  = goroutines * perRoutine
+	)
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perRoutine; i++ {
+				rs.Broadcast(WALEntry{Op: 1, ID: "x"})
+			}
+		}()
+	}
+
+	// Drain the channel in parallel so the broadcaster doesn't block on the
+	// 10K buffer (unlikely but possible if the test scales up).
+	seen := make(map[uint64]int, totalEmits)
+	var drainDone atomic.Bool
+	var drainWg sync.WaitGroup
+	drainWg.Add(1)
+	go func() {
+		defer drainWg.Done()
+		for !drainDone.Load() || len(ch) > 0 {
+			select {
+			case e, ok := <-ch:
+				if !ok {
+					return
+				}
+				seen[e.Seq]++
+			case <-time.After(50 * time.Millisecond):
+			}
+		}
+	}()
+
+	wg.Wait()
+	drainDone.Store(true)
+	drainWg.Wait()
+
+	if len(seen) != totalEmits {
+		t.Errorf("unique Seq count = %d, want %d (duplicates/lost entries indicate race)",
+			len(seen), totalEmits)
+	}
+	for seq, cnt := range seen {
+		if cnt != 1 {
+			t.Errorf("Seq %d appeared %d times (must be unique)", seq, cnt)
+		}
+	}
+}
+
+func TestReplicationServer_Broadcast_DropsWhenReplicaSlow(t *testing.T) {
+	// When a replica's channel is full, Broadcast drops the entry instead of
+	// blocking. We simulate this with a tiny-capacity channel substituted via
+	// AddReplica's return value — but AddReplica returns a 10K-buffer channel
+	// by design, so we instead add the replica and don't drain: with
+	// Seq fan-out this never fills in practice, so this test is a smoke that
+	// the method doesn't deadlock when replicas are attached but silent.
+	rs := NewReplicationServer("n1", nil, nil)
+	_ = rs.AddReplica("slow")
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100; i++ {
+			rs.Broadcast(WALEntry{Op: 1, ID: "x"})
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Broadcast blocked with slow replica attached (deadlock)")
+	}
+}

--- a/Levara/internal/store/db.go
+++ b/Levara/internal/store/db.go
@@ -154,6 +154,15 @@ func NewLevara(dim int, storagePath string, cfg ...HNSWConfig) (*Levara, error) 
 }
 
 // indexerLoop drains pendingVecs into hnsw.Add in the background.
+//
+// Locking: reading db.hnsw without a lock is a data race with Clear() which
+// atomically-but-not-really swaps db.hnsw and db.arena (see fsm.Restore caller).
+// We snapshot the current hnsw pointer under db.mu.RLock() per batch, then
+// release the lock before calling hnsw.Add. If Clear runs concurrently and
+// swaps the pointer, the old hnsw captured here will absorb the batch — those
+// entries become orphaned but not corrupted (old arena + old hnsw stay alive
+// via our local reference until the batch drains). Consistency is preserved
+// because each hnsw owns its own arena reference.
 func (db *Levara) indexerLoop() {
 	for range db.indexSignal {
 		for {
@@ -166,8 +175,12 @@ func (db *Levara) indexerLoop() {
 			db.pendingVecs = nil
 			db.pendingMu.Unlock()
 
+			db.mu.RLock()
+			hnsw := db.hnsw
+			db.mu.RUnlock()
+
 			for _, p := range batch {
-				db.hnsw.Add(p.vector, p.id, p.idx)
+				hnsw.Add(p.vector, p.id, p.idx)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

T-6 from the testing roadmap: regression net for \`internal/cluster\` (810 LOC that had **zero tests**). While writing the tests, two real data races surfaced and got fixed in the same PR — neither would have been caught by the testing we had after PR #1.

### Races fixed

**1. \`store.Levara.indexerLoop\` vs \`store.Levara.Clear\`.** indexerLoop read \`db.hnsw\` without any lock, while Clear (called from \`FSM.Restore\`) swaps both \`db.hnsw\` and \`db.arena\` under \`db.mu.Lock()\`. Any Raft snapshot restore that landed while writes were in flight would trip \`-race\`. **Fix:** snapshot \`db.hnsw\` under \`db.mu.RLock()\` per batch, then release before the Add loop. If Clear swaps the pointer mid-batch, the old hnsw absorbs the batch via the captured reference — entries are orphaned, not corrupted (each hnsw owns its arena).

**2. \`ReplicationServer.Broadcast\` sequence race.** \`Broadcast\` incremented \`rs.seq\` while holding only \`mu.RLock\`. Under concurrent Broadcasts (all writers call it on the primary) two goroutines both read \`seq=N\` and both write \`N+1\`, emitting duplicate \`Seq\` values — which silently breaks the gap-detection contract replicas rely on. **Fix:** migrate \`rs.seq\` to \`atomic.Uint64\`, Add(1) before grabbing the fan-out lock. Verified by \`TestReplicationServer_Broadcast_ConcurrentNoLostSeq\`: 200 concurrent emissions produce 200 unique Seqs under \`-race\`.

### Tests added (20)

- **FSM.Apply** — happy paths for insert / batch_insert / delete / batch_delete, error paths for unknown Op and malformed JSON.
- **FSM.Snapshot → Persist → Restore** roundtrip via an in-memory \`raft.SnapshotSink\`. Asserts Clear wipes existing state and Restore reconstructs the exact snapshotted set.
- **Command JSON roundtrip** for each Op shape.
- **ReplicationServer** — Role/PrimaryAddr get/set, AddReplica/RemoveReplica lifecycle (channel closed on remove, idempotent remove), empty-listeners Broadcast no-op, monotonic Seq, concurrent-safe Seq, slow-replica non-deadlock.
- **DirectNode** — Insert/Search/Delete/BatchInsert/BatchDelete smoke + the conditional that skips Broadcast when no replicas are attached.

## Test plan

- [x] \`go test -race -count=1 ./...\` — 25 PASS / 0 FAIL (was 24; \`internal/cluster\` joined the covered set)
- [x] New race test fails on the pre-fix code, passes post-fix
- [ ] Reviewer: confirm the indexerLoop fix is the right tradeoff vs. making \`db.hnsw\`/\`db.arena\` \`atomic.Pointer\` — the current fix serializes indexer batches against Clear, which is fine since Clear is only called on snapshot restore (cold path), but an atomic.Pointer swap would be lock-free if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)