### PR TITLE
refactor(mcp): F-4 wave 3d — toolAdd moves behind Deps

### DIFF
--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -31,7 +31,6 @@ import (
 	"github.com/stek0v/cognevra/pkg/extract"
 	"github.com/stek0v/cognevra/pkg/git"
 	"github.com/stek0v/cognevra/pkg/graphrank"
-	"github.com/stek0v/cognevra/pkg/ingest"
 	"github.com/stek0v/cognevra/pkg/mcp"
 	"github.com/stek0v/cognevra/pkg/orchestrator"
 	"github.com/stek0v/cognevra/pkg/rerank"
@@ -108,6 +107,11 @@ func (h *mcpHandler) ListCollections() []string {
 	}
 	return h.cfg.Collections.List()
 }
+
+// StoragePath implements mcp.Deps: returns the on-disk directory for
+// ingested files. Empty string is returned as-is; the tool layer
+// applies the legacy "data/uploads" default.
+func (h *mcpHandler) StoragePath() string { return h.cfg.StoragePath }
 
 // getOrValidateSession returns the session for the given ID, or nil if invalid.
 func (h *mcpHandler) getOrValidateSession(sessionID string) *mcpSession {
@@ -747,56 +751,10 @@ func (h *mcpHandler) toolCognifyStatus(args map[string]any) mcpToolResult {
 	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(out)}}}
 }
 
+// toolAdd is a thin shim over mcp.ToolAdd. F-4 wave 3d moved the body
+// into pkg/mcp; the ingest + metadata-write orchestration lives there.
 func (h *mcpHandler) toolAdd(ctx context.Context, args map[string]any) mcpToolResult {
-	data, _ := args["data"].(string)
-	if data == "" {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: 'data' required"}}, IsError: true}
-	}
-
-	datasetName, _ := args["dataset_name"].(string)
-	if datasetName == "" {
-		datasetName = "default"
-	}
-
-	// Ingest data to disk via pkg/ingest
-	storagePath := h.cfg.StoragePath
-	if storagePath == "" {
-		storagePath = "data/uploads"
-	}
-
-	ownerID := "" // MCP tools run without user context for now
-
-	// Optional metadata: tags + room
-	var tags []string
-	if rawTags, ok := args["tags"].([]any); ok {
-		for _, t := range rawTags {
-			if s, ok := t.(string); ok && s != "" {
-				tags = append(tags, s)
-			}
-		}
-	}
-	room, _ := args["room"].(string)
-
-	items := []ingest.Item{{Text: data, DatasetName: datasetName, OwnerID: ownerID, Tags: tags, Room: room}}
-	results, err := ingest.Ingest(items, storagePath)
-	if err != nil {
-		return mcpToolResult{
-			Content: []mcpContent{{Type: "text", Text: fmt.Sprintf("Ingest error: %s", err.Error())}},
-			IsError: true,
-		}
-	}
-
-	// Write metadata to DB
-	dsID := uuid.New().String()
-	if h.cfg.DB != nil {
-		mw := ingest.NewMetadataWriterFromDB(h.cfg.DB)
-		mw.WriteMetadata(context.Background(), results, ownerID, dsID, datasetName)
-	}
-
-	return mcpToolResult{Content: []mcpContent{{
-		Type: "text",
-		Text: fmt.Sprintf("Data ingested into dataset '%s' (dataset_id: %s, items: %d). Use 'cognify' tool to build knowledge graph.", datasetName, dsID, len(results)),
-	}}}
+	return mcp.ToolAdd(ctx, h, args)
 }
 
 // ── Git Commit Analyzer handlers ──

--- a/Levara/pkg/mcp/deps.go
+++ b/Levara/pkg/mcp/deps.go
@@ -6,6 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/google/uuid"
+	"github.com/stek0v/cognevra/pkg/ingest"
 )
 
 // Deps is the narrow application-state surface that MCP tool
@@ -18,6 +21,7 @@ import (
 //   - wave 3a: DB + Q (toolDelete)
 //   - wave 3b: no growth (toolPrune reused DB)
 //   - wave 3c: + HasCollections + ListCollections (toolListData)
+//   - wave 3d: + StoragePath (toolAdd)
 type Deps interface {
 	// DB returns the shared *sql.DB used for palace / datasets / graph
 	// tables. May be nil when no PostgresDSN is configured — tool
@@ -37,6 +41,10 @@ type Deps interface {
 	// nil when HasCollections() is false. The slice is safe to iterate
 	// but must not be mutated.
 	ListCollections() []string
+	// StoragePath returns the on-disk directory where ingested files
+	// are written. An empty string is treated as the legacy default
+	// "data/uploads" by tools that need a path.
+	StoragePath() string
 }
 
 // ToolDelete deletes a dataset row by id.
@@ -205,4 +213,87 @@ func listDataUnfiltered(ctx context.Context, db *sql.DB, rewrite func(string) st
 		out = append(out, map[string]any{"id": id, "name": name, "type": "dataset"})
 	}
 	return out
+}
+
+// defaultStoragePath is used when Deps.StoragePath() returns empty.
+// Matches the pre-refactor fallback in internal/http.
+const defaultStoragePath = "data/uploads"
+
+// mcpToolAddOwnerID is the owner ID stamped on records produced by the
+// MCP add tool. Empty today because MCP tool calls run without user
+// context; callers that need attribution should use the HTTP /add
+// endpoint which reads the authenticated user from the JWT.
+const mcpToolAddOwnerID = ""
+
+// ToolAdd ingests raw text into a named dataset.
+//
+// Two side effects in order:
+//  1. ingest.Ingest writes the raw bytes to disk under Deps.StoragePath
+//     and returns Result rows with hashes + file paths.
+//  2. When Deps.DB() is configured, ingest.MetadataWriter commits a
+//     transaction inserting the dataset row (if new) and one data +
+//     dataset_data link per result.
+//
+// DB metadata failures are silently swallowed to match pre-refactor
+// behavior — the filesystem ingest is the authoritative side effect.
+// Ingest failures, however, surface as IsError results because they
+// indicate the data was not persisted at all.
+func ToolAdd(ctx context.Context, deps Deps, args map[string]any) ToolResult {
+	data, _ := args["data"].(string)
+	if data == "" {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: 'data' required"}},
+			IsError: true,
+		}
+	}
+
+	datasetName, _ := args["dataset_name"].(string)
+	if datasetName == "" {
+		datasetName = "default"
+	}
+
+	storagePath := deps.StoragePath()
+	if storagePath == "" {
+		storagePath = defaultStoragePath
+	}
+
+	var tags []string
+	if rawTags, ok := args["tags"].([]any); ok {
+		for _, t := range rawTags {
+			if s, ok := t.(string); ok && s != "" {
+				tags = append(tags, s)
+			}
+		}
+	}
+	room, _ := args["room"].(string)
+
+	items := []ingest.Item{{
+		Text:        data,
+		DatasetName: datasetName,
+		OwnerID:     mcpToolAddOwnerID,
+		Tags:        tags,
+		Room:        room,
+	}}
+	results, err := ingest.Ingest(items, storagePath)
+	if err != nil {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: fmt.Sprintf("Ingest error: %s", err.Error())}},
+			IsError: true,
+		}
+	}
+
+	dsID := uuid.New().String()
+	if db := deps.DB(); db != nil {
+		mw := ingest.NewMetadataWriterFromDB(db)
+		// Pre-refactor used context.Background() here rather than the
+		// tool's ctx. Preserved for byte-for-byte parity — the metadata
+		// write must not be cancelled if the MCP client disconnects
+		// mid-call, since the filesystem side has already committed.
+		mw.WriteMetadata(context.Background(), results, mcpToolAddOwnerID, dsID, datasetName)
+	}
+
+	return ToolResult{Content: []Content{{
+		Type: "text",
+		Text: fmt.Sprintf("Data ingested into dataset '%s' (dataset_id: %s, items: %d). Use 'cognify' tool to build knowledge graph.", datasetName, dsID, len(results)),
+	}}}
 }

--- a/Levara/pkg/mcp/deps_test.go
+++ b/Levara/pkg/mcp/deps_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	_ "github.com/ncruces/go-sqlite3/driver"
+	"github.com/stek0v/cognevra/pkg/ingest"
 )
 
 // fakeDeps is the minimum Deps implementation for unit-testing tool
@@ -21,6 +22,7 @@ type fakeDeps struct {
 	db          *sql.DB
 	collections []string // nil → HasCollections() false (not configured)
 	hasColls    bool     // explicit flag so empty-but-configured is possible
+	storagePath string   // empty → tool applies its own default
 }
 
 func (f *fakeDeps) DB() *sql.DB { return f.db }
@@ -33,17 +35,19 @@ func (f *fakeDeps) Q(query string) string {
 	return pgPlaceholderRe.ReplaceAllString(query, "?")
 }
 
-func (f *fakeDeps) HasCollections() bool     { return f.hasColls }
+func (f *fakeDeps) HasCollections() bool      { return f.hasColls }
 func (f *fakeDeps) ListCollections() []string { return f.collections }
+func (f *fakeDeps) StoragePath() string        { return f.storagePath }
 
 // nilDBDeps returns nil for DB() — exercises the guard branch.
 // HasCollections defaults to false, matching an unconfigured deployment.
 type nilDBDeps struct{}
 
-func (nilDBDeps) DB() *sql.DB              { return nil }
-func (nilDBDeps) Q(q string) string        { return q }
-func (nilDBDeps) HasCollections() bool     { return false }
+func (nilDBDeps) DB() *sql.DB               { return nil }
+func (nilDBDeps) Q(q string) string         { return q }
+func (nilDBDeps) HasCollections() bool      { return false }
 func (nilDBDeps) ListCollections() []string { return nil }
+func (nilDBDeps) StoragePath() string        { return "" }
 
 func setupDepsTestDB(t *testing.T) *fakeDeps {
 	t.Helper()
@@ -456,6 +460,215 @@ func TestToolListData_EmptyTagStringsIgnored(t *testing.T) {
 	// Should match unfiltered output: 1 collection + 2 datasets = 3.
 	if len(items) != 3 {
 		t.Fatalf("got %d items with empty-tag filter, want 3 (same as unfiltered)", len(items))
+	}
+}
+
+// setupAddTestDB builds the full schema ingest.MetadataWriter writes
+// to. Returns a fake Deps with the DB plus a tempdir StoragePath so the
+// ingest side can actually write files.
+func setupAddTestDB(t *testing.T) *fakeDeps {
+	t.Helper()
+	f, _ := os.CreateTemp("", "mcp-add-test-*.db")
+	path := f.Name()
+	f.Close()
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(path)
+	})
+
+	// Flip pkg/ingest into SQLite mode so its $N placeholders and NOW()
+	// calls get rewritten. Reset on cleanup — other tests may run in
+	// Postgres mode.
+	ingest.SetSQLiteMode(true)
+	t.Cleanup(func() { ingest.SetSQLiteMode(false) })
+
+	// Schema must carry every column MetadataWriter references. Extra
+	// columns (e.g. content_hash, raw_content_hash) matter because the
+	// ON CONFLICT DO UPDATE clause reads EXCLUDED.* on conflict.
+	stmts := []string{
+		`CREATE TABLE datasets (
+			id TEXT PRIMARY KEY, name TEXT, owner_id TEXT,
+			created_at TEXT, updated_at TEXT
+		)`,
+		`CREATE TABLE data (
+			id TEXT PRIMARY KEY, name TEXT, extension TEXT, mime_type TEXT,
+			raw_data_location TEXT, original_data_location TEXT,
+			content_hash TEXT, raw_content_hash TEXT, owner_id TEXT,
+			loader_engine TEXT, pipeline_status TEXT, tags TEXT, room TEXT,
+			token_count INTEGER, data_size INTEGER,
+			created_at TEXT, updated_at TEXT
+		)`,
+		`CREATE TABLE dataset_data (dataset_id TEXT, data_id TEXT, PRIMARY KEY (dataset_id, data_id))`,
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+	}
+
+	return &fakeDeps{
+		db:          db,
+		storagePath: t.TempDir(),
+		hasColls:    true, // not strictly needed for ToolAdd, but consistent
+	}
+}
+
+func TestToolAdd_MissingDataIsError(t *testing.T) {
+	// 'data' is required; no 'data' key or an empty string → IsError.
+	// Must not touch the filesystem either — exit before any ingest call.
+	deps := &fakeDeps{storagePath: t.TempDir()}
+
+	got := ToolAdd(context.Background(), deps, map[string]any{})
+	if !got.IsError {
+		t.Fatalf("IsError = false, want true for missing data")
+	}
+	if len(got.Content) == 0 || !strings.Contains(got.Content[0].Text, "'data' required") {
+		t.Fatalf("content = %+v, want error mentioning 'data' required", got.Content)
+	}
+
+	got = ToolAdd(context.Background(), deps, map[string]any{"data": ""})
+	if !got.IsError {
+		t.Fatalf("empty data: IsError = false, want true")
+	}
+}
+
+func TestToolAdd_WrongTypeDataIsError(t *testing.T) {
+	// Non-string 'data' (e.g. JSON number) → treated as empty → error.
+	deps := &fakeDeps{storagePath: t.TempDir()}
+
+	got := ToolAdd(context.Background(), deps, map[string]any{"data": 42})
+	if !got.IsError {
+		t.Fatalf("int data: IsError = false, want true")
+	}
+}
+
+func TestToolAdd_IngestSucceedsWithNilDB(t *testing.T) {
+	// Nil DB path: ingest writes to disk, metadata phase is skipped,
+	// success message mentions the dataset name and item count.
+	deps := &fakeDeps{storagePath: t.TempDir()}
+
+	got := ToolAdd(context.Background(), deps, map[string]any{
+		"data":         "hello world",
+		"dataset_name": "notes",
+	})
+
+	if got.IsError {
+		t.Fatalf("IsError = true, want false; content=%+v", got.Content)
+	}
+	if len(got.Content) == 0 {
+		t.Fatalf("empty content")
+	}
+	text := got.Content[0].Text
+	if !strings.Contains(text, "dataset 'notes'") {
+		t.Errorf("content = %q, want dataset name 'notes'", text)
+	}
+	if !strings.Contains(text, "items: 1") {
+		t.Errorf("content = %q, want 'items: 1'", text)
+	}
+	if !strings.Contains(text, "dataset_id:") {
+		t.Errorf("content = %q, want dataset_id to be mentioned", text)
+	}
+}
+
+func TestToolAdd_DefaultDatasetName(t *testing.T) {
+	// When 'dataset_name' is missing, the tool substitutes 'default'.
+	// Verified via the success message, which embeds the name.
+	deps := &fakeDeps{storagePath: t.TempDir()}
+
+	got := ToolAdd(context.Background(), deps, map[string]any{"data": "x"})
+	if got.IsError {
+		t.Fatalf("IsError = true, want false")
+	}
+	if !strings.Contains(got.Content[0].Text, "dataset 'default'") {
+		t.Errorf("content = %q, want dataset 'default'", got.Content[0].Text)
+	}
+}
+
+func TestToolAdd_MetadataWriteCommitsToDB(t *testing.T) {
+	// End-to-end happy path: a configured DB means ToolAdd must write
+	// both a datasets row (matching dataset_name) and a data row
+	// (matching the ingest hash).
+	deps := setupAddTestDB(t)
+
+	got := ToolAdd(context.Background(), deps, map[string]any{
+		"data":         "integration-test payload",
+		"dataset_name": "intg",
+		"room":         "testroom",
+		"tags":         []any{"smoke"},
+	})
+
+	if got.IsError {
+		t.Fatalf("IsError = true, want false; content=%+v", got.Content)
+	}
+
+	var datasetName string
+	if err := deps.db.QueryRow("SELECT name FROM datasets WHERE name = 'intg'").Scan(&datasetName); err != nil {
+		t.Fatalf("dataset row not found: %v", err)
+	}
+
+	var dataCount int
+	if err := deps.db.QueryRow("SELECT COUNT(*) FROM data").Scan(&dataCount); err != nil {
+		t.Fatalf("count data: %v", err)
+	}
+	if dataCount != 1 {
+		t.Fatalf("data count = %d, want 1", dataCount)
+	}
+
+	var linkCount int
+	if err := deps.db.QueryRow("SELECT COUNT(*) FROM dataset_data").Scan(&linkCount); err != nil {
+		t.Fatalf("count dataset_data: %v", err)
+	}
+	if linkCount != 1 {
+		t.Errorf("dataset_data link count = %d, want 1", linkCount)
+	}
+
+	// Tags stored as JSON list in the text column.
+	var tagsText string
+	if err := deps.db.QueryRow("SELECT tags FROM data").Scan(&tagsText); err != nil {
+		t.Fatalf("select tags: %v", err)
+	}
+	if !strings.Contains(tagsText, "smoke") {
+		t.Errorf("tags = %q, want to contain 'smoke'", tagsText)
+	}
+}
+
+func TestToolAdd_MetadataErrorIsSwallowed(t *testing.T) {
+	// Partial schema (no data table) → MetadataWriter returns an error
+	// deep inside the transaction. The tool must still return success
+	// because the filesystem ingest has already committed — this locks
+	// in the pre-refactor "DB write is best-effort" contract.
+	f, _ := os.CreateTemp("", "mcp-add-brokendb-*.db")
+	path := f.Name()
+	f.Close()
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(path)
+	})
+
+	ingest.SetSQLiteMode(true)
+	t.Cleanup(func() { ingest.SetSQLiteMode(false) })
+
+	// Only datasets exists; data + dataset_data missing so the inner
+	// INSERT fails.
+	if _, err := db.Exec(`CREATE TABLE datasets (id TEXT, name TEXT, owner_id TEXT, created_at TEXT, updated_at TEXT)`); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	deps := &fakeDeps{db: db, storagePath: t.TempDir()}
+
+	got := ToolAdd(context.Background(), deps, map[string]any{"data": "x"})
+	if got.IsError {
+		t.Errorf("IsError = true, want false (metadata failure should be swallowed); content=%+v", got.Content)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fourth tool body moved into \`pkg/mcp\`. First wave with a non-DB external side effect — \`toolAdd\` writes to disk via \`pkg/ingest\`.
- Deps grows by one narrow method: \`StoragePath() string\`. Still 5 total methods serving 4 migrated tools.
- \`pkg/mcp\` gains imports of \`pkg/ingest\` (leaf package, no cycle risk) and \`google/uuid\`. Neither leaks into the \`Deps\` interface — type-cleanliness preserved.

## Changes

- \`pkg/mcp/deps.go\`:
  - \`Deps\` gains \`StoragePath()\`.
  - \`defaultStoragePath\` constant lifts the \"data/uploads\" fallback.
  - \`mcpToolAddOwnerID\` named constant documents why the MCP ingest owner is empty (HTTP /add uses the JWT; MCP tool calls currently run without user context).
  - \`ToolAdd\` orchestrates ingest + metadata write. Metadata uses \`context.Background()\` deliberately so it isn't cancelled mid-commit if the MCP client disconnects — preserves pre-refactor behavior.
  - Ingest errors → \`IsError\` (no data persisted). Metadata errors → swallowed (filesystem side already committed).
- \`pkg/mcp/deps_test.go\`: 6 new tests — missing data, wrong-type data, nil-DB happy path, default dataset_name, full DB commit (datasets + data + dataset_data + tags), partial-schema metadata failure is swallowed.
- \`internal/http/mcp.go\`: \`*mcpHandler\` gains \`StoragePath\`; \`toolAdd\` collapses to a one-line shim; dropped the now-unused \`pkg/ingest\` import.

## Contract preservation

- Same error strings (\"Error: 'data' required\", \"Ingest error: ...\").
- Same success message format with dataset name, dataset_id, and item count.
- Same \"best-effort metadata\" contract: DB failures don't surface as tool errors.
- Same \`context.Background()\` choice for the metadata write.
- Default dataset_name \"default\" unchanged.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test -race -count=1 ./pkg/mcp/\` — 6 new ToolAdd tests + all prior
- [x] \`go test -race -count=1 ./...\` — 34 PASS / 0 FAIL

## Deps surface after 4 tool migrations

| Method | Wave | Used by |
|---|---|---|
| \`DB() *sql.DB\` | 3a | Delete, Prune, ListData, Add |
| \`Q(string) string\` | 3a | Delete, ListData |
| \`HasCollections() bool\` | 3c | ListData |
| \`ListCollections() []string\` | 3c | ListData |
| \`StoragePath() string\` | 3d | Add |

5 methods serving 4 tools — 1.25 methods per tool on average, and most methods are reused.

## Next wave

3e candidates: \`toolAddFeedback\`, \`toolGetFeedbackStats\`, \`toolSetContext\` (all small, mostly DB, no new methods likely). Could bundle. After that, the memory (palace) tools: \`toolSaveMemory\`, \`toolRecallMemory\`, \`toolListMemories\` — these all use \`ValidateHall\` which is already in pkg/mcp, plus DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)