### PR TITLE
refactor(mcp): F-4 wave 3a — Deps interface + toolDelete prototype

### DIFF
--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -87,6 +87,15 @@ type mcpHandler struct {
 	sessions *mcp.SessionStore
 }
 
+// DB implements mcp.Deps: exposes the shared *sql.DB to tool functions
+// that have migrated into pkg/mcp. May return nil when no PostgresDSN
+// is configured.
+func (h *mcpHandler) DB() *sql.DB { return h.cfg.DB }
+
+// Q implements mcp.Deps: forwards to the package-level Q() so tools in
+// pkg/mcp stay agnostic of internal/http's sqlcompat state.
+func (h *mcpHandler) Q(query string) string { return Q(query) }
+
 // getOrValidateSession returns the session for the given ID, or nil if invalid.
 func (h *mcpHandler) getOrValidateSession(sessionID string) *mcpSession {
 	return h.sessions.Get(sessionID)
@@ -767,17 +776,11 @@ func (h *mcpHandler) toolListData(ctx context.Context, args map[string]any) mcpT
 	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(out)}}}
 }
 
+// toolDelete is a thin shim over mcp.ToolDelete. F-4 wave 3a moved the
+// body into pkg/mcp to establish the Deps-interface pattern; this wrapper
+// stays until the handler itself migrates.
 func (h *mcpHandler) toolDelete(ctx context.Context, args map[string]any) mcpToolResult {
-	dsID, _ := args["dataset_id"].(string)
-	if dsID == "" {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: 'dataset_id' required"}}, IsError: true}
-	}
-
-	if h.cfg.DB != nil {
-		h.cfg.DB.ExecContext(ctx, Q("DELETE FROM datasets WHERE id = $1"), dsID)
-	}
-
-	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: fmt.Sprintf("Dataset %s deleted.", dsID)}}}
+	return mcp.ToolDelete(ctx, h, args)
 }
 
 func (h *mcpHandler) toolPrune(ctx context.Context) mcpToolResult {

--- a/Levara/pkg/mcp/deps.go
+++ b/Levara/pkg/mcp/deps.go
@@ -1,0 +1,49 @@
+package mcp
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// Deps is the narrow application-state surface that MCP tool
+// implementations depend on. The concrete implementation lives in
+// internal/http (wrapping APIConfig); tests pass their own fake.
+//
+// Each F-4 wave adds only the methods the next tool needs, so the seam
+// stays minimal and tools can be unit-tested without pulling in the full
+// HTTP config (embed client, LLM provider, Cluster, ...). The first wave
+// (3a) ships just DB + Q — enough for toolDelete.
+type Deps interface {
+	// DB returns the shared *sql.DB used for palace / datasets / graph
+	// tables. May be nil when no PostgresDSN is configured — tool
+	// implementations must guard against it rather than panic.
+	DB() *sql.DB
+	// Q rewrites a query's placeholder style and syntax to match the
+	// active DB dialect (Postgres passthrough, SQLite translation).
+	// Tools should always route queries through Q so the SQLite test
+	// builds stay working.
+	Q(query string) string
+}
+
+// ToolDelete deletes a dataset row by id.
+//
+// The DELETE is best-effort: any SQL error is swallowed to match the
+// pre-refactor behavior in internal/http (MCP clients treat the
+// response text as the source of truth, not the DB state). Returns an
+// error ToolResult only when 'dataset_id' is missing or empty.
+func ToolDelete(ctx context.Context, deps Deps, args map[string]any) ToolResult {
+	dsID, _ := args["dataset_id"].(string)
+	if dsID == "" {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: 'dataset_id' required"}},
+			IsError: true,
+		}
+	}
+
+	if db := deps.DB(); db != nil {
+		db.ExecContext(ctx, deps.Q("DELETE FROM datasets WHERE id = $1"), dsID)
+	}
+
+	return ToolResult{Content: []Content{{Type: "text", Text: fmt.Sprintf("Dataset %s deleted.", dsID)}}}
+}

--- a/Levara/pkg/mcp/deps_test.go
+++ b/Levara/pkg/mcp/deps_test.go
@@ -1,0 +1,143 @@
+package mcp
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	_ "github.com/ncruces/go-sqlite3/driver"
+)
+
+// fakeDeps is the minimum Deps implementation for unit-testing tool
+// functions: a real *sql.DB (in-memory sqlite) plus a Q() that mirrors
+// the internal/http Postgres→SQLite rewrite (ncruces sqlite does not
+// accept $N placeholders).
+type fakeDeps struct {
+	db *sql.DB
+}
+
+func (f *fakeDeps) DB() *sql.DB { return f.db }
+
+// pgPlaceholderRe matches $N placeholder style used by the production
+// queries; we rewrite to ? for SQLite.
+var pgPlaceholderRe = regexp.MustCompile(`\$(\d+)`)
+
+func (f *fakeDeps) Q(query string) string {
+	return pgPlaceholderRe.ReplaceAllString(query, "?")
+}
+
+// nilDBDeps returns nil for DB() — exercises the guard branch.
+type nilDBDeps struct{}
+
+func (nilDBDeps) DB() *sql.DB       { return nil }
+func (nilDBDeps) Q(q string) string { return q }
+
+func setupDepsTestDB(t *testing.T) *fakeDeps {
+	t.Helper()
+	f, _ := os.CreateTemp("", "mcp-deps-test-*.db")
+	path := f.Name()
+	f.Close()
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(path)
+	})
+
+	if _, err := db.Exec(`CREATE TABLE datasets (id TEXT PRIMARY KEY, name TEXT)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	return &fakeDeps{db: db}
+}
+
+func TestToolDelete_MissingIDReturnsError(t *testing.T) {
+	// Missing / empty 'dataset_id' is a client error; tool must surface it
+	// via IsError=true rather than silently returning "deleted."
+	deps := nilDBDeps{}
+
+	got := ToolDelete(context.Background(), deps, map[string]any{})
+	if !got.IsError {
+		t.Fatalf("IsError = false, want true")
+	}
+	if len(got.Content) == 0 || !strings.Contains(got.Content[0].Text, "dataset_id") {
+		t.Fatalf("content = %+v, want error mentioning 'dataset_id'", got.Content)
+	}
+
+	got = ToolDelete(context.Background(), deps, map[string]any{"dataset_id": ""})
+	if !got.IsError {
+		t.Fatalf("empty dataset_id: IsError = false, want true")
+	}
+}
+
+func TestToolDelete_WrongTypeIsError(t *testing.T) {
+	// Non-string dataset_id (e.g. JSON number) must hit the same "required"
+	// error path — the type assertion failure zeroes the string, not a panic.
+	got := ToolDelete(context.Background(), nilDBDeps{}, map[string]any{"dataset_id": 42})
+	if !got.IsError {
+		t.Fatalf("int dataset_id: IsError = false, want true")
+	}
+}
+
+func TestToolDelete_NilDBNoPanic(t *testing.T) {
+	// No Postgres configured → Deps.DB() returns nil. Tool must treat
+	// this as a no-op and still return a success message, matching the
+	// pre-refactor behavior.
+	got := ToolDelete(context.Background(), nilDBDeps{}, map[string]any{"dataset_id": "abc"})
+	if got.IsError {
+		t.Fatalf("IsError = true, want false (nil DB should be a silent no-op)")
+	}
+	if len(got.Content) == 0 || !strings.Contains(got.Content[0].Text, "abc") {
+		t.Fatalf("content = %+v, want message containing 'abc'", got.Content)
+	}
+}
+
+func TestToolDelete_HappyPathDeletesRow(t *testing.T) {
+	// With a working DB, the DELETE must actually remove the row. The
+	// $1 placeholder is rewritten via Deps.Q() so the sqlite backend
+	// accepts it.
+	deps := setupDepsTestDB(t)
+	deps.db.Exec("INSERT INTO datasets (id, name) VALUES ('ds1', 'alpha')")
+	deps.db.Exec("INSERT INTO datasets (id, name) VALUES ('ds2', 'beta')")
+
+	got := ToolDelete(context.Background(), deps, map[string]any{"dataset_id": "ds1"})
+	if got.IsError {
+		t.Fatalf("IsError = true, want false; content=%+v", got.Content)
+	}
+	if len(got.Content) == 0 || !strings.Contains(got.Content[0].Text, "ds1") {
+		t.Fatalf("content = %+v, want message mentioning 'ds1'", got.Content)
+	}
+
+	var count int
+	if err := deps.db.QueryRow("SELECT COUNT(*) FROM datasets WHERE id = 'ds1'").Scan(&count); err != nil {
+		t.Fatalf("count query: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("ds1 row count = %d after delete, want 0", count)
+	}
+
+	// Other rows untouched.
+	if err := deps.db.QueryRow("SELECT COUNT(*) FROM datasets WHERE id = 'ds2'").Scan(&count); err != nil {
+		t.Fatalf("count query: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("ds2 row count = %d after unrelated delete, want 1", count)
+	}
+}
+
+func TestToolDelete_MissingRowNoError(t *testing.T) {
+	// Deleting a non-existent id is best-effort: the tool returns the
+	// standard success message rather than 404-ing. This matches the
+	// pre-refactor contract MCP clients rely on.
+	deps := setupDepsTestDB(t)
+
+	got := ToolDelete(context.Background(), deps, map[string]any{"dataset_id": "nope"})
+	if got.IsError {
+		t.Fatalf("IsError = true, want false on missing row")
+	}
+}


### PR DESCRIPTION
## Summary

- Introduces `mcp.Deps` — a narrow interface (just `DB()` + `Q()` for now) that MCP tool functions depend on instead of the full `APIConfig`.
- Moves `toolDelete` into `pkg/mcp` as the prototype, establishes the pattern for future waves (each tool adds at most one new method to `Deps`).
- `*mcpHandler` satisfies `Deps` via small accessor methods; the old `toolDelete` receiver becomes a one-line shim.

## Why

F-4 waves 1a–resolve moved only pure helpers (types, Session, ResolveCollection, ToolDescriptors). Tool method bodies stayed in `internal/http` because they reference `h.cfg.{DB,Cluster,BM25Indexes,LLM,...}` and pulling the whole `APIConfig` along defeats the point of the split. `Deps` is the seam that lets tool bodies move one at a time, unit-tested with fakes, without dragging the HTTP layer.

## Changes

- `pkg/mcp/deps.go` — `Deps` interface + `ToolDelete`.
- `pkg/mcp/deps_test.go` — 5 tests: missing id, wrong-type id, nil-DB no-op, happy-path delete (sqlite in-memory), delete-missing-row.
- `internal/http/mcp.go` — `*mcpHandler` gains `DB()` + `Q()`; `toolDelete` collapses to `return mcp.ToolDelete(ctx, h, args)`.

## Contract preservation

Behavior byte-for-byte identical to pre-refactor:
- Same error string for missing `dataset_id`.
- Same silent no-op on nil DB.
- Same success message format \`Dataset %s deleted.\`.
- `handleToolCall` unchanged — no call-site churn.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./pkg/mcp/` — 5 new tests + prior pkg/mcp tests
- [x] `go test -race -count=1 ./...` — 34 PASS / 0 FAIL across all packages

## Next wave

Wave 3b will port `toolPrune` on the same `(DB, Q)` surface — no new interface methods needed. After that, `toolCognifyStatus`, `toolListData`, etc. each add one method as they migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)