### PR TITLE
refactor(mcp): F-4 wave 3c — toolListData moves behind Deps

### DIFF
--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -96,6 +96,19 @@ func (h *mcpHandler) DB() *sql.DB { return h.cfg.DB }
 // pkg/mcp stay agnostic of internal/http's sqlcompat state.
 func (h *mcpHandler) Q(query string) string { return Q(query) }
 
+// HasCollections implements mcp.Deps: true iff a vector-collection
+// manager is configured on this handler's APIConfig.
+func (h *mcpHandler) HasCollections() bool { return h.cfg.Collections != nil }
+
+// ListCollections implements mcp.Deps: returns the registered
+// collection names, or nil if no manager is configured.
+func (h *mcpHandler) ListCollections() []string {
+	if h.cfg.Collections == nil {
+		return nil
+	}
+	return h.cfg.Collections.List()
+}
+
 // getOrValidateSession returns the session for the given ID, or nil if invalid.
 func (h *mcpHandler) getOrValidateSession(sessionID string) *mcpSession {
 	return h.sessions.Get(sessionID)
@@ -698,82 +711,11 @@ func (h *mcpHandler) toolSearch(ctx context.Context, args map[string]any) mcpToo
 	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(out)}}}
 }
 
+// toolListData is a thin shim over mcp.ToolListData. F-4 wave 3c moved
+// the body into pkg/mcp; the filter parsing and SQL live in
+// pkg/mcp/deps.go's listDataFiltered / listDataUnfiltered helpers.
 func (h *mcpHandler) toolListData(ctx context.Context, args map[string]any) mcpToolResult {
-	if h.cfg.Collections == nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "[]"}}}
-	}
-
-	// Optional filters
-	var wantTags []string
-	if rawTags, ok := args["tags"].([]any); ok {
-		for _, t := range rawTags {
-			if s, ok := t.(string); ok && s != "" {
-				wantTags = append(wantTags, s)
-			}
-		}
-	}
-	roomFilter, _ := args["room"].(string)
-	hasFilter := len(wantTags) > 0 || roomFilter != ""
-
-	var items []map[string]any
-	if !hasFilter {
-		colls := h.cfg.Collections.List()
-		for _, c := range colls {
-			items = append(items, map[string]any{"collection": c, "type": "vector_collection"})
-		}
-	}
-
-	// Also list datasets / data items from DB
-	if h.cfg.DB != nil {
-		if hasFilter {
-			// Tag/room filter operates on the data table directly.
-			var conds []string
-			var qargs []any
-			pos := 1
-			if roomFilter != "" {
-				conds = append(conds, fmt.Sprintf("room = $%d", pos))
-				qargs = append(qargs, roomFilter)
-				pos++
-			}
-			for _, t := range wantTags {
-				// JSON tag list is stored as a string like ["a","b"]; LIKE works on both PG/SQLite.
-				conds = append(conds, fmt.Sprintf("tags LIKE $%d", pos))
-				qargs = append(qargs, "%\""+t+"\"%")
-				pos++
-			}
-			sqlStr := `SELECT id, name, extension, room, tags FROM data`
-			if len(conds) > 0 {
-				sqlStr += " WHERE " + strings.Join(conds, " AND ")
-			}
-			sqlStr += " ORDER BY created_at DESC LIMIT 200"
-			rows, err := h.cfg.DB.QueryContext(ctx, Q(sqlStr), qargs...)
-			if err == nil {
-				defer rows.Close()
-				for rows.Next() {
-					var id, name, ext, rm, tg string
-					rows.Scan(&id, &name, &ext, &rm, &tg)
-					items = append(items, map[string]any{
-						"id": id, "name": name, "extension": ext,
-						"room": rm, "tags": json.RawMessage(tg),
-						"type": "data",
-					})
-				}
-			}
-		} else {
-			rows, err := h.cfg.DB.QueryContext(ctx, Q("SELECT id, name FROM datasets ORDER BY created_at DESC LIMIT 100"))
-			if err == nil {
-				defer rows.Close()
-				for rows.Next() {
-					var id, name string
-					rows.Scan(&id, &name)
-					items = append(items, map[string]any{"id": id, "name": name, "type": "dataset"})
-				}
-			}
-		}
-	}
-
-	out, _ := json.MarshalIndent(items, "", "  ")
-	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(out)}}}
+	return mcp.ToolListData(ctx, h, args)
 }
 
 // toolDelete is a thin shim over mcp.ToolDelete. F-4 wave 3a moved the

--- a/Levara/pkg/mcp/deps.go
+++ b/Levara/pkg/mcp/deps.go
@@ -3,7 +3,9 @@ package mcp
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // Deps is the narrow application-state surface that MCP tool
@@ -12,8 +14,10 @@ import (
 //
 // Each F-4 wave adds only the methods the next tool needs, so the seam
 // stays minimal and tools can be unit-tested without pulling in the full
-// HTTP config (embed client, LLM provider, Cluster, ...). The first wave
-// (3a) ships just DB + Q — enough for toolDelete.
+// HTTP config (embed client, LLM provider, Cluster, ...). Growth so far:
+//   - wave 3a: DB + Q (toolDelete)
+//   - wave 3b: no growth (toolPrune reused DB)
+//   - wave 3c: + HasCollections + ListCollections (toolListData)
 type Deps interface {
 	// DB returns the shared *sql.DB used for palace / datasets / graph
 	// tables. May be nil when no PostgresDSN is configured — tool
@@ -24,6 +28,15 @@ type Deps interface {
 	// Tools should always route queries through Q so the SQLite test
 	// builds stay working.
 	Q(query string) string
+	// HasCollections reports whether a vector-collection manager is
+	// configured. Some tools (e.g. list_data) return an empty result
+	// when this is false, mirroring a deployment that runs without the
+	// vector engine.
+	HasCollections() bool
+	// ListCollections returns the registered collection names. Returns
+	// nil when HasCollections() is false. The slice is safe to iterate
+	// but must not be mutated.
+	ListCollections() []string
 }
 
 // ToolDelete deletes a dataset row by id.
@@ -73,4 +86,123 @@ func ToolPrune(ctx context.Context, deps Deps) ToolResult {
 		}
 	}
 	return ToolResult{Content: []Content{{Type: "text", Text: "All data pruned."}}}
+}
+
+// listDataItemCap is the LIMIT applied to the data / datasets SELECTs.
+// Matches the pre-refactor numbers — 200 for filtered data rows, 100
+// for the unfiltered datasets listing.
+const (
+	listDataItemCap     = 200
+	listDataDatasetsCap = 100
+)
+
+// ToolListData lists the available data for MCP clients.
+//
+// Three modes, chosen by argument shape:
+//   - Collections not configured → "[]" (deployments without the vector
+//     engine surface nothing here, matching the pre-refactor contract).
+//   - With "room" or "tags" filter → SELECT from the data table.
+//   - Otherwise → collection names from the manager + recent datasets.
+//
+// All DB errors are swallowed; a failing query simply contributes no
+// items to the output.
+func ToolListData(ctx context.Context, deps Deps, args map[string]any) ToolResult {
+	if !deps.HasCollections() {
+		return ToolResult{Content: []Content{{Type: "text", Text: "[]"}}}
+	}
+
+	var wantTags []string
+	if rawTags, ok := args["tags"].([]any); ok {
+		for _, t := range rawTags {
+			if s, ok := t.(string); ok && s != "" {
+				wantTags = append(wantTags, s)
+			}
+		}
+	}
+	roomFilter, _ := args["room"].(string)
+	hasFilter := len(wantTags) > 0 || roomFilter != ""
+
+	var items []map[string]any
+	if !hasFilter {
+		for _, c := range deps.ListCollections() {
+			items = append(items, map[string]any{"collection": c, "type": "vector_collection"})
+		}
+	}
+
+	if db := deps.DB(); db != nil {
+		if hasFilter {
+			items = append(items, listDataFiltered(ctx, db, deps.Q, roomFilter, wantTags)...)
+		} else {
+			items = append(items, listDataUnfiltered(ctx, db, deps.Q)...)
+		}
+	}
+
+	out, _ := json.MarshalIndent(items, "", "  ")
+	return ToolResult{Content: []Content{{Type: "text", Text: string(out)}}}
+}
+
+// listDataFiltered runs the tag/room-scoped SELECT against the data
+// table. Returns an empty slice if the query fails — MCP callers
+// distinguish "no match" from "error" by checking the enclosing
+// ToolResult.IsError flag, which the filtered path never sets.
+func listDataFiltered(ctx context.Context, db *sql.DB, rewrite func(string) string, roomFilter string, wantTags []string) []map[string]any {
+	var conds []string
+	var qargs []any
+	pos := 1
+	if roomFilter != "" {
+		conds = append(conds, fmt.Sprintf("room = $%d", pos))
+		qargs = append(qargs, roomFilter)
+		pos++
+	}
+	for _, t := range wantTags {
+		// JSON tag list is stored as a string like ["a","b"]; LIKE works
+		// on both PG and SQLite because we match the quoted tag token.
+		conds = append(conds, fmt.Sprintf("tags LIKE $%d", pos))
+		qargs = append(qargs, "%\""+t+"\"%")
+		pos++
+	}
+	sqlStr := `SELECT id, name, extension, room, tags FROM data`
+	if len(conds) > 0 {
+		sqlStr += " WHERE " + strings.Join(conds, " AND ")
+	}
+	sqlStr += fmt.Sprintf(" ORDER BY created_at DESC LIMIT %d", listDataItemCap)
+
+	rows, err := db.QueryContext(ctx, rewrite(sqlStr), qargs...)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var out []map[string]any
+	for rows.Next() {
+		var id, name, ext, rm, tg string
+		rows.Scan(&id, &name, &ext, &rm, &tg)
+		out = append(out, map[string]any{
+			"id":        id,
+			"name":      name,
+			"extension": ext,
+			"room":      rm,
+			"tags":      json.RawMessage(tg),
+			"type":      "data",
+		})
+	}
+	return out
+}
+
+// listDataUnfiltered lists the most recent datasets (used when no
+// room/tags filter is supplied).
+func listDataUnfiltered(ctx context.Context, db *sql.DB, rewrite func(string) string) []map[string]any {
+	rows, err := db.QueryContext(ctx, rewrite(fmt.Sprintf("SELECT id, name FROM datasets ORDER BY created_at DESC LIMIT %d", listDataDatasetsCap)))
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var out []map[string]any
+	for rows.Next() {
+		var id, name string
+		rows.Scan(&id, &name)
+		out = append(out, map[string]any{"id": id, "name": name, "type": "dataset"})
+	}
+	return out
 }

--- a/Levara/pkg/mcp/deps_test.go
+++ b/Levara/pkg/mcp/deps_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"os"
 	"regexp"
 	"strings"
@@ -14,9 +15,12 @@ import (
 // fakeDeps is the minimum Deps implementation for unit-testing tool
 // functions: a real *sql.DB (in-memory sqlite) plus a Q() that mirrors
 // the internal/http Postgres→SQLite rewrite (ncruces sqlite does not
-// accept $N placeholders).
+// accept $N placeholders). collections is optional — leave nil for
+// tests that exercise the "no vector engine" branch.
 type fakeDeps struct {
-	db *sql.DB
+	db          *sql.DB
+	collections []string // nil → HasCollections() false (not configured)
+	hasColls    bool     // explicit flag so empty-but-configured is possible
 }
 
 func (f *fakeDeps) DB() *sql.DB { return f.db }
@@ -29,11 +33,17 @@ func (f *fakeDeps) Q(query string) string {
 	return pgPlaceholderRe.ReplaceAllString(query, "?")
 }
 
+func (f *fakeDeps) HasCollections() bool     { return f.hasColls }
+func (f *fakeDeps) ListCollections() []string { return f.collections }
+
 // nilDBDeps returns nil for DB() — exercises the guard branch.
+// HasCollections defaults to false, matching an unconfigured deployment.
 type nilDBDeps struct{}
 
-func (nilDBDeps) DB() *sql.DB       { return nil }
-func (nilDBDeps) Q(q string) string { return q }
+func (nilDBDeps) DB() *sql.DB              { return nil }
+func (nilDBDeps) Q(q string) string        { return q }
+func (nilDBDeps) HasCollections() bool     { return false }
+func (nilDBDeps) ListCollections() []string { return nil }
 
 func setupDepsTestDB(t *testing.T) *fakeDeps {
 	t.Helper()
@@ -261,5 +271,211 @@ func TestToolPrune_MissingTableIsBestEffort(t *testing.T) {
 	}
 	if n != 0 {
 		t.Errorf("datasets count = %d after prune, want 0 even when other tables are missing", n)
+	}
+}
+
+// setupListDataTestDB builds the schema ToolListData reads: datasets
+// (id, name, created_at) and data (id, name, extension, room, tags,
+// created_at). Seeded with rows that exercise both paths.
+func setupListDataTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	f, _ := os.CreateTemp("", "mcp-listdata-test-*.db")
+	path := f.Name()
+	f.Close()
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(path)
+	})
+
+	stmts := []string{
+		`CREATE TABLE datasets (id TEXT PRIMARY KEY, name TEXT, created_at TEXT)`,
+		`CREATE TABLE data (
+			id TEXT PRIMARY KEY, name TEXT, extension TEXT,
+			room TEXT, tags TEXT, created_at TEXT
+		)`,
+		// Two datasets, newest first by created_at.
+		`INSERT INTO datasets VALUES ('ds2', 'newer', '2026-02-01')`,
+		`INSERT INTO datasets VALUES ('ds1', 'older', '2026-01-01')`,
+		// Data rows: mix of rooms and tag sets.
+		`INSERT INTO data VALUES ('d1', 'auth-doc', 'md', 'auth', '["security","docs"]', '2026-03-01')`,
+		`INSERT INTO data VALUES ('d2', 'deploy-log', 'txt', 'deploy', '["ops"]', '2026-03-02')`,
+		`INSERT INTO data VALUES ('d3', 'auth-test', 'go', 'auth', '["tests"]', '2026-03-03')`,
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("exec %q: %v", s, err)
+		}
+	}
+	return db
+}
+
+// parseListDataContent pulls the JSON array out of a ToolResult so
+// assertions can inspect individual items.
+func parseListDataContent(t *testing.T, res ToolResult) []map[string]any {
+	t.Helper()
+	if res.IsError {
+		t.Fatalf("IsError = true, want false; content=%+v", res.Content)
+	}
+	if len(res.Content) != 1 || res.Content[0].Type != "text" {
+		t.Fatalf("content = %+v, want single text item", res.Content)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &items); err != nil {
+		t.Fatalf("json unmarshal %q: %v", res.Content[0].Text, err)
+	}
+	return items
+}
+
+func TestToolListData_NoCollectionsReturnsEmpty(t *testing.T) {
+	// When no collection manager is configured (HasCollections false),
+	// the tool must short-circuit to "[]" without touching the DB. This
+	// matches deployments that run without the vector engine.
+	got := ToolListData(context.Background(), nilDBDeps{}, map[string]any{})
+	if got.IsError {
+		t.Fatalf("IsError = true, want false")
+	}
+	if len(got.Content) != 1 || got.Content[0].Text != "[]" {
+		t.Fatalf("content = %+v, want single text \"[]\"", got.Content)
+	}
+}
+
+func TestToolListData_UnfilteredListsCollectionsAndDatasets(t *testing.T) {
+	// With no room/tags filter: emit one vector_collection item per
+	// registered collection, then datasets ordered by created_at DESC.
+	deps := &fakeDeps{
+		db:          setupListDataTestDB(t),
+		collections: []string{"levara", "other"},
+		hasColls:    true,
+	}
+
+	items := parseListDataContent(t, ToolListData(context.Background(), deps, map[string]any{}))
+
+	// Expect 2 collections + 2 datasets = 4 items.
+	if len(items) != 4 {
+		t.Fatalf("got %d items, want 4; items=%+v", len(items), items)
+	}
+	// First two are collections in registration order.
+	for i, name := range []string{"levara", "other"} {
+		if items[i]["type"] != "vector_collection" {
+			t.Errorf("item %d type = %v, want vector_collection", i, items[i]["type"])
+		}
+		if items[i]["collection"] != name {
+			t.Errorf("item %d collection = %v, want %s", i, items[i]["collection"], name)
+		}
+	}
+	// Last two are datasets, newest first.
+	if items[2]["type"] != "dataset" || items[2]["id"] != "ds2" {
+		t.Errorf("items[2] = %+v, want dataset ds2 (newest)", items[2])
+	}
+	if items[3]["type"] != "dataset" || items[3]["id"] != "ds1" {
+		t.Errorf("items[3] = %+v, want dataset ds1", items[3])
+	}
+}
+
+func TestToolListData_RoomFilterHitsDataTable(t *testing.T) {
+	// "room=auth" must skip the collections listing and return only
+	// data rows whose room column matches.
+	deps := &fakeDeps{
+		db:          setupListDataTestDB(t),
+		collections: []string{"levara"},
+		hasColls:    true,
+	}
+
+	items := parseListDataContent(t, ToolListData(context.Background(), deps,
+		map[string]any{"room": "auth"}))
+
+	if len(items) != 2 {
+		t.Fatalf("got %d items, want 2 auth rows; items=%+v", len(items), items)
+	}
+	for _, it := range items {
+		if it["type"] != "data" {
+			t.Errorf("item type = %v, want data (filter path skips collections)", it["type"])
+		}
+		if it["room"] != "auth" {
+			t.Errorf("item room = %v, want auth", it["room"])
+		}
+	}
+}
+
+func TestToolListData_TagsFilterMatchesAnyTag(t *testing.T) {
+	// "tags=[security]" hits d1 only (the tags string contains "security").
+	// Confirms the LIKE '%"tag"%' pattern works against JSON-as-text.
+	deps := &fakeDeps{
+		db:          setupListDataTestDB(t),
+		collections: []string{"levara"},
+		hasColls:    true,
+	}
+
+	items := parseListDataContent(t, ToolListData(context.Background(), deps,
+		map[string]any{"tags": []any{"security"}}))
+
+	if len(items) != 1 {
+		t.Fatalf("got %d items, want 1; items=%+v", len(items), items)
+	}
+	if items[0]["id"] != "d1" {
+		t.Errorf("item id = %v, want d1", items[0]["id"])
+	}
+}
+
+func TestToolListData_CombinedFilterAndsConditions(t *testing.T) {
+	// room=auth AND tags=[tests] → only d3 matches (d1 is auth but has
+	// security+docs, not tests; d2 is deploy/ops). ANDing is important
+	// because tag-only or room-only would return different rows.
+	deps := &fakeDeps{
+		db:          setupListDataTestDB(t),
+		collections: []string{"levara"},
+		hasColls:    true,
+	}
+
+	items := parseListDataContent(t, ToolListData(context.Background(), deps,
+		map[string]any{"room": "auth", "tags": []any{"tests"}}))
+
+	if len(items) != 1 || items[0]["id"] != "d3" {
+		t.Fatalf("got %+v, want single d3 item", items)
+	}
+}
+
+func TestToolListData_EmptyTagStringsIgnored(t *testing.T) {
+	// Clients sometimes send `{"tags": [""]}` — these must not become a
+	// LIKE '%""%' that matches every row. The tool strips empty strings
+	// before building the filter.
+	deps := &fakeDeps{
+		db:          setupListDataTestDB(t),
+		collections: []string{"levara"},
+		hasColls:    true,
+	}
+
+	// tags=[""] with no room → treated as no filter → collections + datasets.
+	items := parseListDataContent(t, ToolListData(context.Background(), deps,
+		map[string]any{"tags": []any{""}}))
+	// Should match unfiltered output: 1 collection + 2 datasets = 3.
+	if len(items) != 3 {
+		t.Fatalf("got %d items with empty-tag filter, want 3 (same as unfiltered)", len(items))
+	}
+}
+
+func TestToolListData_CollectionsConfiguredButEmpty(t *testing.T) {
+	// HasCollections=true but ListCollections returns zero names (fresh
+	// deployment). The tool still proceeds to the DB section rather than
+	// short-circuiting — short-circuit is only for "not configured."
+	deps := &fakeDeps{
+		db:       setupListDataTestDB(t),
+		hasColls: true, // configured, just no collections yet
+	}
+
+	items := parseListDataContent(t, ToolListData(context.Background(), deps, map[string]any{}))
+	// Zero collections + 2 datasets = 2 items.
+	if len(items) != 2 {
+		t.Fatalf("got %d items, want 2 dataset rows; items=%+v", len(items), items)
+	}
+	for _, it := range items {
+		if it["type"] != "dataset" {
+			t.Errorf("item type = %v, want dataset", it["type"])
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Third tool body moved into \`pkg/mcp\`. First wave to grow the \`Deps\` interface — earlier waves reused \`DB\`/\`Q\` only.
- New methods: \`HasCollections() bool\` and \`ListCollections() []string\`. Keeps \`pkg/mcp\` free of a \`pkg/store\` dependency by exposing behavior (bool + slice) rather than the \`CollectionManager\` struct.
- \`toolListData\` is the first non-trivial tool: 77 LOC with three branches (no-collections short-circuit, unfiltered listing, filtered data-table query).

## Why this shape

The original body inlined everything. In the move I split into \`listDataFiltered\` + \`listDataUnfiltered\` helpers so each branch reads top-to-bottom, and lifted the magic LIMIT numbers into named constants. The tool function itself is now a linear pipeline: guard → parse filters → collections section → DB section → marshal.

## Contract preservation

- Exact same output for every code path: collection items first (registration order), then datasets (newest-first), same column lists, same JSON shape with \`type: vector_collection | data | dataset\`.
- Same LIMITs (200 for filtered data, 100 for unfiltered datasets).
- Same silent-error-swallow on DB failures.
- \`HasCollections=false\` still short-circuits to \`\"[]\"\` without touching DB.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test -race -count=1 ./pkg/mcp/\` — 7 new ToolListData tests covering every branch: no-collections short-circuit, unfiltered ordering, room-only filter, tags-only filter, combined AND, empty-tag-string stripping, empty-but-configured collections.
- [x] \`go test -race -count=1 ./...\` — 34 PASS / 0 FAIL

## Deps interface so far

| Method | Wave | Purpose |
|---|---|---|
| \`DB() *sql.DB\` | 3a | shared connection pool |
| \`Q(string) string\` | 3a | dialect rewrite |
| \`HasCollections() bool\` | 3c | vector-engine configured? |
| \`ListCollections() []string\` | 3c | registered collection names |

Still 4 methods after 3 tool bodies migrated (\`toolDelete\`, \`toolPrune\`, \`toolListData\`) — the Deps surface is growing slower than the number of tools it serves, which is the point.

## Next wave

\`toolCognifyStatus\` touches the package-local \`pipelineRuns sync.Map\` singleton shared between HTTP cognify handler and MCP. Needs a decoupling step (likely move the registry to a small shared package or pass it through Deps) before it can migrate cleanly. Deferred in favor of simpler wins next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)