### PR TITLE
refactor(mcp): F-4 wave 1a — pkg/mcp foundation (types + helpers)

### DIFF
--- a/Levara/docs/testing-logs/2026-04-16-f4-wave1a.txt
+++ b/Levara/docs/testing-logs/2026-04-16-f4-wave1a.txt
@@ -1,0 +1,43 @@
+?   	github.com/stek0v/cognevra/cmd/backup	[no test files]
+?   	github.com/stek0v/cognevra/cmd/benchmark	[no test files]
+?   	github.com/stek0v/cognevra/cmd/cli	[no test files]
+?   	github.com/stek0v/cognevra/cmd/loadtest	[no test files]
+?   	github.com/stek0v/cognevra/cmd/server	[no test files]
+ok  	github.com/stek0v/cognevra/internal/cluster	2.027s
+ok  	github.com/stek0v/cognevra/internal/grpc	2.827s
+ok  	github.com/stek0v/cognevra/internal/http	1.816s
+?   	github.com/stek0v/cognevra/internal/metrics	[no test files]
+ok  	github.com/stek0v/cognevra/internal/store	33.639s
+ok  	github.com/stek0v/cognevra/pipeline	3.050s
+ok  	github.com/stek0v/cognevra/pkg/aggregator	3.000s
+ok  	github.com/stek0v/cognevra/pkg/audio	3.484s
+ok  	github.com/stek0v/cognevra/pkg/backup	3.900s
+ok  	github.com/stek0v/cognevra/pkg/bm25	4.308s
+ok  	github.com/stek0v/cognevra/pkg/chunker	4.787s
+ok  	github.com/stek0v/cognevra/pkg/classify	3.362s
+ok  	github.com/stek0v/cognevra/pkg/community	2.940s
+ok  	github.com/stek0v/cognevra/pkg/embed	3.529s
+ok  	github.com/stek0v/cognevra/pkg/extract	3.864s
+ok  	github.com/stek0v/cognevra/pkg/fetch	4.128s
+ok  	github.com/stek0v/cognevra/pkg/fileio	4.338s
+ok  	github.com/stek0v/cognevra/pkg/git	4.388s
+ok  	github.com/stek0v/cognevra/pkg/graph	4.890s
+ok  	github.com/stek0v/cognevra/pkg/graphdb	4.553s
+ok  	github.com/stek0v/cognevra/pkg/graphrank	5.108s
+?   	github.com/stek0v/cognevra/pkg/graphstore	[no test files]
+ok  	github.com/stek0v/cognevra/pkg/ingest	4.727s
+ok  	github.com/stek0v/cognevra/pkg/llm	5.073s
+ok  	github.com/stek0v/cognevra/pkg/llm/mock	4.708s
+ok  	github.com/stek0v/cognevra/pkg/llmcache	4.706s
+ok  	github.com/stek0v/cognevra/pkg/llmproxy	4.055s
+ok  	github.com/stek0v/cognevra/pkg/mcp	4.215s
+ok  	github.com/stek0v/cognevra/pkg/observe	3.612s
+ok  	github.com/stek0v/cognevra/pkg/ontology	3.662s
+ok  	github.com/stek0v/cognevra/pkg/orchestrator	3.335s
+ok  	github.com/stek0v/cognevra/pkg/rerank	3.839s
+ok  	github.com/stek0v/cognevra/pkg/router	3.871s
+ok  	github.com/stek0v/cognevra/pkg/storage	3.806s
+ok  	github.com/stek0v/cognevra/pkg/temporal	3.992s
+ok  	github.com/stek0v/cognevra/pkg/vectorstore	3.951s
+?   	github.com/stek0v/cognevra/proto	[no test files]
+?   	github.com/stek0v/cognevra/proto/pb	[no test files]

--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -13,7 +13,6 @@ package http
 import (
 	"bufio"
 	"context"
-	"crypto/rand"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -30,10 +29,11 @@ import (
 	"github.com/stek0v/cognevra/internal/metrics"
 	"github.com/stek0v/cognevra/pkg/community"
 	"github.com/stek0v/cognevra/pkg/embed"
-	"github.com/stek0v/cognevra/pkg/graphrank"
 	"github.com/stek0v/cognevra/pkg/extract"
 	"github.com/stek0v/cognevra/pkg/git"
+	"github.com/stek0v/cognevra/pkg/graphrank"
 	"github.com/stek0v/cognevra/pkg/ingest"
+	"github.com/stek0v/cognevra/pkg/mcp"
 	"github.com/stek0v/cognevra/pkg/orchestrator"
 	"github.com/stek0v/cognevra/pkg/rerank"
 	"github.com/stek0v/cognevra/pkg/router"
@@ -577,7 +577,7 @@ func (h *mcpHandler) getOrValidateSession(sessionID string) *mcpSession {
 
 // createSession creates a new MCP session and returns its ID.
 func (h *mcpHandler) createSession() string {
-	id := fmt.Sprintf("mcp-%d-%s", time.Now().UnixNano(), randomHex(8))
+	id := fmt.Sprintf("mcp-%d-%s", time.Now().UnixNano(), mcp.RandomHex(8))
 	h.mu.Lock()
 	h.sessions[id] = &mcpSession{
 		id:        id,
@@ -599,14 +599,7 @@ func (h *mcpHandler) deleteSession(id string) {
 	h.mu.Unlock()
 }
 
-// randomHex returns n random hex characters.
-func randomHex(n int) string {
-	b := make([]byte, n/2+1)
-	if _, err := rand.Read(b); err != nil {
-		panic("crypto/rand failed: " + err.Error())
-	}
-	return fmt.Sprintf("%x", b)[:n]
-}
+// randomHex moved to pkg/mcp.RandomHex.
 
 func (h *mcpHandler) handleRPC(c *fiber.Ctx) error {
 	var req jsonRPCRequest
@@ -1162,7 +1155,7 @@ func (h *mcpHandler) toolSearch(ctx context.Context, args map[string]any) mcpToo
 		}
 
 		for _, r := range res {
-			if hasMetaFilter && !chunkMetaMatches(r.Metadata, roomFilter, tagFilters) {
+			if hasMetaFilter && !mcp.ChunkMetaMatches(r.Metadata, roomFilter, tagFilters) {
 				continue
 			}
 			results = append(results, map[string]any{
@@ -1513,8 +1506,8 @@ func (h *mcpHandler) toolSaveMemory(ctx context.Context, args map[string]any) mc
 	collectionName, _ := args["collection"].(string)
 	room, _ := args["room"].(string)
 	hall, _ := args["hall"].(string)
-	if hall != "" && !isValidHall(hall) {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: fmt.Sprintf("Error: invalid hall '%s'. Valid values: %s", hall, strings.Join(validHalls(), ", "))}}, IsError: true}
+	if hall != "" && !mcp.IsValidHall(hall) {
+		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: fmt.Sprintf("Error: invalid hall '%s'. Valid values: %s", hall, strings.Join(mcp.ValidHalls(), ", "))}}, IsError: true}
 	}
 	pin, _ := args["pin"].(bool)
 	pinPriority := 0

--- a/Levara/internal/http/mcp_palace.go
+++ b/Levara/internal/http/mcp_palace.go
@@ -15,74 +15,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stek0v/cognevra/pkg/mcp"
 )
 
-// ── Hall vocabulary ──
-
-// Controlled vocabulary for the "hall" field on a memory record. Extending the
-// list is a deliberate code change so that downstream consumers (search filters,
-// dashboards) stay in sync.
-var hallVocab = []string{
-	"fact",
-	"event",
-	"decision",
-	"preference",
-	"advice",
-	"discovery",
-}
-
-func validHalls() []string { return hallVocab }
-
-// chunkMetaMatches returns true when the chunk metadata blob (JSON, as written
-// by orchestrator pipeline) satisfies the room and tag filters. An empty
-// roomFilter or empty tagFilters slice means "no filter on that dimension".
-// Tag filtering is OR-semantics: a chunk matches if it has ANY of the wanted
-// tags. This makes recall easier and matches user expectation when listing
-// related topics.
-func chunkMetaMatches(raw []byte, roomFilter string, tagFilters []string) bool {
-	if roomFilter == "" && len(tagFilters) == 0 {
-		return true
-	}
-	var meta struct {
-		Room string   `json:"room"`
-		Tags []string `json:"tags"`
-	}
-	if err := json.Unmarshal(raw, &meta); err != nil {
-		// Older chunks without room/tags metadata: keep them only when no
-		// filter is requested. Since we know hasMetaFilter is true, drop.
-		return false
-	}
-	if roomFilter != "" && meta.Room != roomFilter {
-		return false
-	}
-	if len(tagFilters) > 0 {
-		hit := false
-		for _, want := range tagFilters {
-			for _, have := range meta.Tags {
-				if want == have {
-					hit = true
-					break
-				}
-			}
-			if hit {
-				break
-			}
-		}
-		if !hit {
-			return false
-		}
-	}
-	return true
-}
-
-func isValidHall(h string) bool {
-	for _, v := range hallVocab {
-		if v == h {
-			return true
-		}
-	}
-	return false
-}
+// Hall vocabulary, ChunkMetaMatches, and IsValidHall live in pkg/mcp now
+// (F-4 wave 1a) — see pkg/mcp/hall.go.
 
 // ── wake_up ──
 
@@ -345,11 +282,7 @@ func (h *mcpHandler) toolQueryEntity(ctx context.Context, args map[string]any) m
 
 // ── Agent diaries ──
 
-const diaryOwnerPrefix = "agent:"
-
-func diaryOwner(agent string) string {
-	return diaryOwnerPrefix + strings.TrimSpace(agent)
-}
+// DiaryOwnerPrefix and DiaryOwner moved to pkg/mcp/util.go.
 
 func (h *mcpHandler) toolDiaryWrite(ctx context.Context, args map[string]any) mcpToolResult {
 	if h.cfg.DB == nil {
@@ -362,7 +295,7 @@ func (h *mcpHandler) toolDiaryWrite(ctx context.Context, args map[string]any) mc
 		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: 'agent', 'key', 'value' required"}}, IsError: true}
 	}
 	collectionName, _ := args["collection"].(string)
-	owner := diaryOwner(agent)
+	owner := mcp.DiaryOwner(agent)
 	id := uuid.New().String()
 	now := time.Now().UTC().Format(time.RFC3339)
 	q, qargs := QArgs(`INSERT INTO memories (id, key, value, type, owner_id, collection_name, room, hall, is_pinned, pin_priority, created_at, updated_at)
@@ -383,7 +316,7 @@ func (h *mcpHandler) toolDiaryRead(ctx context.Context, args map[string]any) mcp
 	if agent == "" {
 		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: 'agent' required"}}, IsError: true}
 	}
-	owner := diaryOwner(agent)
+	owner := mcp.DiaryOwner(agent)
 	queryStr, _ := args["query"].(string)
 	collectionName, _ := args["collection"].(string)
 

--- a/Levara/pkg/mcp/hall.go
+++ b/Levara/pkg/mcp/hall.go
@@ -1,0 +1,84 @@
+package mcp
+
+import "encoding/json"
+
+// hallVocab is the controlled vocabulary for the "hall" field on a memory
+// record. Extending this list is a deliberate code change so downstream
+// consumers (search filters, dashboards) stay in sync — adding a value here
+// without updating those consumers leaks unfiltered memories into UI.
+//
+// Vocabulary semantics:
+//   fact       — objective characteristic (version, dimension, IP, path)
+//   event      — something happened at a moment (deploy, merge, incident)
+//   decision   — architectural/project choice with justification
+//   preference — user preference about style, tools, workflow
+//   advice     — reusable rule of thumb ("before X, do Y")
+//   discovery  — non-obvious insight worth recalling months later
+var hallVocab = []string{
+	"fact",
+	"event",
+	"decision",
+	"preference",
+	"advice",
+	"discovery",
+}
+
+// ValidHalls returns the controlled hall vocabulary. Returned slice should
+// be treated as read-only by callers.
+func ValidHalls() []string { return hallVocab }
+
+// IsValidHall reports whether h is a member of the controlled vocabulary.
+// Empty string is invalid (callers must explicitly pick a hall).
+func IsValidHall(h string) bool {
+	for _, v := range hallVocab {
+		if v == h {
+			return true
+		}
+	}
+	return false
+}
+
+// ChunkMetaMatches returns true when the chunk metadata blob (JSON, as
+// written by the orchestrator pipeline) satisfies room and tag filters.
+//
+// Empty roomFilter or empty tagFilters means "no filter on that dimension".
+// Tag filtering uses OR semantics: a chunk matches if it has ANY of the
+// wanted tags. This makes recall easier and matches user expectation when
+// listing related topics.
+//
+// If raw can't be unmarshalled (older chunks without room/tags metadata),
+// the function returns false when any filter is requested. The caller is
+// expected to skip the filter call entirely when no filter is set.
+func ChunkMetaMatches(raw []byte, roomFilter string, tagFilters []string) bool {
+	if roomFilter == "" && len(tagFilters) == 0 {
+		return true
+	}
+	var meta struct {
+		Room string   `json:"room"`
+		Tags []string `json:"tags"`
+	}
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return false
+	}
+	if roomFilter != "" && meta.Room != roomFilter {
+		return false
+	}
+	if len(tagFilters) > 0 {
+		hit := false
+		for _, want := range tagFilters {
+			for _, have := range meta.Tags {
+				if want == have {
+					hit = true
+					break
+				}
+			}
+			if hit {
+				break
+			}
+		}
+		if !hit {
+			return false
+		}
+	}
+	return true
+}

--- a/Levara/pkg/mcp/hall_test.go
+++ b/Levara/pkg/mcp/hall_test.go
@@ -1,0 +1,85 @@
+package mcp
+
+import "testing"
+
+func TestValidHalls_StableOrder(t *testing.T) {
+	got := ValidHalls()
+	want := []string{"fact", "event", "decision", "preference", "advice", "discovery"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d halls, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("hall[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestIsValidHall(t *testing.T) {
+	for _, h := range []string{"fact", "event", "decision", "preference", "advice", "discovery"} {
+		if !IsValidHall(h) {
+			t.Errorf("IsValidHall(%q) = false, want true", h)
+		}
+	}
+	for _, h := range []string{"", "facts", "FACT", "unknown", "memory"} {
+		if IsValidHall(h) {
+			t.Errorf("IsValidHall(%q) = true, want false", h)
+		}
+	}
+}
+
+func TestChunkMetaMatches_NoFilter(t *testing.T) {
+	if !ChunkMetaMatches(nil, "", nil) {
+		t.Error("no filter should always match")
+	}
+	if !ChunkMetaMatches([]byte(`{"room":"x"}`), "", nil) {
+		t.Error("no filter should match arbitrary metadata")
+	}
+}
+
+func TestChunkMetaMatches_RoomFilter(t *testing.T) {
+	meta := []byte(`{"room":"auth","tags":["security"]}`)
+	if !ChunkMetaMatches(meta, "auth", nil) {
+		t.Error("room match should pass")
+	}
+	if ChunkMetaMatches(meta, "deploy", nil) {
+		t.Error("room mismatch should fail")
+	}
+}
+
+func TestChunkMetaMatches_TagFilterOrSemantics(t *testing.T) {
+	meta := []byte(`{"room":"auth","tags":["security","oauth"]}`)
+	// Any-match: presence of any wanted tag is enough.
+	if !ChunkMetaMatches(meta, "", []string{"oauth"}) {
+		t.Error("single tag match should pass")
+	}
+	if !ChunkMetaMatches(meta, "", []string{"missing", "oauth"}) {
+		t.Error("multi-tag OR should pass when one matches")
+	}
+	if ChunkMetaMatches(meta, "", []string{"missing", "absent"}) {
+		t.Error("no overlapping tag should fail")
+	}
+}
+
+func TestChunkMetaMatches_BothFilters(t *testing.T) {
+	meta := []byte(`{"room":"auth","tags":["security"]}`)
+	if !ChunkMetaMatches(meta, "auth", []string{"security"}) {
+		t.Error("both matching should pass")
+	}
+	if ChunkMetaMatches(meta, "auth", []string{"oauth"}) {
+		t.Error("room match + tag miss should fail")
+	}
+	if ChunkMetaMatches(meta, "deploy", []string{"security"}) {
+		t.Error("room miss + tag match should fail")
+	}
+}
+
+func TestChunkMetaMatches_MalformedJSON_DropsWhenFiltered(t *testing.T) {
+	// Older chunks without metadata: dropped only when a filter is requested.
+	if !ChunkMetaMatches([]byte("not json"), "", nil) {
+		t.Error("no filter: should match even malformed metadata")
+	}
+	if ChunkMetaMatches([]byte("not json"), "auth", nil) {
+		t.Error("with filter: should drop malformed metadata")
+	}
+}

--- a/Levara/pkg/mcp/types.go
+++ b/Levara/pkg/mcp/types.go
@@ -1,0 +1,74 @@
+// Package mcp holds Model Context Protocol (MCP) types and helpers shared
+// between the HTTP handler in internal/http and any future SDK consumers.
+//
+// This package is the foundation of the F-4 split: pure types and stateless
+// helpers live here so the eventual handler/tools migration can lean on them
+// without circular imports. See ADR-002 (forthcoming) for the full plan.
+package mcp
+
+import "encoding/json"
+
+// ── JSON-RPC 2.0 wire types ──
+//
+// MCP rides on JSON-RPC 2.0 over HTTP (spec 2025-03-26). These types capture
+// the request/response/error envelope; the rest is method+params dispatch.
+
+// JSONRPCRequest is the inbound JSON-RPC 2.0 request envelope.
+type JSONRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// JSONRPCResponse is the outbound JSON-RPC 2.0 response envelope.
+// Either Result OR Error is set, never both.
+type JSONRPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *RPCError       `json:"error,omitempty"`
+}
+
+// RPCError is the JSON-RPC 2.0 error object. Codes follow the spec
+// (-32700 parse, -32600 invalid request, -32601 method not found, ...).
+type RPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// ── MCP-specific types ──
+
+// Tool describes one MCP tool exposed to clients via tools/list.
+// InputSchema is a JSON Schema document describing the tool's parameters.
+type Tool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"inputSchema"`
+}
+
+// Content is one chunk of MCP tool output. Today we only emit "text"; future
+// types include "image" and "resource". Multiple content items can be
+// returned from a single tool call.
+type Content struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// ToolResult is what a tool returns. IsError=true signals that Content holds
+// an error message (e.g. validation failure) rather than data — distinct from
+// JSON-RPC level errors which use the RPCError envelope.
+type ToolResult struct {
+	Content []Content `json:"content"`
+	IsError bool      `json:"isError,omitempty"`
+}
+
+// ── Context keys ──
+
+// ContextKey is the type used for MCP context.WithValue keys to avoid
+// collisions with other packages.
+type ContextKey string
+
+// UserIDKey identifies the per-call user ID (extracted from auth) for
+// scoping memories, diaries, and rate limits in tool implementations.
+const UserIDKey ContextKey = "mcp_user_id"

--- a/Levara/pkg/mcp/types_test.go
+++ b/Levara/pkg/mcp/types_test.go
@@ -1,0 +1,103 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// JSON wire-format tests for the MCP envelope types. These lock in the on-the-
+// wire field names that external clients (Claude Code, Cursor, Cline) depend
+// on — any rename here breaks every MCP client silently.
+
+func TestJSONRPCRequest_FieldNames(t *testing.T) {
+	src := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"search"}`),
+	}
+	raw, err := json.Marshal(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search"}}`
+	if string(raw) != want {
+		t.Errorf("got  %s\nwant %s", raw, want)
+	}
+}
+
+func TestJSONRPCResponse_OmitsErrorWhenNil(t *testing.T) {
+	src := JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Result:  map[string]string{"k": "v"},
+	}
+	raw, _ := json.Marshal(src)
+	if string(raw) != `{"jsonrpc":"2.0","id":1,"result":{"k":"v"}}` {
+		t.Errorf("got %s", raw)
+	}
+}
+
+func TestJSONRPCResponse_OmitsResultWhenError(t *testing.T) {
+	src := JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Error:   &RPCError{Code: -32601, Message: "Method not found"},
+	}
+	raw, _ := json.Marshal(src)
+	want := `{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}`
+	if string(raw) != want {
+		t.Errorf("got  %s\nwant %s", raw, want)
+	}
+}
+
+func TestToolResult_OmitsIsErrorWhenFalse(t *testing.T) {
+	src := ToolResult{Content: []Content{{Type: "text", Text: "ok"}}}
+	raw, _ := json.Marshal(src)
+	want := `{"content":[{"type":"text","text":"ok"}]}`
+	if string(raw) != want {
+		t.Errorf("got %s, want %s", raw, want)
+	}
+}
+
+func TestToolResult_IncludesIsErrorWhenTrue(t *testing.T) {
+	src := ToolResult{
+		Content: []Content{{Type: "text", Text: "boom"}},
+		IsError: true,
+	}
+	raw, _ := json.Marshal(src)
+	want := `{"content":[{"type":"text","text":"boom"}],"isError":true}`
+	if string(raw) != want {
+		t.Errorf("got %s, want %s", raw, want)
+	}
+}
+
+func TestTool_RoundTrip(t *testing.T) {
+	src := Tool{
+		Name:        "search",
+		Description: "Search",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"query": map[string]any{"type": "string"},
+			},
+		},
+	}
+	raw, _ := json.Marshal(src)
+	var got Tool
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "search" || got.Description != "Search" {
+		t.Errorf("roundtrip lost fields: %+v", got)
+	}
+}
+
+func TestUserIDKey_TypedConstant(t *testing.T) {
+	// UserIDKey must be of type ContextKey (not plain string) to avoid
+	// collisions with other packages stuffing keys into context.WithValue.
+	var k any = UserIDKey
+	if _, ok := k.(ContextKey); !ok {
+		t.Errorf("UserIDKey is %T, want ContextKey", k)
+	}
+}

--- a/Levara/pkg/mcp/util.go
+++ b/Levara/pkg/mcp/util.go
@@ -1,0 +1,31 @@
+package mcp
+
+import (
+	"crypto/rand"
+	"fmt"
+	"strings"
+)
+
+// RandomHex returns n random hex characters. Panics if crypto/rand is
+// unavailable (which would indicate a system-level failure where panicking
+// is preferable to silently emitting predictable IDs). Used for MCP session
+// IDs and any other "must be unguessable" tokens.
+func RandomHex(n int) string {
+	b := make([]byte, n/2+1)
+	if _, err := rand.Read(b); err != nil {
+		panic("crypto/rand failed: " + err.Error())
+	}
+	return fmt.Sprintf("%x", b)[:n]
+}
+
+// DiaryOwnerPrefix is the namespace prefix for per-agent diary entries
+// stored in the memory palace. Combined with the agent name it forms an
+// owner_id like "agent:reviewer".
+const DiaryOwnerPrefix = "agent:"
+
+// DiaryOwner builds the owner_id used to scope diary memories to a specific
+// subagent (Explore, Plan, code-review, ...). Trims whitespace from agent so
+// "  reviewer " and "reviewer" produce the same owner.
+func DiaryOwner(agent string) string {
+	return DiaryOwnerPrefix + strings.TrimSpace(agent)
+}

--- a/Levara/pkg/mcp/util_test.go
+++ b/Levara/pkg/mcp/util_test.go
@@ -1,0 +1,58 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRandomHex_Length(t *testing.T) {
+	for _, n := range []int{1, 4, 8, 16, 32, 63, 64} {
+		got := RandomHex(n)
+		if len(got) != n {
+			t.Errorf("RandomHex(%d) = %q (len %d), want length %d", n, got, len(got), n)
+		}
+		// Hex characters only
+		for _, c := range got {
+			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+				t.Errorf("RandomHex(%d) = %q contains non-hex char %q", n, got, c)
+				break
+			}
+		}
+	}
+}
+
+func TestRandomHex_Unguessable(t *testing.T) {
+	// 100 calls should produce 100 distinct values for any reasonable n.
+	seen := make(map[string]struct{}, 100)
+	for i := 0; i < 100; i++ {
+		seen[RandomHex(16)] = struct{}{}
+	}
+	if len(seen) != 100 {
+		t.Errorf("got %d unique values out of 100 — RNG too weak?", len(seen))
+	}
+}
+
+func TestDiaryOwner(t *testing.T) {
+	cases := map[string]string{
+		"reviewer":     "agent:reviewer",
+		"  reviewer  ": "agent:reviewer", // trims whitespace
+		"":             "agent:",
+		"explore":      "agent:explore",
+	}
+	for input, want := range cases {
+		if got := DiaryOwner(input); got != want {
+			t.Errorf("DiaryOwner(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestDiaryOwnerPrefix_StableConst(t *testing.T) {
+	// External consumers (search filters, dashboards) parse owner_id by
+	// looking for the "agent:" prefix. Changing it would break them silently.
+	if !strings.HasPrefix(DiaryOwner("x"), DiaryOwnerPrefix) {
+		t.Errorf("DiaryOwner output doesn't start with DiaryOwnerPrefix")
+	}
+	if DiaryOwnerPrefix != "agent:" {
+		t.Errorf("DiaryOwnerPrefix changed to %q — external consumers may break", DiaryOwnerPrefix)
+	}
+}


### PR DESCRIPTION
## Summary

F-4 wave 1a from the testing roadmap: create the \`pkg/mcp/\` directory and move the easiest, lowest-risk pieces — pure helpers + JSON-RPC envelope types. **Foundation only**, no handler logic moved.

This unblocks the larger waves 2-4 (handler struct, tool methods, doctor + memify) which need this foundation in place before they can be safely peeled out of \`internal/http\`.

### What moved

| File | Contents |
|---|---|
| \`pkg/mcp/types.go\` | JSON-RPC envelope: \`JSONRPCRequest\` / \`JSONRPCResponse\` / \`RPCError\`. MCP wire types: \`Tool\`, \`Content\`, \`ToolResult\`, \`ContextKey\`, \`UserIDKey\` |
| \`pkg/mcp/hall.go\` | Memory palace hall vocabulary (\`hallVocab\`, \`ValidHalls\`, \`IsValidHall\`) + \`ChunkMetaMatches\` filter |
| \`pkg/mcp/util.go\` | \`RandomHex\` (crypto/rand wrapper, used for session IDs), \`DiaryOwner\` + \`DiaryOwnerPrefix\` |

JSON field tags preserved bit-exact — external clients (Claude Code, Cursor, Cline) see no protocol change.

### What stayed in \`internal/http\` (deferred to later waves)

- \`mcpHandler\` struct (still uses local \`jsonRPCRequest\`/\`mcpToolResult\` etc — these migrate when the handler itself moves in wave 1b)
- All tool method implementations
- Session lifecycle, \`RegisterMCPAPI\`

### Why not all in one PR

\`mcpHandler\` has receivers on ~30 methods across 4 375 LOC, transitively pulls in \`APIConfig\` + DB + Cluster + dataset cache + BM25 indexes. Moving it requires reworking the cfg plumbing (likely a small \`mcp.Deps\` interface) — that's wave 2-4.

### Tests added (18 new tests, all in \`pkg/mcp\`)

- Hall vocab order stability, IsValidHall truth table
- ChunkMetaMatches: no-filter, room only, tag OR-semantics, both filters, malformed JSON drop-when-filtered
- RandomHex: length contract, 100-call uniqueness (catches RNG weakness)
- DiaryOwner: trim, empty agent, \`agent:\` prefix stability check (external consumers parse owner_id by this prefix)
- JSON wire format: omit empty Result/Error in response, omit IsError=false in ToolResult, Tool roundtrip
- UserIDKey typed as ContextKey (avoids context.WithValue collisions)

## Test plan

- [x] \`go test -race -count=1 ./...\` — 34 PASS / 0 FAIL (\`pkg/mcp\` joined the covered set)
- [x] Build clean — no breakage in \`internal/http\` callers
- [x] All call-sites of moved helpers updated (3 in mcp.go, 2 in mcp_palace.go)

🤖 Generated with [Claude Code](https://claude.com/claude-code)