### PR TITLE
refactor(mcp): F-4 wave 3e — feedback + setContext bundle

### DIFF
--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -113,6 +113,13 @@ func (h *mcpHandler) ListCollections() []string {
 // applies the legacy "data/uploads" default.
 func (h *mcpHandler) StoragePath() string { return h.cfg.StoragePath }
 
+// CollectionExists implements mcp.Deps: true iff a collection with
+// the given name is registered in the CollectionManager. Always false
+// when no manager is configured.
+func (h *mcpHandler) CollectionExists(name string) bool {
+	return h.cfg.Collections != nil && h.cfg.Collections.Has(name)
+}
+
 // getOrValidateSession returns the session for the given ID, or nil if invalid.
 func (h *mcpHandler) getOrValidateSession(sessionID string) *mcpSession {
 	return h.sessions.Get(sessionID)
@@ -1261,12 +1268,10 @@ func (h *mcpHandler) toolSearchChats(ctx context.Context, args map[string]any) m
 }
 
 // truncate cuts a string to maxLen and adds "..." if truncated.
-func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen-3] + "..."
-}
+// truncate is a shim over mcp.Truncate kept so the surviving in-http
+// tool bodies (analyzeCommits, saveMemory, crossSearch, ...) don't need
+// to be edited in this wave. Removed once those tools migrate too.
+func truncate(s string, maxLen int) string { return mcp.Truncate(s, maxLen) }
 
 // ── MCP Resources API ──────────────────────────────────────────────────────
 
@@ -1495,85 +1500,18 @@ func (h *mcpHandler) toolCodify(ctx context.Context, args map[string]any) mcpToo
 	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(out)}}}
 }
 
+// toolAddFeedback / toolGetFeedbackStats / toolSetContext are thin
+// shims over their pkg/mcp counterparts. F-4 wave 3e moved the bodies.
 func (h *mcpHandler) toolAddFeedback(ctx context.Context, args map[string]any) mcpToolResult {
-	query, _ := args["query"].(string)
-	if query == "" {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: 'query' required"}}, IsError: true}
-	}
-	rating := 0
-	if r, ok := args["rating"].(float64); ok {
-		rating = int(r)
-	}
-	if rating < 1 || rating > 5 {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: 'rating' must be 1-5"}}, IsError: true}
-	}
-	if h.cfg.DB == nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: database not configured"}}, IsError: true}
-	}
-
-	resultID, _ := args["result_id"].(string)
-	collection, _ := args["collection"].(string)
-	searchType, _ := args["search_type"].(string)
-	comment, _ := args["comment"].(string)
-	userID := ""
-	if uid, ok := ctx.Value(mcpUserIDKey).(string); ok {
-		userID = uid
-	}
-
-	id := uuid.New().String()
-	h.cfg.DB.ExecContext(ctx,
-		Q(`INSERT INTO search_feedback (id, query, result_id, collection, search_type, rating, comment, user_id)
-		   VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`),
-		id, query, resultID, collection, searchType, rating, comment, userID)
-
-	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: fmt.Sprintf("Feedback saved: rating=%d for query '%s'", rating, truncate(query, 50))}}}
+	return mcp.ToolAddFeedback(ctx, h, args)
 }
 
 func (h *mcpHandler) toolGetFeedbackStats(ctx context.Context, args map[string]any) mcpToolResult {
-	if h.cfg.DB == nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: `{"total":0}`}}}
-	}
-	collection, _ := args["collection"].(string)
-
-	var total int
-	var avgRating float64
-	var worstQuery string
-
-	if collection != "" {
-		h.cfg.DB.QueryRowContext(ctx,
-			Q(`SELECT COUNT(*), COALESCE(AVG(rating),0) FROM search_feedback WHERE collection = $1`), collection).Scan(&total, &avgRating)
-		h.cfg.DB.QueryRowContext(ctx,
-			Q(`SELECT COALESCE(query,'') FROM search_feedback WHERE collection = $1 ORDER BY rating ASC LIMIT 1`), collection).Scan(&worstQuery)
-	} else {
-		h.cfg.DB.QueryRowContext(ctx,
-			Q(`SELECT COUNT(*), COALESCE(AVG(rating),0) FROM search_feedback`)).Scan(&total, &avgRating)
-		h.cfg.DB.QueryRowContext(ctx,
-			Q(`SELECT COALESCE(query,'') FROM search_feedback ORDER BY rating ASC LIMIT 1`)).Scan(&worstQuery)
-	}
-
-	out, _ := json.MarshalIndent(map[string]any{
-		"total": total, "avg_rating": avgRating, "worst_query": worstQuery, "collection": collection,
-	}, "", "  ")
-	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(out)}}}
+	return mcp.ToolGetFeedbackStats(ctx, h, args)
 }
 
 func (h *mcpHandler) toolSetContext(sess *mcpSession, args map[string]any) mcpToolResult {
-	collection, _ := args["collection"].(string)
-	if collection == "" {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: 'collection' required"}}, IsError: true}
-	}
-	if sess == nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: no active session (send initialize first)"}}, IsError: true}
-	}
-	// Validate collection exists (or allow setting for future use)
-	exists := h.cfg.Collections != nil && h.cfg.Collections.Has(collection)
-	sess.DefaultCollection = collection
-
-	status := "set"
-	if !exists {
-		status = "set (collection not yet created — will be used when data is added)"
-	}
-	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: fmt.Sprintf("Context %s: default collection = '%s'", status, collection)}}}
+	return mcp.ToolSetContext(sess, h, args)
 }
 
 var sensitiveKeyPatterns = []string{"api_key", "apikey", "password", "passwd", "secret", "token", "credential", "private_key"}

--- a/Levara/pkg/mcp/deps.go
+++ b/Levara/pkg/mcp/deps.go
@@ -22,6 +22,7 @@ import (
 //   - wave 3b: no growth (toolPrune reused DB)
 //   - wave 3c: + HasCollections + ListCollections (toolListData)
 //   - wave 3d: + StoragePath (toolAdd)
+//   - wave 3e: + CollectionExists (toolSetContext)
 type Deps interface {
 	// DB returns the shared *sql.DB used for palace / datasets / graph
 	// tables. May be nil when no PostgresDSN is configured — tool
@@ -45,6 +46,12 @@ type Deps interface {
 	// are written. An empty string is treated as the legacy default
 	// "data/uploads" by tools that need a path.
 	StoragePath() string
+	// CollectionExists reports whether a collection with the given name
+	// is registered. Always false when HasCollections() is false.
+	// Callers use this for soft validation — unknown names are still
+	// allowed through ToolSetContext on the "will be created when data
+	// is added" promise.
+	CollectionExists(name string) bool
 }
 
 // ToolDelete deletes a dataset row by id.
@@ -295,5 +302,141 @@ func ToolAdd(ctx context.Context, deps Deps, args map[string]any) ToolResult {
 	return ToolResult{Content: []Content{{
 		Type: "text",
 		Text: fmt.Sprintf("Data ingested into dataset '%s' (dataset_id: %s, items: %d). Use 'cognify' tool to build knowledge graph.", datasetName, dsID, len(results)),
+	}}}
+}
+
+// feedbackQueryLogMaxLen caps how much of the query text we echo back in
+// ToolAddFeedback's success message. The DB row still carries the full
+// query; this limit only affects the human-readable response.
+const feedbackQueryLogMaxLen = 50
+
+// ToolAddFeedback records user feedback on a search result.
+//
+// Validation: query required, rating must be 1..5, DB must be configured
+// (unlike other tools, feedback has no useful degraded mode — if the
+// feedback table can't be written, the caller should know).
+//
+// The SQL insert is fire-and-forget: error return from ExecContext is
+// ignored to match pre-refactor behavior, since the duplicate-id
+// collision can be a benign retry.
+func ToolAddFeedback(ctx context.Context, deps Deps, args map[string]any) ToolResult {
+	query, _ := args["query"].(string)
+	if query == "" {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: 'query' required"}},
+			IsError: true,
+		}
+	}
+	rating := 0
+	if r, ok := args["rating"].(float64); ok {
+		rating = int(r)
+	}
+	if rating < 1 || rating > 5 {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: 'rating' must be 1-5"}},
+			IsError: true,
+		}
+	}
+	db := deps.DB()
+	if db == nil {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: database not configured"}},
+			IsError: true,
+		}
+	}
+
+	resultID, _ := args["result_id"].(string)
+	collection, _ := args["collection"].(string)
+	searchType, _ := args["search_type"].(string)
+	comment, _ := args["comment"].(string)
+	userID := ""
+	if uid, ok := ctx.Value(UserIDKey).(string); ok {
+		userID = uid
+	}
+
+	id := uuid.New().String()
+	db.ExecContext(ctx, deps.Q(`
+		INSERT INTO search_feedback (id, query, result_id, collection, search_type, rating, comment, user_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`), id, query, resultID, collection, searchType, rating, comment, userID)
+
+	return ToolResult{Content: []Content{{
+		Type: "text",
+		Text: fmt.Sprintf("Feedback saved: rating=%d for query '%s'", rating, Truncate(query, feedbackQueryLogMaxLen)),
+	}}}
+}
+
+// ToolGetFeedbackStats aggregates the search_feedback table.
+//
+// Optional "collection" filter scopes to one collection. Nil DB is not
+// an error here — returns {"total":0} to match pre-refactor behavior
+// (some deployments have MCP without feedback logging).
+func ToolGetFeedbackStats(ctx context.Context, deps Deps, args map[string]any) ToolResult {
+	db := deps.DB()
+	if db == nil {
+		return ToolResult{Content: []Content{{Type: "text", Text: `{"total":0}`}}}
+	}
+	collection, _ := args["collection"].(string)
+
+	var total int
+	var avgRating float64
+	var worstQuery string
+
+	if collection != "" {
+		db.QueryRowContext(ctx,
+			deps.Q(`SELECT COUNT(*), COALESCE(AVG(rating),0) FROM search_feedback WHERE collection = $1`),
+			collection).Scan(&total, &avgRating)
+		db.QueryRowContext(ctx,
+			deps.Q(`SELECT COALESCE(query,'') FROM search_feedback WHERE collection = $1 ORDER BY rating ASC LIMIT 1`),
+			collection).Scan(&worstQuery)
+	} else {
+		db.QueryRowContext(ctx,
+			deps.Q(`SELECT COUNT(*), COALESCE(AVG(rating),0) FROM search_feedback`)).Scan(&total, &avgRating)
+		db.QueryRowContext(ctx,
+			deps.Q(`SELECT COALESCE(query,'') FROM search_feedback ORDER BY rating ASC LIMIT 1`)).Scan(&worstQuery)
+	}
+
+	out, _ := json.MarshalIndent(map[string]any{
+		"total":       total,
+		"avg_rating":  avgRating,
+		"worst_query": worstQuery,
+		"collection":  collection,
+	}, "", "  ")
+	return ToolResult{Content: []Content{{Type: "text", Text: string(out)}}}
+}
+
+// ToolSetContext binds a default collection to the caller's session.
+// Subsequent tool calls that omit the "collection" argument will use
+// this default (see ResolveCollection).
+//
+// Unknown collection names are accepted with a "will be created when
+// data is added" note — this lets clients pre-set a context before the
+// first write. A nil session is treated as a client error (initialize
+// was skipped).
+func ToolSetContext(sess *Session, deps Deps, args map[string]any) ToolResult {
+	collection, _ := args["collection"].(string)
+	if collection == "" {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: 'collection' required"}},
+			IsError: true,
+		}
+	}
+	if sess == nil {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: no active session (send initialize first)"}},
+			IsError: true,
+		}
+	}
+
+	exists := deps.CollectionExists(collection)
+	sess.DefaultCollection = collection
+
+	status := "set"
+	if !exists {
+		status = "set (collection not yet created — will be used when data is added)"
+	}
+	return ToolResult{Content: []Content{{
+		Type: "text",
+		Text: fmt.Sprintf("Context %s: default collection = '%s'", status, collection),
 	}}}
 }

--- a/Levara/pkg/mcp/deps_test.go
+++ b/Levara/pkg/mcp/deps_test.go
@@ -37,17 +37,30 @@ func (f *fakeDeps) Q(query string) string {
 
 func (f *fakeDeps) HasCollections() bool      { return f.hasColls }
 func (f *fakeDeps) ListCollections() []string { return f.collections }
-func (f *fakeDeps) StoragePath() string        { return f.storagePath }
+func (f *fakeDeps) StoragePath() string       { return f.storagePath }
+
+func (f *fakeDeps) CollectionExists(name string) bool {
+	if !f.hasColls {
+		return false
+	}
+	for _, c := range f.collections {
+		if c == name {
+			return true
+		}
+	}
+	return false
+}
 
 // nilDBDeps returns nil for DB() — exercises the guard branch.
 // HasCollections defaults to false, matching an unconfigured deployment.
 type nilDBDeps struct{}
 
-func (nilDBDeps) DB() *sql.DB               { return nil }
-func (nilDBDeps) Q(q string) string         { return q }
-func (nilDBDeps) HasCollections() bool      { return false }
-func (nilDBDeps) ListCollections() []string { return nil }
-func (nilDBDeps) StoragePath() string        { return "" }
+func (nilDBDeps) DB() *sql.DB                    { return nil }
+func (nilDBDeps) Q(q string) string              { return q }
+func (nilDBDeps) HasCollections() bool           { return false }
+func (nilDBDeps) ListCollections() []string      { return nil }
+func (nilDBDeps) StoragePath() string            { return "" }
+func (nilDBDeps) CollectionExists(string) bool   { return false }
 
 func setupDepsTestDB(t *testing.T) *fakeDeps {
 	t.Helper()
@@ -690,5 +703,262 @@ func TestToolListData_CollectionsConfiguredButEmpty(t *testing.T) {
 		if it["type"] != "dataset" {
 			t.Errorf("item type = %v, want dataset", it["type"])
 		}
+	}
+}
+
+// setupFeedbackTestDB builds the search_feedback schema. Columns match
+// the real production schema's shape; only the ones ToolAddFeedback
+// writes and ToolGetFeedbackStats reads matter for these tests.
+func setupFeedbackTestDB(t *testing.T) *fakeDeps {
+	t.Helper()
+	f, _ := os.CreateTemp("", "mcp-feedback-test-*.db")
+	path := f.Name()
+	f.Close()
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(path)
+	})
+
+	stmt := `CREATE TABLE search_feedback (
+		id TEXT PRIMARY KEY, query TEXT, result_id TEXT, collection TEXT,
+		search_type TEXT, rating INTEGER, comment TEXT, user_id TEXT
+	)`
+	if _, err := db.Exec(stmt); err != nil {
+		t.Fatalf("create search_feedback: %v", err)
+	}
+	return &fakeDeps{db: db}
+}
+
+func TestToolAddFeedback_MissingQueryIsError(t *testing.T) {
+	// 'query' is required — missing or empty → IsError with specific message.
+	deps := setupFeedbackTestDB(t)
+
+	got := ToolAddFeedback(context.Background(), deps, map[string]any{"rating": float64(3)})
+	if !got.IsError {
+		t.Fatalf("missing query: IsError = false, want true")
+	}
+	if !strings.Contains(got.Content[0].Text, "'query' required") {
+		t.Errorf("content = %q, want error mentioning 'query' required", got.Content[0].Text)
+	}
+}
+
+func TestToolAddFeedback_InvalidRatingRange(t *testing.T) {
+	// Rating must be 1..5 inclusive. Zero (missing / unparseable), negative,
+	// and >5 all reject with the same error.
+	deps := setupFeedbackTestDB(t)
+	bad := []any{nil, float64(0), float64(6), float64(-1), "three"}
+	for _, r := range bad {
+		args := map[string]any{"query": "q"}
+		if r != nil {
+			args["rating"] = r
+		}
+		got := ToolAddFeedback(context.Background(), deps, args)
+		if !got.IsError {
+			t.Errorf("rating=%v: IsError = false, want true", r)
+			continue
+		}
+		if !strings.Contains(got.Content[0].Text, "'rating' must be 1-5") {
+			t.Errorf("rating=%v: content = %q, want 1-5 error", r, got.Content[0].Text)
+		}
+	}
+}
+
+func TestToolAddFeedback_NilDBIsError(t *testing.T) {
+	// Unlike other tools, feedback treats a missing DB as a hard error —
+	// there's no useful degraded mode when the feedback table is
+	// unreachable.
+	got := ToolAddFeedback(context.Background(), nilDBDeps{}, map[string]any{
+		"query":  "q",
+		"rating": float64(3),
+	})
+	if !got.IsError {
+		t.Fatalf("nil DB: IsError = false, want true")
+	}
+	if !strings.Contains(got.Content[0].Text, "database not configured") {
+		t.Errorf("content = %q, want 'database not configured'", got.Content[0].Text)
+	}
+}
+
+func TestToolAddFeedback_HappyPathWritesRow(t *testing.T) {
+	// Valid input → row inserted, success message echoes rating + query
+	// (truncated for long queries).
+	deps := setupFeedbackTestDB(t)
+
+	got := ToolAddFeedback(context.Background(), deps, map[string]any{
+		"query":       "why is search slow",
+		"rating":      float64(4),
+		"result_id":   "res-1",
+		"collection":  "levara",
+		"search_type": "hybrid",
+		"comment":     "took 2s",
+	})
+	if got.IsError {
+		t.Fatalf("IsError = true, want false; content=%+v", got.Content)
+	}
+	if !strings.Contains(got.Content[0].Text, "rating=4") {
+		t.Errorf("content = %q, want 'rating=4'", got.Content[0].Text)
+	}
+
+	var count int
+	if err := deps.db.QueryRow("SELECT COUNT(*) FROM search_feedback WHERE rating = 4").Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("row count = %d, want 1", count)
+	}
+}
+
+func TestToolAddFeedback_LongQueryTruncatedInMessage(t *testing.T) {
+	// Messages echo the query text, truncated at feedbackQueryLogMaxLen.
+	// DB row still carries the full query (not asserted here — owned by
+	// pkg/ingest tests); we only verify the user-visible echo is bounded.
+	deps := setupFeedbackTestDB(t)
+
+	long := strings.Repeat("a", 200)
+	got := ToolAddFeedback(context.Background(), deps, map[string]any{
+		"query":  long,
+		"rating": float64(1),
+	})
+	if got.IsError {
+		t.Fatalf("IsError = true, want false")
+	}
+	if strings.Contains(got.Content[0].Text, long) {
+		t.Errorf("success message contains full 200-char query; expected Truncate to kick in")
+	}
+	if !strings.Contains(got.Content[0].Text, "...") {
+		t.Errorf("success message missing ellipsis; content = %q", got.Content[0].Text)
+	}
+}
+
+func TestToolGetFeedbackStats_NilDBReturnsZero(t *testing.T) {
+	// Absent DB → return a concrete `{"total":0}` payload, not an error.
+	// This matches pre-refactor behavior that lets feedback be optional
+	// in downstream clients.
+	got := ToolGetFeedbackStats(context.Background(), nilDBDeps{}, map[string]any{})
+	if got.IsError {
+		t.Fatalf("IsError = true, want false")
+	}
+	if got.Content[0].Text != `{"total":0}` {
+		t.Errorf("content = %q, want `{\"total\":0}`", got.Content[0].Text)
+	}
+}
+
+func TestToolGetFeedbackStats_AggregatesAll(t *testing.T) {
+	// Seed 3 feedback rows (ratings 1, 3, 5) → total=3, avg=3, worst
+	// query is the rating=1 row.
+	deps := setupFeedbackTestDB(t)
+	rows := []struct{ id, q string; r int }{
+		{"f1", "bad search", 1},
+		{"f2", "ok search", 3},
+		{"f3", "great search", 5},
+	}
+	for _, r := range rows {
+		deps.db.Exec("INSERT INTO search_feedback (id, query, rating, collection) VALUES (?,?,?,?)",
+			r.id, r.q, r.r, "levara")
+	}
+
+	res := ToolGetFeedbackStats(context.Background(), deps, map[string]any{})
+	if res.IsError {
+		t.Fatalf("IsError = true, want false")
+	}
+	var stats map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &stats); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if int(stats["total"].(float64)) != 3 {
+		t.Errorf("total = %v, want 3", stats["total"])
+	}
+	if stats["avg_rating"].(float64) != 3.0 {
+		t.Errorf("avg_rating = %v, want 3.0", stats["avg_rating"])
+	}
+	if stats["worst_query"] != "bad search" {
+		t.Errorf("worst_query = %v, want 'bad search'", stats["worst_query"])
+	}
+}
+
+func TestToolGetFeedbackStats_CollectionFilterScopes(t *testing.T) {
+	// With a "collection" filter, stats are scoped to that collection.
+	// Rows in other collections must not contribute.
+	deps := setupFeedbackTestDB(t)
+	deps.db.Exec("INSERT INTO search_feedback (id, query, rating, collection) VALUES ('a','x',5,'levara')")
+	deps.db.Exec("INSERT INTO search_feedback (id, query, rating, collection) VALUES ('b','y',1,'other')")
+
+	res := ToolGetFeedbackStats(context.Background(), deps, map[string]any{"collection": "levara"})
+	var stats map[string]any
+	json.Unmarshal([]byte(res.Content[0].Text), &stats)
+	if int(stats["total"].(float64)) != 1 {
+		t.Errorf("total = %v, want 1 (filtered)", stats["total"])
+	}
+	if stats["avg_rating"].(float64) != 5.0 {
+		t.Errorf("avg_rating = %v, want 5.0", stats["avg_rating"])
+	}
+}
+
+func TestToolSetContext_MissingCollectionIsError(t *testing.T) {
+	// 'collection' arg is required.
+	sess := &Session{}
+	got := ToolSetContext(sess, nilDBDeps{}, map[string]any{})
+	if !got.IsError {
+		t.Fatalf("missing collection: IsError = false, want true")
+	}
+	if !strings.Contains(got.Content[0].Text, "'collection' required") {
+		t.Errorf("content = %q, want error", got.Content[0].Text)
+	}
+	if sess.DefaultCollection != "" {
+		t.Errorf("DefaultCollection mutated to %q on error path", sess.DefaultCollection)
+	}
+}
+
+func TestToolSetContext_NilSessionIsError(t *testing.T) {
+	// No session → caller forgot to send initialize; return a specific
+	// error rather than panicking.
+	got := ToolSetContext(nil, nilDBDeps{}, map[string]any{"collection": "levara"})
+	if !got.IsError {
+		t.Fatalf("nil session: IsError = false, want true")
+	}
+	if !strings.Contains(got.Content[0].Text, "no active session") {
+		t.Errorf("content = %q, want session error", got.Content[0].Text)
+	}
+}
+
+func TestToolSetContext_ExistingCollection(t *testing.T) {
+	// Collection registered → session gets the default, message says "set".
+	sess := &Session{}
+	deps := &fakeDeps{hasColls: true, collections: []string{"levara", "other"}}
+
+	got := ToolSetContext(sess, deps, map[string]any{"collection": "levara"})
+	if got.IsError {
+		t.Fatalf("IsError = true, want false")
+	}
+	if sess.DefaultCollection != "levara" {
+		t.Errorf("DefaultCollection = %q, want levara", sess.DefaultCollection)
+	}
+	// "set" but NOT the "not yet created" tail.
+	if strings.Contains(got.Content[0].Text, "not yet created") {
+		t.Errorf("content = %q, should not mention 'not yet created' for existing coll", got.Content[0].Text)
+	}
+}
+
+func TestToolSetContext_UnknownCollectionIsAllowed(t *testing.T) {
+	// Unknown collection → session still updated, but message flags
+	// "will be created when data is added." This lets clients pre-set
+	// a context before the first write.
+	sess := &Session{}
+	deps := &fakeDeps{hasColls: true, collections: []string{"levara"}}
+
+	got := ToolSetContext(sess, deps, map[string]any{"collection": "new-coll"})
+	if got.IsError {
+		t.Fatalf("IsError = true, want false for unknown coll")
+	}
+	if sess.DefaultCollection != "new-coll" {
+		t.Errorf("DefaultCollection = %q, want new-coll (session updated even for unknown)", sess.DefaultCollection)
+	}
+	if !strings.Contains(got.Content[0].Text, "not yet created") {
+		t.Errorf("content = %q, want 'not yet created' warning", got.Content[0].Text)
 	}
 }

--- a/Levara/pkg/mcp/util.go
+++ b/Levara/pkg/mcp/util.go
@@ -29,3 +29,14 @@ const DiaryOwnerPrefix = "agent:"
 func DiaryOwner(agent string) string {
 	return DiaryOwnerPrefix + strings.TrimSpace(agent)
 }
+
+// Truncate shortens s to at most maxLen runes, replacing the tail with
+// "..." (3 bytes) when the cut happens. Used by tool implementations
+// to keep log/message echoes bounded. Operates on bytes, not runes —
+// acceptable for the short ASCII-heavy strings the tools emit.
+func Truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/Levara/pkg/mcp/util_test.go
+++ b/Levara/pkg/mcp/util_test.go
@@ -56,3 +56,28 @@ func TestDiaryOwnerPrefix_StableConst(t *testing.T) {
 		t.Errorf("DiaryOwnerPrefix changed to %q — external consumers may break", DiaryOwnerPrefix)
 	}
 }
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     string
+		maxLen int
+		want   string
+	}{
+		{"shorter returned as-is", "hello", 10, "hello"},
+		{"exact length returned as-is", "hello", 5, "hello"},
+		{"longer is truncated with ellipsis", "hello world", 8, "hello..."},
+		{"empty string stays empty", "", 5, ""},
+		// maxLen=3 is the degenerate case — result is just "..." (len 3),
+		// consistent with "the ellipsis replaces the last 3 chars of the
+		// kept prefix."
+		{"maxLen=3 yields just ellipsis for any input over 3 chars", "abcdef", 3, "..."},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Truncate(c.in, c.maxLen); got != c.want {
+				t.Errorf("Truncate(%q, %d) = %q, want %q", c.in, c.maxLen, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Three small tools migrated together — they share validator patterns (all mutate state, emit status messages) and share one new Deps method.

- \`toolAddFeedback\` — INSERT into search_feedback with validation (query required, rating 1..5, DB required).
- \`toolGetFeedbackStats\` — aggregate query over search_feedback, optional collection filter.
- \`toolSetContext\` — binds default collection to session; first tool to take \`*Session\` directly instead of via ctx.

Also promotes \`truncate\` → \`mcp.Truncate\` so tools in pkg/mcp can reuse it.

## New in Deps

\`CollectionExists(name string) bool\` — soft existence check for SetContext. Unknown names are still accepted (with a \"will be created when data is added\" warning) so clients can pre-set context before the first write.

## Changes

- \`pkg/mcp/util.go\`: \`Truncate\` exported + \`TestTruncate\` (5 cases).
- \`pkg/mcp/deps.go\`: \`CollectionExists\` on Deps; three new tool functions + \`feedbackQueryLogMaxLen\` constant.
- \`pkg/mcp/deps_test.go\`: 12 new tests — 5 for feedback (missing query, bad ratings, nil DB, happy path, truncate-in-echo), 3 for stats (nil DB \`{\"total\":0}\`, aggregate-all, collection filter), 4 for SetContext (missing coll, nil session, existing coll, unknown coll accepted with warning).
- \`internal/http/mcp.go\`: three shims + \`CollectionExists\` impl on \`*mcpHandler\`; \`truncate()\` becomes one line forwarding to \`mcp.Truncate\` (other in-http callers unchanged until later waves).

## Contract preservation

All three tools preserve pre-refactor behavior byte-for-byte:
- Same error strings (\"Error: 'query' required\", \"Error: 'rating' must be 1-5\", \"Error: database not configured\", \"Error: 'collection' required\", \"Error: no active session (send initialize first)\").
- Same success message formats (\"Feedback saved: rating=%d for query '%s'\", stats JSON keys, \"Context %s: default collection = '%s'\").
- Same nil-DB semantics per tool (hard error for AddFeedback, soft \`{\"total\":0}\` for stats, not-applicable for SetContext).
- Same fire-and-forget INSERT for AddFeedback (collision on id is a benign retry).

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test -race -count=1 ./pkg/mcp/\` — 12 new tool tests + Truncate test
- [x] \`go test -race -count=1 ./...\` — 34 PASS / 0 FAIL

## Deps surface after 3e

| Method | Waves | Used by |
|---|---|---|
| \`DB() *sql.DB\` | 3a | Delete, Prune, ListData, Add, AddFeedback, GetFeedbackStats |
| \`Q(string) string\` | 3a | Delete, ListData, AddFeedback, GetFeedbackStats |
| \`HasCollections() bool\` | 3c | ListData |
| \`ListCollections() []string\` | 3c | ListData |
| \`StoragePath() string\` | 3d | Add |
| \`CollectionExists(string) bool\` | 3e | SetContext |

6 methods serving 7 migrated tools. Growth ratio stays subunity.

## Next

3f — memory (palace) wave: \`toolSaveMemory\`, \`toolRecallMemory\`, \`toolListMemories\`, \`toolPinMemory\`, \`toolUnpinMemory\`, \`toolWakeUp\`. All use DB + \`ValidateHall\` (already in pkg/mcp). Good bundle candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)