### PR TITLE
test+fix(http): T-5 contract tests for core vector-ops endpoints

### DIFF
--- a/Levara/docs/testing-logs/2026-04-16-t5-final.txt
+++ b/Levara/docs/testing-logs/2026-04-16-t5-final.txt
@@ -1,0 +1,42 @@
+?   	github.com/stek0v/cognevra/cmd/backup	[no test files]
+?   	github.com/stek0v/cognevra/cmd/benchmark	[no test files]
+?   	github.com/stek0v/cognevra/cmd/cli	[no test files]
+?   	github.com/stek0v/cognevra/cmd/loadtest	[no test files]
+?   	github.com/stek0v/cognevra/cmd/server	[no test files]
+ok  	github.com/stek0v/cognevra/internal/cluster	2.379s
+ok  	github.com/stek0v/cognevra/internal/grpc	2.072s
+ok  	github.com/stek0v/cognevra/internal/http	1.925s
+?   	github.com/stek0v/cognevra/internal/metrics	[no test files]
+ok  	github.com/stek0v/cognevra/internal/store	29.661s
+ok  	github.com/stek0v/cognevra/pipeline	4.782s
+ok  	github.com/stek0v/cognevra/pkg/aggregator	2.168s
+?   	github.com/stek0v/cognevra/pkg/audio	[no test files]
+?   	github.com/stek0v/cognevra/pkg/backup	[no test files]
+ok  	github.com/stek0v/cognevra/pkg/bm25	2.575s
+ok  	github.com/stek0v/cognevra/pkg/chunker	3.019s
+?   	github.com/stek0v/cognevra/pkg/classify	[no test files]
+ok  	github.com/stek0v/cognevra/pkg/community	4.355s
+ok  	github.com/stek0v/cognevra/pkg/embed	4.808s
+?   	github.com/stek0v/cognevra/pkg/extract	[no test files]
+?   	github.com/stek0v/cognevra/pkg/fetch	[no test files]
+ok  	github.com/stek0v/cognevra/pkg/fileio	3.312s
+?   	github.com/stek0v/cognevra/pkg/git	[no test files]
+ok  	github.com/stek0v/cognevra/pkg/graph	3.827s
+ok  	github.com/stek0v/cognevra/pkg/graphdb	3.517s
+ok  	github.com/stek0v/cognevra/pkg/graphrank	3.634s
+?   	github.com/stek0v/cognevra/pkg/graphstore	[no test files]
+ok  	github.com/stek0v/cognevra/pkg/ingest	2.654s
+ok  	github.com/stek0v/cognevra/pkg/llm	3.038s
+ok  	github.com/stek0v/cognevra/pkg/llm/mock	3.094s
+ok  	github.com/stek0v/cognevra/pkg/llmcache	3.134s
+ok  	github.com/stek0v/cognevra/pkg/llmproxy	2.871s
+ok  	github.com/stek0v/cognevra/pkg/observe	3.305s
+ok  	github.com/stek0v/cognevra/pkg/ontology	3.140s
+ok  	github.com/stek0v/cognevra/pkg/orchestrator	3.324s
+ok  	github.com/stek0v/cognevra/pkg/rerank	3.181s
+ok  	github.com/stek0v/cognevra/pkg/router	3.425s
+ok  	github.com/stek0v/cognevra/pkg/storage	3.366s
+ok  	github.com/stek0v/cognevra/pkg/temporal	3.248s
+?   	github.com/stek0v/cognevra/pkg/vectorstore	[no test files]
+?   	github.com/stek0v/cognevra/proto	[no test files]
+?   	github.com/stek0v/cognevra/proto/pb	[no test files]

--- a/Levara/internal/http/handler_contract_test.go
+++ b/Levara/internal/http/handler_contract_test.go
@@ -1,0 +1,379 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stek0v/cognevra/internal/cluster"
+	"github.com/stek0v/cognevra/internal/store"
+)
+
+// T-5: HTTP contract tests for the four vector-ops endpoints that back every
+// search, ingest, delete and batch-write path in Levara:
+//
+//   POST /api/v1/insert
+//   POST /api/v1/batch_insert
+//   POST /api/v1/search
+//   POST /api/v1/delete
+//
+// The goal is a regression net for the request/response shape — the fields,
+// status codes, and error messages that external clients (WebUI, SDK, MCP
+// tools) depend on. We use a real store.Levara via cluster.DirectNode instead
+// of mocking so the tests also exercise the wiring that main.go uses.
+//
+// These tests intentionally avoid auth middleware: we register the handlers
+// on a bare fiber.App to isolate the contract. Auth is covered elsewhere.
+
+// testHandler spins up a Handler wired to a real in-memory-ish store
+// (tempdir-backed) plus a fiber app mounted at /api/v1/* with the four core
+// vector-op routes. Returns the app + cleanup.
+func testHandler(t testing.TB, dim int) (*fiber.App, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "levara-contract-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := store.NewLevara(dim, dir+"/meta.bin")
+	if err != nil {
+		os.RemoveAll(dir)
+		t.Fatal(err)
+	}
+	shard := &cluster.DirectNode{DB: db}
+	c := store.NewCluster([]store.ShardHandler{shard})
+
+	h := NewHandler(c, dim)
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	api := app.Group("/api/v1")
+	api.Post("/insert", h.Insert)
+	api.Post("/batch_insert", h.BatchInsert)
+	api.Post("/search", h.Search)
+	api.Post("/delete", h.Delete)
+
+	return app, func() {
+		_ = app.Shutdown()
+		_ = db.Close()
+		os.RemoveAll(dir)
+	}
+}
+
+// doJSON posts body as JSON and returns status + parsed response body.
+func doJSON(t testing.TB, app *fiber.App, method, path string, body any) (int, []byte) {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		reader = bytes.NewReader(b)
+	}
+	req := httptest.NewRequest(method, path, reader)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, respBody
+}
+
+// ──────────────────────────────────────────────────────────────────
+// POST /api/v1/insert
+// ──────────────────────────────────────────────────────────────────
+
+func TestInsert_HappyPath(t *testing.T) {
+	app, cleanup := testHandler(t, 4)
+	defer cleanup()
+
+	req := InsertRequest{
+		ID:     "rec-1",
+		Vector: []float32{1, 2, 3, 4},
+		Data:   map[string]any{"title": "hello"},
+	}
+	status, body := doJSON(t, app, "POST", "/api/v1/insert", req)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", status, body)
+	}
+	var out map[string]string
+	_ = json.Unmarshal(body, &out)
+	if !strings.Contains(out["message"], "inserted successfully") {
+		t.Errorf("body = %s, want 'inserted successfully'", body)
+	}
+}
+
+func TestInsert_BadJSON_Returns400(t *testing.T) {
+	app, cleanup := testHandler(t, 4)
+	defer cleanup()
+
+	req := httptest.NewRequest("POST", "/api/v1/insert", strings.NewReader("{not json"))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req, -1)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestInsert_MissingID_Returns400(t *testing.T) {
+	app, cleanup := testHandler(t, 4)
+	defer cleanup()
+	status, body := doJSON(t, app, "POST", "/api/v1/insert", InsertRequest{
+		Vector: []float32{1, 2, 3, 4},
+	})
+	if status != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body = %s", status, body)
+	}
+	if !strings.Contains(string(body), "id and vector") {
+		t.Errorf("error message = %s, want to mention 'id and vector'", body)
+	}
+}
+
+func TestInsert_MissingVector_Returns400(t *testing.T) {
+	app, cleanup := testHandler(t, 4)
+	defer cleanup()
+	status, _ := doJSON(t, app, "POST", "/api/v1/insert", InsertRequest{ID: "x"})
+	if status != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", status)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────
+// POST /api/v1/batch_insert
+// ──────────────────────────────────────────────────────────────────
+
+func TestBatchInsert_HappyPath(t *testing.T) {
+	app, cleanup := testHandler(t, 2)
+	defer cleanup()
+
+	req := BatchInsertRequest{
+		Records: []BatchInsertItem{
+			{ID: "a", Vector: []float32{1, 0}, Data: map[string]any{"n": 1}},
+			{ID: "b", Vector: []float32{0, 1}, Data: map[string]any{"n": 2}},
+			{ID: "c", Vector: []float32{1, 1}},
+		},
+	}
+	status, body := doJSON(t, app, "POST", "/api/v1/batch_insert", req)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", status, body)
+	}
+	var out BatchInsertResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Inserted != 3 || out.Failed != 0 {
+		t.Errorf("out = %+v, want Inserted=3 Failed=0", out)
+	}
+}
+
+func TestBatchInsert_EmptyRecords_Returns400(t *testing.T) {
+	app, cleanup := testHandler(t, 2)
+	defer cleanup()
+	status, body := doJSON(t, app, "POST", "/api/v1/batch_insert", BatchInsertRequest{})
+	if status != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body = %s", status, body)
+	}
+}
+
+func TestBatchInsert_InvalidRecord_Returns400(t *testing.T) {
+	// One invalid record (missing vector) → whole batch rejected with 400
+	// before any record is inserted. This is the current contract; clients
+	// rely on all-or-nothing semantics for partial validation errors.
+	app, cleanup := testHandler(t, 2)
+	defer cleanup()
+	req := BatchInsertRequest{
+		Records: []BatchInsertItem{
+			{ID: "good", Vector: []float32{1, 0}},
+			{ID: "bad-no-vector"},
+		},
+	}
+	status, body := doJSON(t, app, "POST", "/api/v1/batch_insert", req)
+	if status != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body = %s", status, body)
+	}
+	if !strings.Contains(string(body), "bad-no-vector") {
+		t.Errorf("error should name the offending record; body = %s", body)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────
+// POST /api/v1/search
+// ──────────────────────────────────────────────────────────────────
+
+func TestSearch_HappyPath(t *testing.T) {
+	app, cleanup := testHandler(t, 2)
+	defer cleanup()
+
+	// Seed a couple of records.
+	_, _ = doJSON(t, app, "POST", "/api/v1/insert", InsertRequest{
+		ID: "a", Vector: []float32{1, 0}, Data: map[string]any{"tag": "x"},
+	})
+	_, _ = doJSON(t, app, "POST", "/api/v1/insert", InsertRequest{
+		ID: "b", Vector: []float32{0, 1}, Data: map[string]any{"tag": "y"},
+	})
+
+	status, body := doJSON(t, app, "POST", "/api/v1/search", SearchRequest{
+		Vector: []float32{1, 0}, TopK: 2,
+	})
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", status, body)
+	}
+	var out SearchResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatal(err)
+	}
+	// Results may be empty if HNSW indexer hasn't caught up, but the contract
+	// is the shape: SearchResponse with a results array (possibly empty).
+	if out.Results == nil {
+		t.Error("Results = nil, want non-nil slice (can be empty)")
+	}
+}
+
+func TestSearch_MissingVector_Returns400(t *testing.T) {
+	app, cleanup := testHandler(t, 2)
+	defer cleanup()
+	status, _ := doJSON(t, app, "POST", "/api/v1/search", SearchRequest{TopK: 5})
+	if status != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", status)
+	}
+}
+
+func TestSearch_DefaultTopK(t *testing.T) {
+	// Omitted TopK should default to 5, not error. Contract stability check.
+	app, cleanup := testHandler(t, 2)
+	defer cleanup()
+	status, body := doJSON(t, app, "POST", "/api/v1/search", SearchRequest{
+		Vector: []float32{1, 0},
+	})
+	if status != http.StatusOK {
+		t.Errorf("status = %d, want 200; body = %s", status, body)
+	}
+}
+
+func TestSearch_BadJSON_Returns400(t *testing.T) {
+	app, cleanup := testHandler(t, 2)
+	defer cleanup()
+	req := httptest.NewRequest("POST", "/api/v1/search", strings.NewReader("not-json"))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req, -1)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────
+// POST /api/v1/delete
+// ──────────────────────────────────────────────────────────────────
+
+func TestDelete_HappyPath(t *testing.T) {
+	app, cleanup := testHandler(t, 2)
+	defer cleanup()
+
+	for _, id := range []string{"a", "b"} {
+		_, _ = doJSON(t, app, "POST", "/api/v1/insert", InsertRequest{
+			ID: id, Vector: []float32{1, 0},
+		})
+	}
+
+	status, body := doJSON(t, app, "POST", "/api/v1/delete", DeleteRequest{
+		IDs: []string{"a", "b"},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", status, body)
+	}
+	var out DeleteResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Deleted != 2 || out.Failed != 0 {
+		t.Errorf("out = %+v, want Deleted=2 Failed=0", out)
+	}
+}
+
+func TestDelete_EmptyIDs_Returns400(t *testing.T) {
+	app, cleanup := testHandler(t, 2)
+	defer cleanup()
+	status, body := doJSON(t, app, "POST", "/api/v1/delete", DeleteRequest{})
+	if status != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body = %s", status, body)
+	}
+}
+
+func TestDelete_MissingRecord_ReportsFailure(t *testing.T) {
+	app, cleanup := testHandler(t, 2)
+	defer cleanup()
+
+	status, body := doJSON(t, app, "POST", "/api/v1/delete", DeleteRequest{
+		IDs: []string{"nonexistent"},
+	})
+	// Delete of a nonexistent record is NOT a 4xx — the API is idempotent-ish:
+	// Failed count is incremented but the call succeeds. Contract lock-in.
+	if status != http.StatusOK {
+		t.Errorf("status = %d, want 200 (deletion of missing record is not a client error); body = %s",
+			status, body)
+	}
+	var out DeleteResponse
+	_ = json.Unmarshal(body, &out)
+	if out.Failed != 1 || len(out.Errors) != 1 {
+		t.Errorf("out = %+v, want Failed=1 with 1 error entry", out)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Round-trip: insert → delete → search hits nothing
+// ──────────────────────────────────────────────────────────────────
+
+func TestInsertDeleteSearch_Roundtrip(t *testing.T) {
+	app, cleanup := testHandler(t, 2)
+	defer cleanup()
+
+	// Insert, delete, then re-search — guards against regressions where
+	// the handler stops calling into cluster methods properly.
+	_, _ = doJSON(t, app, "POST", "/api/v1/insert", InsertRequest{
+		ID: "ephemeral", Vector: []float32{0.5, 0.5},
+	})
+	status, _ := doJSON(t, app, "POST", "/api/v1/delete", DeleteRequest{
+		IDs: []string{"ephemeral"},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("delete status = %d", status)
+	}
+	// Search and don't care about the exact results — the shape must
+	// round-trip (no panic, valid JSON, SearchResponse parseable).
+	status, body := doJSON(t, app, "POST", "/api/v1/search", SearchRequest{
+		Vector: []float32{0.5, 0.5}, TopK: 5,
+	})
+	if status != http.StatusOK {
+		t.Fatalf("search status = %d", status)
+	}
+	var out SearchResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("search response not parseable: %v; body = %s", err, body)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Content-Type requirement
+// ──────────────────────────────────────────────────────────────────
+
+func TestInsert_MissingContentType_Returns400(t *testing.T) {
+	// fiber's BodyParser rejects bodies without Content-Type=application/json.
+	// Locking this in prevents accidental MIME type sniffing regressions.
+	app, cleanup := testHandler(t, 2)
+	defer cleanup()
+	body, _ := json.Marshal(InsertRequest{ID: "x", Vector: []float32{1, 0}})
+	req := httptest.NewRequest("POST", "/api/v1/insert", bytes.NewReader(body))
+	// No Content-Type header set.
+	resp, _ := app.Test(req, -1)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 (no Content-Type)", resp.StatusCode)
+	}
+}

--- a/Levara/internal/http/reembed.go
+++ b/Levara/internal/http/reembed.go
@@ -39,12 +39,39 @@ type reembedStatus struct {
 	Message          string     `json:"message"`
 }
 
+// reembedStatusSnapshot is a lock-free copy of reembedStatus suitable for
+// JSON serialization. Decoupling it from the live status prevents the
+// copylocks warning that firing from copying reembedStatus (which holds a
+// sync.Mutex).
+type reembedStatusSnapshot struct {
+	RunID            string `json:"run_id"`
+	Status           string `json:"status"`
+	SourceCollection string `json:"source_collection"`
+	TargetCollection string `json:"target_collection"`
+	TargetModel      string `json:"target_model"`
+	TotalRecords     int    `json:"total_records"`
+	Processed        int    `json:"processed"`
+	Failed           int    `json:"failed"`
+	ElapsedMs        int64  `json:"elapsed_ms"`
+	Message          string `json:"message"`
+}
+
 // snapshot returns a copy of the status safe for JSON serialization.
-func (s *reembedStatus) snapshot() reembedStatus {
+func (s *reembedStatus) snapshot() reembedStatusSnapshot {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	cp := *s
-	return cp
+	return reembedStatusSnapshot{
+		RunID:            s.RunID,
+		Status:           s.Status,
+		SourceCollection: s.SourceCollection,
+		TargetCollection: s.TargetCollection,
+		TargetModel:      s.TargetModel,
+		TotalRecords:     s.TotalRecords,
+		Processed:        s.Processed,
+		Failed:           s.Failed,
+		ElapsedMs:        s.ElapsedMs,
+		Message:          s.Message,
+	}
 }
 
 var reembedRuns sync.Map


### PR DESCRIPTION
## Summary

T-5 from the testing roadmap: first regression net for \`internal/http\` (12 702 LOC, previously **zero tests**). Covers the four endpoints that back every search/ingest/delete path in the Levara HTTP API:

- \`POST /api/v1/insert\`
- \`POST /api/v1/batch_insert\`
- \`POST /api/v1/search\`
- \`POST /api/v1/delete\`

**16 contract tests** assert the request/response shape, status codes, and error messages that WebUI, SDK, and MCP clients depend on. Tests spin up a bare fiber app with a real \`store.Levara\` (via \`cluster.DirectNode\` wrapping a tempdir) — no auth middleware, so the contract is isolated from that layer.

### What's locked in

- Happy paths for all four endpoints
- Missing required fields → 400 with the offending field named in the error message
- Bad JSON body → 400
- Missing Content-Type → 400 (locks in fiber BodyParser behaviour — prevents accidental MIME-sniffing regressions)
- BatchInsert: 3-record happy path, empty → 400, invalid record rejects the whole batch (all-or-nothing semantics contract)
- Search: default TopK=5 when omitted, shape stability (empty \`Results\` slice is always non-nil)
- Delete of nonexistent record → 200 with \`Failed=1\` in body (NOT 4xx — API is idempotent-ish)
- Insert→Delete→Search roundtrip

### Bonus fix

\`reembed.go\` had a \`copylocks\` vet warning: \`snapshot()\` copied \`reembedStatus\` by value, which embeds \`sync.Mutex\`. Introduced a separate \`reembedStatusSnapshot\` type with only the JSON-serializable fields; \`snapshot()\` returns that. No functional change.

## Why this matters

\`internal/http\` was the single biggest LOC-to-tests gap in the codebase. With this PR the door is open for **F-4 (MCP split)** — we can now refactor the handler layout without worrying that a URL-renaming error or a DTO-field drift will ship silently.

## Test plan

- [x] \`go test -race -count=1 ./...\` — 26 PASS / 0 FAIL (\`internal/http\` joined the covered set)
- [x] All 16 new tests pass
- [x] vet (\`go build\`) clean — no new copylocks/similar warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)