### PR TITLE
refactor(mcp): F-4 wave 3b — toolPrune moves behind Deps

### DIFF
--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -783,16 +783,11 @@ func (h *mcpHandler) toolDelete(ctx context.Context, args map[string]any) mcpToo
 	return mcp.ToolDelete(ctx, h, args)
 }
 
+// toolPrune is a thin shim over mcp.ToolPrune. F-4 wave 3b moved the
+// body into pkg/mcp; the full table list lives in pkg/mcp/deps.go's
+// pruneTables.
 func (h *mcpHandler) toolPrune(ctx context.Context) mcpToolResult {
-	if h.cfg.DB != nil {
-		h.cfg.DB.ExecContext(ctx, "DELETE FROM dataset_data")
-		h.cfg.DB.ExecContext(ctx, "DELETE FROM data")
-		h.cfg.DB.ExecContext(ctx, "DELETE FROM datasets")
-		h.cfg.DB.ExecContext(ctx, "DELETE FROM graph_nodes")
-		h.cfg.DB.ExecContext(ctx, "DELETE FROM graph_edges")
-	}
-
-	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "All data pruned."}}}
+	return mcp.ToolPrune(ctx, h)
 }
 
 func (h *mcpHandler) toolCognifyStatus(args map[string]any) mcpToolResult {

--- a/Levara/pkg/mcp/deps.go
+++ b/Levara/pkg/mcp/deps.go
@@ -47,3 +47,30 @@ func ToolDelete(ctx context.Context, deps Deps, args map[string]any) ToolResult 
 
 	return ToolResult{Content: []Content{{Type: "text", Text: fmt.Sprintf("Dataset %s deleted.", dsID)}}}
 }
+
+// pruneTables lists every table cleared by ToolPrune, in the order the
+// DELETEs are issued. Child tables come first so a future FK constraint
+// wouldn't block the parent delete — today the schema has no cross-table
+// FKs enforced, but the order is cheap to keep correct.
+var pruneTables = []string{
+	"dataset_data",
+	"data",
+	"datasets",
+	"graph_nodes",
+	"graph_edges",
+}
+
+// ToolPrune clears all dataset, document, and graph rows.
+//
+// Like ToolDelete, each DELETE is best-effort: SQL errors are swallowed
+// to match pre-refactor behavior. The queries are static (no placeholders),
+// so Deps.Q is not needed — a plain ExecContext is fine on both Postgres
+// and SQLite. nil DB is a silent no-op.
+func ToolPrune(ctx context.Context, deps Deps) ToolResult {
+	if db := deps.DB(); db != nil {
+		for _, table := range pruneTables {
+			db.ExecContext(ctx, "DELETE FROM "+table)
+		}
+	}
+	return ToolResult{Content: []Content{{Type: "text", Text: "All data pruned."}}}
+}

--- a/Levara/pkg/mcp/deps_test.go
+++ b/Levara/pkg/mcp/deps_test.go
@@ -141,3 +141,125 @@ func TestToolDelete_MissingRowNoError(t *testing.T) {
 		t.Fatalf("IsError = true, want false on missing row")
 	}
 }
+
+// setupPruneTestDB builds a sqlite DB with every table ToolPrune touches
+// (see pruneTables). Rows are pre-seeded so the happy-path test can
+// assert post-prune counts.
+func setupPruneTestDB(t *testing.T) *fakeDeps {
+	t.Helper()
+	f, _ := os.CreateTemp("", "mcp-prune-test-*.db")
+	path := f.Name()
+	f.Close()
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(path)
+	})
+
+	// Same column lists used by the real schema; only the bits ToolPrune
+	// reads (table existence) matter here, so minimal schemas are fine.
+	stmts := []string{
+		`CREATE TABLE dataset_data (dataset_id TEXT, data_id TEXT)`,
+		`CREATE TABLE data (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE datasets (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE graph_nodes (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE graph_edges (id TEXT PRIMARY KEY)`,
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+	}
+
+	// Seed one row per table so the post-prune count=0 assertion is
+	// meaningful (counting empty tables would pass trivially).
+	seeds := []string{
+		`INSERT INTO dataset_data (dataset_id, data_id) VALUES ('ds1', 'd1')`,
+		`INSERT INTO data (id) VALUES ('d1')`,
+		`INSERT INTO datasets (id) VALUES ('ds1')`,
+		`INSERT INTO graph_nodes (id) VALUES ('n1')`,
+		`INSERT INTO graph_edges (id) VALUES ('e1')`,
+	}
+	for _, s := range seeds {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	return &fakeDeps{db: db}
+}
+
+func TestToolPrune_NilDBNoPanic(t *testing.T) {
+	// nil DB path mirrors ToolDelete: silent no-op, success message.
+	got := ToolPrune(context.Background(), nilDBDeps{})
+	if got.IsError {
+		t.Fatalf("IsError = true, want false (nil DB should be a silent no-op)")
+	}
+	if len(got.Content) == 0 || !strings.Contains(got.Content[0].Text, "pruned") {
+		t.Fatalf("content = %+v, want 'pruned' message", got.Content)
+	}
+}
+
+func TestToolPrune_ClearsEveryKnownTable(t *testing.T) {
+	// End-to-end: with one row per prune target, a single ToolPrune call
+	// must leave each table empty. This is the regression net against
+	// future pruneTables edits that forget to add a new table.
+	deps := setupPruneTestDB(t)
+
+	got := ToolPrune(context.Background(), deps)
+	if got.IsError {
+		t.Fatalf("IsError = true, want false; content=%+v", got.Content)
+	}
+
+	for _, table := range pruneTables {
+		var n int
+		if err := deps.db.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if n != 0 {
+			t.Errorf("table %s: count = %d after prune, want 0", table, n)
+		}
+	}
+}
+
+func TestToolPrune_MissingTableIsBestEffort(t *testing.T) {
+	// If a table is missing (e.g. schema drift in a minority deployment),
+	// ToolPrune must still succeed for the tables that do exist. This
+	// locks in the "errors are swallowed" contract from pre-refactor.
+	f, _ := os.CreateTemp("", "mcp-prune-partial-*.db")
+	path := f.Name()
+	f.Close()
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(path)
+	})
+
+	// Only datasets exists; the other four pruneTables are absent.
+	if _, err := db.Exec(`CREATE TABLE datasets (id TEXT PRIMARY KEY)`); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO datasets (id) VALUES ('x')`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	got := ToolPrune(context.Background(), &fakeDeps{db: db})
+	if got.IsError {
+		t.Fatalf("IsError = true, want false on partial schema")
+	}
+
+	var n int
+	if err := db.QueryRow("SELECT COUNT(*) FROM datasets").Scan(&n); err != nil {
+		t.Fatalf("count datasets: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("datasets count = %d after prune, want 0 even when other tables are missing", n)
+	}
+}


### PR DESCRIPTION
## Summary

- Second tool body moved out of \`internal/http\` into \`pkg/mcp\`, behind the \`Deps\` seam established in wave 3a (#12).
- \`toolPrune\` needs only \`DB()\` (no placeholders in its DELETEs, so no \`Q()\`) — the \`Deps\` interface stays at 2 methods. Pure extraction, no interface growth.

## Changes

- \`pkg/mcp/deps.go\`:
  - \`pruneTables\` slice listing every table the prune clears (\`dataset_data\`, \`data\`, \`datasets\`, \`graph_nodes\`, \`graph_edges\`, in child-first order).
  - \`ToolPrune(ctx, deps)\` — iterates the slice, best-effort DELETEs, silent no-op on nil DB.
- \`pkg/mcp/deps_test.go\`: 3 new tests.
  - nil-DB no-panic.
  - Happy path: seed one row per table, run ToolPrune, assert count=0 on every entry in \`pruneTables\` — locks in the regression net against future edits that forget to add a table.
  - Best-effort: partial schema (only one of the five tables exists) still prunes what's there without erroring.
- \`internal/http/mcp.go\`: \`toolPrune\` collapses to a one-line shim.

## Contract preservation

Behavior byte-for-byte identical:
- Same \`"All data pruned."\` message.
- Same silent swallowing of SQL errors.
- Same table order.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test -race -count=1 ./pkg/mcp/\` — 3 new ToolPrune tests + all prior pkg/mcp tests
- [x] \`go test -race -count=1 ./...\` — 34 PASS / 0 FAIL

## Next wave (3c)

\`toolCognifyStatus\` is the natural follow-up — no new \`Deps\` methods needed (reads the in-memory run registry, not DB). After that, \`toolListData\` pulls in one \`DB\`-only method the interface already has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)