### PR TITLE
refactor(mcp): F-4 wave 1b — collapse local types to pkg/mcp aliases

### DIFF
--- a/Levara/docs/testing-logs/2026-04-16-f4-wave1b.txt
+++ b/Levara/docs/testing-logs/2026-04-16-f4-wave1b.txt
@@ -1,0 +1,43 @@
+?   	github.com/stek0v/cognevra/cmd/backup	[no test files]
+?   	github.com/stek0v/cognevra/cmd/benchmark	[no test files]
+?   	github.com/stek0v/cognevra/cmd/cli	[no test files]
+?   	github.com/stek0v/cognevra/cmd/loadtest	[no test files]
+?   	github.com/stek0v/cognevra/cmd/server	[no test files]
+ok  	github.com/stek0v/cognevra/internal/cluster	3.027s
+ok  	github.com/stek0v/cognevra/internal/grpc	2.582s
+ok  	github.com/stek0v/cognevra/internal/http	2.292s
+?   	github.com/stek0v/cognevra/internal/metrics	[no test files]
+ok  	github.com/stek0v/cognevra/internal/store	28.727s
+ok  	github.com/stek0v/cognevra/pipeline	2.397s
+ok  	github.com/stek0v/cognevra/pkg/aggregator	2.967s
+ok  	github.com/stek0v/cognevra/pkg/audio	4.676s
+ok  	github.com/stek0v/cognevra/pkg/backup	3.799s
+ok  	github.com/stek0v/cognevra/pkg/bm25	3.375s
+ok  	github.com/stek0v/cognevra/pkg/chunker	4.249s
+ok  	github.com/stek0v/cognevra/pkg/classify	2.767s
+ok  	github.com/stek0v/cognevra/pkg/community	3.142s
+ok  	github.com/stek0v/cognevra/pkg/embed	3.057s
+ok  	github.com/stek0v/cognevra/pkg/extract	3.118s
+ok  	github.com/stek0v/cognevra/pkg/fetch	3.182s
+ok  	github.com/stek0v/cognevra/pkg/fileio	3.149s
+ok  	github.com/stek0v/cognevra/pkg/git	3.105s
+ok  	github.com/stek0v/cognevra/pkg/graph	3.488s
+ok  	github.com/stek0v/cognevra/pkg/graphdb	3.108s
+ok  	github.com/stek0v/cognevra/pkg/graphrank	3.201s
+?   	github.com/stek0v/cognevra/pkg/graphstore	[no test files]
+ok  	github.com/stek0v/cognevra/pkg/ingest	3.087s
+ok  	github.com/stek0v/cognevra/pkg/llm	3.396s
+ok  	github.com/stek0v/cognevra/pkg/llm/mock	3.108s
+ok  	github.com/stek0v/cognevra/pkg/llmcache	3.187s
+ok  	github.com/stek0v/cognevra/pkg/llmproxy	2.867s
+ok  	github.com/stek0v/cognevra/pkg/mcp	3.108s
+ok  	github.com/stek0v/cognevra/pkg/observe	3.009s
+ok  	github.com/stek0v/cognevra/pkg/ontology	3.040s
+ok  	github.com/stek0v/cognevra/pkg/orchestrator	2.767s
+ok  	github.com/stek0v/cognevra/pkg/rerank	3.297s
+ok  	github.com/stek0v/cognevra/pkg/router	3.180s
+ok  	github.com/stek0v/cognevra/pkg/storage	3.098s
+ok  	github.com/stek0v/cognevra/pkg/temporal	3.153s
+ok  	github.com/stek0v/cognevra/pkg/vectorstore	3.113s
+?   	github.com/stek0v/cognevra/proto	[no test files]
+?   	github.com/stek0v/cognevra/proto/pb	[no test files]

--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -40,48 +40,21 @@ import (
 	"github.com/stek0v/cognevra/pipeline"
 )
 
-// ── JSON-RPC 2.0 types ──
+// F-4 wave 1b: the canonical type definitions live in pkg/mcp now. Local
+// names below are type aliases that preserve every existing call-site inside
+// this package unchanged while the handler migration continues in later
+// waves. When the handler itself moves to pkg/mcp the aliases can be dropped.
+type (
+	jsonRPCRequest  = mcp.JSONRPCRequest
+	jsonRPCResponse = mcp.JSONRPCResponse
+	rpcError        = mcp.RPCError
+	contextKey      = mcp.ContextKey
+	mcpTool         = mcp.Tool
+	mcpContent      = mcp.Content
+	mcpToolResult   = mcp.ToolResult
+)
 
-type jsonRPCRequest struct {
-	JSONRPC string          `json:"jsonrpc"`
-	ID      json.RawMessage `json:"id"`
-	Method  string          `json:"method"`
-	Params  json.RawMessage `json:"params,omitempty"`
-}
-
-type jsonRPCResponse struct {
-	JSONRPC string      `json:"jsonrpc"`
-	ID      json.RawMessage `json:"id"`
-	Result  any         `json:"result,omitempty"`
-	Error   *rpcError   `json:"error,omitempty"`
-}
-
-type rpcError struct {
-	Code    int    `json:"code"`
-	Message string `json:"message"`
-}
-
-// ── MCP types ──
-
-// mcpUserIDKey is the context key for user isolation in MCP tools.
-type contextKey string
-const mcpUserIDKey contextKey = "mcp_user_id"
-
-type mcpTool struct {
-	Name        string         `json:"name"`
-	Description string         `json:"description"`
-	InputSchema map[string]any `json:"inputSchema"`
-}
-
-type mcpContent struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
-}
-
-type mcpToolResult struct {
-	Content []mcpContent `json:"content"`
-	IsError bool         `json:"isError,omitempty"`
-}
+const mcpUserIDKey = mcp.UserIDKey
 
 // ── Tool definitions ──
 


### PR DESCRIPTION
## Summary

F-4 wave 1b: eliminate the duplication between \`pkg/mcp\` and \`internal/http\` for JSON-RPC envelope + MCP wire types. The local declarations in \`internal/http/mcp.go\` are now Go type aliases for their \`pkg/mcp\` counterparts.

### Before

\`\`\`go
// internal/http/mcp.go
type jsonRPCRequest struct { JSONRPC string \`json:\"jsonrpc\"\`; ID json.RawMessage ... }
type jsonRPCResponse struct { ... }
type rpcError struct { ... }
type mcpTool struct { ... }
// ... 7 types total, duplicating pkg/mcp definitions exactly
\`\`\`

### After

\`\`\`go
// internal/http/mcp.go
type (
    jsonRPCRequest  = mcp.JSONRPCRequest
    jsonRPCResponse = mcp.JSONRPCResponse
    rpcError        = mcp.RPCError
    contextKey      = mcp.ContextKey
    mcpTool         = mcp.Tool
    mcpContent      = mcp.Content
    mcpToolResult   = mcp.ToolResult
)
const mcpUserIDKey = mcp.UserIDKey
\`\`\`

### Zero call-site changes

~200 references across internal/http keep working as-is thanks to Go type aliases — a \`*jsonRPCRequest\` is identical to a \`*mcp.JSONRPCRequest\`, and \`json\` tags are inherited from the aliased type. This is the safest way to unify type ownership without a big-bang rewrite.

### What this unblocks

- **pkg/mcp tests can construct the same types used on the wire** — no more drift risk between the canonical definitions and what the handler actually serializes.
- **Future waves can drop aliases file-by-file** as individual handler methods migrate to pkg/mcp.
- **External packages** (\`internal/grpc\`, \`cmd/server\`) can now import \`pkg/mcp\` directly for protocol-level types without pulling in the whole HTTP handler.

### Scope discipline

Aliases only. No handler logic moved. The \`mcpHandler\` struct, session lifecycle, and tool implementations stay in \`internal/http\` until wave 2 (palace tools) and wave 3 (core tools + cfg-as-interface).

## Test plan

- [x] \`go test -race -count=1 ./...\` — 34 PASS / 0 FAIL
- [x] \`go build ./...\` — clean, no breakage
- [x] JSON wire format unchanged (aliased types inherit json tags from pkg/mcp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)