### PR TITLE
refactor(mcp): F-4 wave 2 — session lifecycle → pkg/mcp

### DIFF
--- a/Levara/docs/testing-logs/2026-04-16-f4-wave2.txt
+++ b/Levara/docs/testing-logs/2026-04-16-f4-wave2.txt
@@ -1,0 +1,43 @@
+?   	github.com/stek0v/cognevra/cmd/backup	[no test files]
+?   	github.com/stek0v/cognevra/cmd/benchmark	[no test files]
+?   	github.com/stek0v/cognevra/cmd/cli	[no test files]
+?   	github.com/stek0v/cognevra/cmd/loadtest	[no test files]
+?   	github.com/stek0v/cognevra/cmd/server	[no test files]
+ok  	github.com/stek0v/cognevra/internal/cluster	1.783s
+ok  	github.com/stek0v/cognevra/internal/grpc	2.612s
+ok  	github.com/stek0v/cognevra/internal/http	1.928s
+?   	github.com/stek0v/cognevra/internal/metrics	[no test files]
+ok  	github.com/stek0v/cognevra/internal/store	30.602s
+ok  	github.com/stek0v/cognevra/pipeline	4.201s
+ok  	github.com/stek0v/cognevra/pkg/aggregator	4.677s
+ok  	github.com/stek0v/cognevra/pkg/audio	2.158s
+ok  	github.com/stek0v/cognevra/pkg/backup	4.165s
+ok  	github.com/stek0v/cognevra/pkg/bm25	2.461s
+ok  	github.com/stek0v/cognevra/pkg/chunker	3.793s
+ok  	github.com/stek0v/cognevra/pkg/classify	3.175s
+ok  	github.com/stek0v/cognevra/pkg/community	3.576s
+ok  	github.com/stek0v/cognevra/pkg/embed	3.869s
+ok  	github.com/stek0v/cognevra/pkg/extract	3.050s
+ok  	github.com/stek0v/cognevra/pkg/fetch	3.154s
+ok  	github.com/stek0v/cognevra/pkg/fileio	3.546s
+ok  	github.com/stek0v/cognevra/pkg/git	3.491s
+ok  	github.com/stek0v/cognevra/pkg/graph	4.072s
+ok  	github.com/stek0v/cognevra/pkg/graphdb	3.349s
+ok  	github.com/stek0v/cognevra/pkg/graphrank	3.453s
+?   	github.com/stek0v/cognevra/pkg/graphstore	[no test files]
+ok  	github.com/stek0v/cognevra/pkg/ingest	3.297s
+ok  	github.com/stek0v/cognevra/pkg/llm	3.698s
+ok  	github.com/stek0v/cognevra/pkg/llm/mock	3.458s
+ok  	github.com/stek0v/cognevra/pkg/llmcache	3.453s
+ok  	github.com/stek0v/cognevra/pkg/llmproxy	3.079s
+ok  	github.com/stek0v/cognevra/pkg/mcp	3.271s
+ok  	github.com/stek0v/cognevra/pkg/observe	3.088s
+ok  	github.com/stek0v/cognevra/pkg/ontology	3.060s
+ok  	github.com/stek0v/cognevra/pkg/orchestrator	2.723s
+ok  	github.com/stek0v/cognevra/pkg/rerank	3.259s
+ok  	github.com/stek0v/cognevra/pkg/router	3.241s
+ok  	github.com/stek0v/cognevra/pkg/storage	3.105s
+ok  	github.com/stek0v/cognevra/pkg/temporal	3.190s
+ok  	github.com/stek0v/cognevra/pkg/vectorstore	3.263s
+?   	github.com/stek0v/cognevra/proto	[no test files]
+?   	github.com/stek0v/cognevra/proto/pb	[no test files]

--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -513,9 +512,13 @@ var mcpTools = []mcpTool{
 // GET  /mcp — SSE stream for server-initiated messages
 // DELETE /mcp — terminate session
 func RegisterMCPAPI(app fiber.Router, cfg APIConfig) {
+	store := mcp.NewSessionStore()
+	store.OnCountChange = func(n int) {
+		metrics.MCPSessionsActive.Set(float64(n))
+	}
 	handler := &mcpHandler{
 		cfg:      cfg,
-		sessions: make(map[string]*mcpSession),
+		sessions: store,
 	}
 	app.Post("/mcp", handler.handleRPC)
 	app.Get("/mcp", handler.handleSSEStream)
@@ -523,53 +526,28 @@ func RegisterMCPAPI(app fiber.Router, cfg APIConfig) {
 	go handler.sessionCleanupLoop()
 }
 
-// mcpSession tracks a connected MCP client session.
-type mcpSession struct {
-	id                string
-	userID            string    // from Authorization header (JWT), empty for anonymous
-	createdAt         time.Time
-	sseCh             chan []byte // buffered channel for server-initiated SSE messages
-	defaultCollection string     // session-scoped default project collection (set via set_context tool)
-}
+// mcpSession is a type alias for the canonical mcp.Session — all session
+// state and lifecycle now lives in pkg/mcp (F-4 wave 2). See pkg/mcp/session.go.
+type mcpSession = mcp.Session
 
 type mcpHandler struct {
 	cfg      APIConfig
-	mu       sync.RWMutex
-	sessions map[string]*mcpSession
+	sessions *mcp.SessionStore
 }
 
 // getOrValidateSession returns the session for the given ID, or nil if invalid.
 func (h *mcpHandler) getOrValidateSession(sessionID string) *mcpSession {
-	if sessionID == "" {
-		return nil
-	}
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-	return h.sessions[sessionID]
+	return h.sessions.Get(sessionID)
 }
 
 // createSession creates a new MCP session and returns its ID.
 func (h *mcpHandler) createSession() string {
-	id := fmt.Sprintf("mcp-%d-%s", time.Now().UnixNano(), mcp.RandomHex(8))
-	h.mu.Lock()
-	h.sessions[id] = &mcpSession{
-		id:        id,
-		createdAt: time.Now(),
-		sseCh:     make(chan []byte, 100),
-	}
-	h.mu.Unlock()
-	metrics.MCPSessionsActive.Set(float64(len(h.sessions)))
-	return id
+	return h.sessions.Create().ID
 }
 
 // deleteSession removes a session.
 func (h *mcpHandler) deleteSession(id string) {
-	h.mu.Lock()
-	if s, ok := h.sessions[id]; ok {
-		close(s.sseCh)
-		delete(h.sessions, id)
-	}
-	h.mu.Unlock()
+	h.sessions.Delete(id)
 }
 
 // randomHex moved to pkg/mcp.RandomHex.
@@ -663,8 +641,8 @@ func (h *mcpHandler) resolveCollection(sess *mcpSession, args map[string]any, fo
 	if coll, _ := args["collection"].(string); coll != "" {
 		return coll
 	}
-	if sess != nil && sess.defaultCollection != "" {
-		return sess.defaultCollection
+	if sess != nil && sess.DefaultCollection != "" {
+		return sess.DefaultCollection
 	}
 	if forWrite {
 		return "default"
@@ -688,8 +666,8 @@ func (h *mcpHandler) handleToolCall(c *fiber.Ctx, req jsonRPCRequest) error {
 	toolCtx := context.Background()
 	sessionID := c.Get("Mcp-Session-Id")
 	sess := h.getOrValidateSession(sessionID)
-	if sess != nil && sess.userID != "" {
-		toolCtx = context.WithValue(toolCtx, mcpUserIDKey, sess.userID)
+	if sess != nil && sess.UserID != "" {
+		toolCtx = context.WithValue(toolCtx, mcpUserIDKey, sess.UserID)
 	}
 
 	result := h.executeTool(toolCtx, sess, params.Name, params.Arguments)
@@ -725,8 +703,8 @@ func (h *mcpHandler) executeToolInner(ctx context.Context, sess *mcpSession, nam
 		// Memory tools: only inject session default, NOT "default" fallback.
 		// Empty collection → global _memories (backward compatible with Pi data).
 		if _, ok := args["collection"]; !ok || args["collection"] == "" {
-			if sess != nil && sess.defaultCollection != "" {
-				args["collection"] = sess.defaultCollection
+			if sess != nil && sess.DefaultCollection != "" {
+				args["collection"] = sess.DefaultCollection
 			}
 			// else: leave empty → _memories (global, no suffix)
 		}
@@ -2147,7 +2125,7 @@ func (h *mcpHandler) toolSetContext(sess *mcpSession, args map[string]any) mcpTo
 	}
 	// Validate collection exists (or allow setting for future use)
 	exists := h.cfg.Collections != nil && h.cfg.Collections.Has(collection)
-	sess.defaultCollection = collection
+	sess.DefaultCollection = collection
 
 	status := "set"
 	if !exists {
@@ -2641,17 +2619,9 @@ func (h *mcpHandler) sessionCleanupLoop() {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 	for range ticker.C {
-		h.mu.Lock()
-		now := time.Now()
-		for id, s := range h.sessions {
-			if now.Sub(s.createdAt) > time.Hour {
-				close(s.sseCh)
-				delete(h.sessions, id)
-			}
-		}
-		metrics.MCPSessionsActive.Set(float64(len(h.sessions)))
-		h.mu.Unlock()
-
+		// SessionStore.CleanupIdle fires OnCountChange which updates the
+		// MCPSessionsActive gauge for us — no explicit metrics.Set here.
+		h.sessions.CleanupIdle(time.Hour)
 		h.updateDataMetrics()
 	}
 }
@@ -2699,7 +2669,7 @@ func (h *mcpHandler) handleSSEStream(c *fiber.Ctx) error {
 
 		for {
 			select {
-			case msg, ok := <-sess.sseCh:
+			case msg, ok := <-sess.SSECh:
 				if !ok {
 					return // session closed
 				}

--- a/Levara/pkg/mcp/session.go
+++ b/Levara/pkg/mcp/session.go
@@ -1,0 +1,123 @@
+package mcp
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Session tracks one connected MCP client. Fields are exported so the HTTP
+// handler in internal/http (and the future pkg/mcp handler) can read/write
+// them directly — Session is a plain value object, not a hidden state
+// machine. Concurrent mutation is the caller's responsibility; SessionStore
+// below handles concurrent map access.
+type Session struct {
+	ID                string
+	UserID            string    // from Authorization header (JWT); empty for anonymous
+	CreatedAt         time.Time
+	SSECh             chan []byte // buffered channel for server-initiated SSE messages
+	DefaultCollection string      // set via the set_context tool
+}
+
+// SessionStore is the thread-safe registry of active MCP sessions. Create /
+// Get / Delete are all O(1) under a single RWMutex. CleanupIdle sweeps stale
+// entries older than the given maxAge and returns how many were evicted —
+// external callers use that for metrics bookkeeping (we intentionally don't
+// depend on the metrics package inside this package).
+//
+// An optional OnCountChange hook fires after every operation that modifies
+// the store size, passing the new count. Handlers plug their own Prometheus
+// gauge update here without SessionStore knowing about the metrics package.
+type SessionStore struct {
+	mu            sync.RWMutex
+	sessions      map[string]*Session
+	OnCountChange func(n int)
+}
+
+// NewSessionStore returns an empty store. OnCountChange may be set directly
+// on the returned value; default nil means "no hook".
+func NewSessionStore() *SessionStore {
+	return &SessionStore{sessions: make(map[string]*Session)}
+}
+
+// Get returns the session with the given ID, or nil if absent. Empty ID is
+// treated as "no session" rather than triggering a zero-value lookup.
+func (s *SessionStore) Get(id string) *Session {
+	if id == "" {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.sessions[id]
+}
+
+// Create registers a new session with a freshly-generated ID. The buffered
+// SSECh has capacity 100 to absorb short bursts of notifications without
+// blocking the producer. The returned Session is already visible to Get.
+func (s *SessionStore) Create() *Session {
+	id := fmt.Sprintf("mcp-%d-%s", time.Now().UnixNano(), RandomHex(8))
+	sess := &Session{
+		ID:        id,
+		CreatedAt: time.Now(),
+		SSECh:     make(chan []byte, 100),
+	}
+	s.mu.Lock()
+	s.sessions[id] = sess
+	count := len(s.sessions)
+	s.mu.Unlock()
+	s.notifyCount(count)
+	return sess
+}
+
+// Delete removes the session and closes its SSECh. Calling on an absent ID
+// is a no-op (idempotent — lets callers retry cleanly on network hiccups).
+// OnCountChange fires only when the store size actually changed.
+func (s *SessionStore) Delete(id string) {
+	s.mu.Lock()
+	sess, ok := s.sessions[id]
+	if ok {
+		close(sess.SSECh)
+		delete(s.sessions, id)
+	}
+	count := len(s.sessions)
+	s.mu.Unlock()
+	if ok {
+		s.notifyCount(count)
+	}
+}
+
+// Count returns the current number of active sessions.
+func (s *SessionStore) Count() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.sessions)
+}
+
+// CleanupIdle removes sessions older than maxAge. Returns the number evicted
+// so the caller can log / alert on large sweeps. Sessions' SSECh are closed
+// as part of eviction — any goroutine blocked on a send will unblock with
+// the zero value on the receive side.
+func (s *SessionStore) CleanupIdle(maxAge time.Duration) int {
+	now := time.Now()
+	evicted := 0
+	s.mu.Lock()
+	for id, sess := range s.sessions {
+		if now.Sub(sess.CreatedAt) > maxAge {
+			close(sess.SSECh)
+			delete(s.sessions, id)
+			evicted++
+		}
+	}
+	count := len(s.sessions)
+	s.mu.Unlock()
+	if evicted > 0 {
+		s.notifyCount(count)
+	}
+	return evicted
+}
+
+func (s *SessionStore) notifyCount(n int) {
+	if s.OnCountChange != nil {
+		s.OnCountChange(n)
+	}
+}

--- a/Levara/pkg/mcp/session_test.go
+++ b/Levara/pkg/mcp/session_test.go
@@ -1,0 +1,175 @@
+package mcp
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSessionStore_CreateGetDelete(t *testing.T) {
+	s := NewSessionStore()
+	sess := s.Create()
+	if sess.ID == "" {
+		t.Fatal("Create returned empty ID")
+	}
+	if !strings.HasPrefix(sess.ID, "mcp-") {
+		t.Errorf("ID %q does not use mcp- prefix", sess.ID)
+	}
+	if got := s.Get(sess.ID); got != sess {
+		t.Errorf("Get after Create did not return the same pointer")
+	}
+	if s.Count() != 1 {
+		t.Errorf("Count = %d, want 1", s.Count())
+	}
+
+	s.Delete(sess.ID)
+	if s.Get(sess.ID) != nil {
+		t.Error("Get after Delete should return nil")
+	}
+	if s.Count() != 0 {
+		t.Errorf("Count after Delete = %d, want 0", s.Count())
+	}
+}
+
+func TestSessionStore_GetEmptyIDReturnsNil(t *testing.T) {
+	s := NewSessionStore()
+	if s.Get("") != nil {
+		t.Error("Get(\"\") should return nil without a lookup")
+	}
+}
+
+func TestSessionStore_DeleteAbsentIsNoop(t *testing.T) {
+	s := NewSessionStore()
+	// Should not panic, should not fire OnCountChange either.
+	var fired atomic.Bool
+	s.OnCountChange = func(n int) { fired.Store(true) }
+	s.Delete("does-not-exist")
+	if fired.Load() {
+		t.Error("OnCountChange fired for absent Delete")
+	}
+}
+
+func TestSessionStore_CreateSSECh_Buffered(t *testing.T) {
+	s := NewSessionStore()
+	sess := s.Create()
+	// Channel should accept sends without blocking up to cap=100.
+	for i := 0; i < 100; i++ {
+		select {
+		case sess.SSECh <- []byte("x"):
+		default:
+			t.Fatalf("SSECh blocked at send %d; expected cap ≥ 100", i)
+		}
+	}
+}
+
+func TestSessionStore_DeleteClosesSSECh(t *testing.T) {
+	s := NewSessionStore()
+	sess := s.Create()
+	s.Delete(sess.ID)
+	select {
+	case _, ok := <-sess.SSECh:
+		if ok {
+			t.Error("SSECh should be closed after Delete")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("SSECh not closed within 100ms of Delete")
+	}
+}
+
+func TestSessionStore_OnCountChangeFires(t *testing.T) {
+	s := NewSessionStore()
+	var counts []int
+	var mu sync.Mutex
+	s.OnCountChange = func(n int) {
+		mu.Lock()
+		counts = append(counts, n)
+		mu.Unlock()
+	}
+
+	a := s.Create()
+	b := s.Create()
+	s.Delete(a.ID)
+	s.Delete(b.ID)
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := []int{1, 2, 1, 0}
+	if len(counts) != len(want) {
+		t.Fatalf("got %d hook fires, want %d (counts=%v)", len(counts), len(want), counts)
+	}
+	for i := range want {
+		if counts[i] != want[i] {
+			t.Errorf("counts[%d] = %d, want %d", i, counts[i], want[i])
+		}
+	}
+}
+
+func TestSessionStore_CleanupIdle_EvictsOld(t *testing.T) {
+	s := NewSessionStore()
+	old := s.Create()
+	old.CreatedAt = time.Now().Add(-2 * time.Hour) // rewind to force eviction
+	fresh := s.Create()
+
+	evicted := s.CleanupIdle(time.Hour)
+	if evicted != 1 {
+		t.Errorf("evicted = %d, want 1", evicted)
+	}
+	if s.Get(old.ID) != nil {
+		t.Error("old session still present after CleanupIdle")
+	}
+	if s.Get(fresh.ID) == nil {
+		t.Error("fresh session evicted by mistake")
+	}
+
+	// SSECh of the evicted session must be closed.
+	select {
+	case _, ok := <-old.SSECh:
+		if ok {
+			t.Error("evicted session SSECh should be closed")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("evicted SSECh not closed")
+	}
+}
+
+func TestSessionStore_CleanupIdle_NothingToEvictDoesNotFireHook(t *testing.T) {
+	s := NewSessionStore()
+	s.Create() // not old enough
+	var fired atomic.Int32
+	s.OnCountChange = func(n int) { fired.Add(1) }
+	evicted := s.CleanupIdle(time.Hour)
+	if evicted != 0 {
+		t.Errorf("evicted = %d, want 0", evicted)
+	}
+	if fired.Load() != 0 {
+		t.Errorf("OnCountChange fired %d times on zero-eviction sweep", fired.Load())
+	}
+}
+
+func TestSessionStore_ConcurrentCreateDelete(t *testing.T) {
+	// Race detector catches any map or mutex misuse.
+	s := NewSessionStore()
+	const goroutines = 16
+	const perRoutine = 50
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ids := make([]string, perRoutine)
+			for j := 0; j < perRoutine; j++ {
+				ids[j] = s.Create().ID
+			}
+			for _, id := range ids {
+				s.Delete(id)
+			}
+		}()
+	}
+	wg.Wait()
+	if got := s.Count(); got != 0 {
+		t.Errorf("Count after concurrent Create+Delete = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

F-4 wave 2: move the MCP session registry from \`internal/http/mcp.go\` into \`pkg/mcp\` as a reusable concurrent-safe component. Handler receivers stay as thin delegations.

### pkg/mcp additions

- **Session** — plain value object with exported fields (\`ID\`, \`UserID\`, \`CreatedAt\`, \`SSECh\`, \`DefaultCollection\`). No hidden state machine.
- **SessionStore** — thread-safe registry with \`Get\`, \`Create\`, \`Delete\`, \`Count\`, \`CleanupIdle(maxAge)\`. Internal \`sync.RWMutex\` + map. Optional \`OnCountChange func(n int)\` hook lets callers plug Prometheus gauge updates without pkg/mcp importing internal/metrics.

### internal/http changes

- \`mcpSession\` is now \`type mcpSession = mcp.Session\` (alias — zero call-site churn on the type name).
- \`mcpHandler\` holds \`*mcp.SessionStore\` instead of raw map + mu.
- \`RegisterMCPAPI\` installs \`OnCountChange = metrics.MCPSessionsActive.Set\`.
- \`sessionCleanupLoop\` delegates to \`store.CleanupIdle\` — cleanup is now two lines instead of an inlined locked sweep.
- Field references renamed: \`sess.userID → sess.UserID\`, \`sess.sseCh → sess.SSECh\`, \`sess.defaultCollection → sess.DefaultCollection\` (~10 sites).

### Bug caught by tests during implementation

First iteration of \`Delete\` fired \`OnCountChange\` unconditionally — even when the target ID wasn't present, the Prometheus gauge would redundantly set to the same value. Fixed before merge: fire only when store size actually changed. Covered by \`TestSessionStore_DeleteAbsentIsNoop\`.

### Tests (9 new)

- \`Create\`/\`Get\`/\`Delete\` round-trip
- \`Get(\"\")\` returns nil without a lookup
- \`Delete\` on absent ID is idempotent AND skips \`OnCountChange\`
- \`SSECh\` cap=100 (non-blocking burst)
- \`Delete\` closes \`SSECh\` so blocked readers unblock
- \`OnCountChange\` fires with new count after every mutation
- \`CleanupIdle\` evicts old, closes their \`SSECh\`, leaves fresh ones
- \`CleanupIdle\` zero-eviction sweep doesn't fire the hook
- Concurrent Create+Delete: 16 goroutines × 50 each under -race, final Count=0

## Test plan

- [x] \`go test -race -count=1 ./...\` — 34 PASS / 0 FAIL
- [x] \`go build ./...\` — clean
- [x] Metrics gauge continues to update on session changes (OnCountChange wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)