### PR TITLE
refactor(mcp): move ResolveCollection to pkg/mcp

### DIFF
--- a/Levara/docs/testing-logs/2026-04-16-f4-resolve.txt
+++ b/Levara/docs/testing-logs/2026-04-16-f4-resolve.txt
@@ -1,0 +1,43 @@
+?   	github.com/stek0v/cognevra/cmd/backup	[no test files]
+?   	github.com/stek0v/cognevra/cmd/benchmark	[no test files]
+?   	github.com/stek0v/cognevra/cmd/cli	[no test files]
+?   	github.com/stek0v/cognevra/cmd/loadtest	[no test files]
+?   	github.com/stek0v/cognevra/cmd/server	[no test files]
+ok  	github.com/stek0v/cognevra/internal/cluster	3.691s
+ok  	github.com/stek0v/cognevra/internal/grpc	3.131s
+ok  	github.com/stek0v/cognevra/internal/http	3.929s
+?   	github.com/stek0v/cognevra/internal/metrics	[no test files]
+ok  	github.com/stek0v/cognevra/internal/store	29.302s
+ok  	github.com/stek0v/cognevra/pipeline	3.930s
+ok  	github.com/stek0v/cognevra/pkg/aggregator	5.661s
+ok  	github.com/stek0v/cognevra/pkg/audio	5.038s
+ok  	github.com/stek0v/cognevra/pkg/backup	4.251s
+ok  	github.com/stek0v/cognevra/pkg/bm25	2.004s
+ok  	github.com/stek0v/cognevra/pkg/chunker	6.183s
+ok  	github.com/stek0v/cognevra/pkg/classify	4.789s
+ok  	github.com/stek0v/cognevra/pkg/community	3.448s
+ok  	github.com/stek0v/cognevra/pkg/embed	4.112s
+ok  	github.com/stek0v/cognevra/pkg/extract	4.470s
+ok  	github.com/stek0v/cognevra/pkg/fetch	4.297s
+ok  	github.com/stek0v/cognevra/pkg/fileio	4.246s
+ok  	github.com/stek0v/cognevra/pkg/git	4.219s
+ok  	github.com/stek0v/cognevra/pkg/graph	4.550s
+ok  	github.com/stek0v/cognevra/pkg/graphdb	3.997s
+ok  	github.com/stek0v/cognevra/pkg/graphrank	4.305s
+?   	github.com/stek0v/cognevra/pkg/graphstore	[no test files]
+ok  	github.com/stek0v/cognevra/pkg/ingest	3.967s
+ok  	github.com/stek0v/cognevra/pkg/llm	4.349s
+ok  	github.com/stek0v/cognevra/pkg/llm/mock	4.048s
+ok  	github.com/stek0v/cognevra/pkg/llmcache	4.135s
+ok  	github.com/stek0v/cognevra/pkg/llmproxy	3.768s
+ok  	github.com/stek0v/cognevra/pkg/mcp	4.263s
+ok  	github.com/stek0v/cognevra/pkg/observe	3.868s
+ok  	github.com/stek0v/cognevra/pkg/ontology	4.079s
+ok  	github.com/stek0v/cognevra/pkg/orchestrator	3.709s
+ok  	github.com/stek0v/cognevra/pkg/rerank	4.131s
+ok  	github.com/stek0v/cognevra/pkg/router	3.922s
+ok  	github.com/stek0v/cognevra/pkg/storage	3.736s
+ok  	github.com/stek0v/cognevra/pkg/temporal	3.605s
+ok  	github.com/stek0v/cognevra/pkg/vectorstore	3.490s
+?   	github.com/stek0v/cognevra/proto	[no test files]
+?   	github.com/stek0v/cognevra/proto/pb	[no test files]

--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -187,19 +187,11 @@ func (h *mcpHandler) handleRPC(c *fiber.Ctx) error {
 	}
 }
 
-// resolveCollection returns the collection to use for a tool call.
-// Priority: 1) explicit arg, 2) session default, 3) "default" for writes, "" for reads (= all).
+// resolveCollection is a thin shim around mcp.ResolveCollection kept here so
+// existing call-sites inside this package don't need to change. The real
+// logic lives in pkg/mcp/session.go now (F-4 wave).
 func (h *mcpHandler) resolveCollection(sess *mcpSession, args map[string]any, forWrite bool) string {
-	if coll, _ := args["collection"].(string); coll != "" {
-		return coll
-	}
-	if sess != nil && sess.DefaultCollection != "" {
-		return sess.DefaultCollection
-	}
-	if forWrite {
-		return "default"
-	}
-	return ""
+	return mcp.ResolveCollection(sess, args, forWrite)
 }
 
 func (h *mcpHandler) handleToolCall(c *fiber.Ctx, req jsonRPCRequest) error {

--- a/Levara/pkg/mcp/resolve_test.go
+++ b/Levara/pkg/mcp/resolve_test.go
@@ -1,0 +1,72 @@
+package mcp
+
+import "testing"
+
+// ResolveCollection decides the collection scope for a tool call. The
+// priority order (arg > session default > forWrite fallback) is part of the
+// MCP contract — clients rely on set_context to change the session default
+// without re-specifying collection on every call.
+
+func TestResolveCollection_ExplicitArgWins(t *testing.T) {
+	sess := &Session{DefaultCollection: "session-default"}
+	got := ResolveCollection(sess, map[string]any{"collection": "explicit"}, false)
+	if got != "explicit" {
+		t.Errorf("got %q, want explicit (arg should beat session default)", got)
+	}
+}
+
+func TestResolveCollection_SessionDefault(t *testing.T) {
+	sess := &Session{DefaultCollection: "from-session"}
+	// No "collection" arg → session default used.
+	if got := ResolveCollection(sess, map[string]any{}, false); got != "from-session" {
+		t.Errorf("got %q, want from-session", got)
+	}
+}
+
+func TestResolveCollection_WriteFallbackDefault(t *testing.T) {
+	// No arg, no session default, forWrite=true → "default".
+	if got := ResolveCollection(nil, nil, true); got != "default" {
+		t.Errorf("got %q, want 'default' (write fallback)", got)
+	}
+	if got := ResolveCollection(&Session{}, map[string]any{}, true); got != "default" {
+		t.Errorf("got %q, want 'default' (empty-session write fallback)", got)
+	}
+}
+
+func TestResolveCollection_ReadFallbackEmpty(t *testing.T) {
+	// No arg, no session default, forWrite=false → "" meaning "all
+	// collections". Downstream search code treats empty as unscoped.
+	if got := ResolveCollection(nil, nil, false); got != "" {
+		t.Errorf("got %q, want empty (read fallback)", got)
+	}
+}
+
+func TestResolveCollection_NilSessionOK(t *testing.T) {
+	// Anonymous MCP client (no session yet): ResolveCollection must not
+	// dereference nil session. Returns arg if present, else fallback.
+	got := ResolveCollection(nil, map[string]any{"collection": "foo"}, false)
+	if got != "foo" {
+		t.Errorf("got %q, want foo", got)
+	}
+}
+
+func TestResolveCollection_EmptyStringArgIsIgnored(t *testing.T) {
+	// "collection": "" in args is treated as unset, falling through to
+	// session default. Guards against clients that always include the field.
+	sess := &Session{DefaultCollection: "kept"}
+	got := ResolveCollection(sess, map[string]any{"collection": ""}, false)
+	if got != "kept" {
+		t.Errorf("got %q, want kept (empty arg should not override session default)", got)
+	}
+}
+
+func TestResolveCollection_WrongTypeIgnored(t *testing.T) {
+	// Type assertion failure (non-string value for "collection") falls
+	// through to session default — MCP clients sending bad arg types
+	// shouldn't silently hit an unintended collection.
+	sess := &Session{DefaultCollection: "kept"}
+	got := ResolveCollection(sess, map[string]any{"collection": 42}, false)
+	if got != "kept" {
+		t.Errorf("got %q, want kept (int arg should be ignored)", got)
+	}
+}

--- a/Levara/pkg/mcp/session.go
+++ b/Levara/pkg/mcp/session.go
@@ -19,6 +19,27 @@ type Session struct {
 	DefaultCollection string      // set via the set_context tool
 }
 
+// ResolveCollection picks the collection for a tool call. Priority:
+//  1. explicit "collection" argument on the call
+//  2. session default (set via set_context)
+//  3. "default" for writes; empty string for reads (which means "all")
+//
+// Returning empty for reads is intentional: downstream search code treats it
+// as "no filter" and scans every collection, which is the right fallback for
+// an unscoped MCP client that hasn't called set_context yet.
+func ResolveCollection(sess *Session, args map[string]any, forWrite bool) string {
+	if coll, _ := args["collection"].(string); coll != "" {
+		return coll
+	}
+	if sess != nil && sess.DefaultCollection != "" {
+		return sess.DefaultCollection
+	}
+	if forWrite {
+		return "default"
+	}
+	return ""
+}
+
 // SessionStore is the thread-safe registry of active MCP sessions. Create /
 // Get / Delete are all O(1) under a single RWMutex. CleanupIdle sweeps stale
 // entries older than the given maxAge and returns how many were evicted —


### PR DESCRIPTION
## Summary

Pure-helper extraction. \`resolveCollection\` had no dependencies on APIConfig / DB / Cluster — it just read the args map and Session struct. Moved to \`pkg/mcp.ResolveCollection\`.

### Priority contract (locked in by tests)

1. Explicit \`\"collection\"\` argument on the tool call
2. Session default (set via \`set_context\`)
3. \`\"default\"\` for writes; \`\"\"\` for reads (meaning \"all collections\")

### Changes

- \`pkg/mcp/session.go\` — \`ResolveCollection(sess, args, forWrite)\` added
- \`internal/http/mcp.go\` — \`h.resolveCollection\` is now a one-line shim delegating to the pkg/mcp version. Two call-sites unchanged.

### Tests (7 new)

- Explicit arg wins over session default
- Session default used when arg absent
- \`\"default\"\` write fallback
- Empty read fallback (unscoped)
- Nil session is safe (anonymous clients)
- Empty-string arg falls through to session default
- Wrong-type arg (int) ignored safely

## Test plan

- [x] \`go test -race -count=1 ./...\` — 34 PASS / 0 FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)