### PR TITLE
refactor(mcp): F-4 wave 3f — memory palace quartet

### DIFF
--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -1069,71 +1069,9 @@ func (h *mcpHandler) toolRecallMemory(ctx context.Context, args map[string]any) 
 	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(out)}}}
 }
 
+// toolListMemories is a thin shim over mcp.ToolListMemories (F-4 wave 3f).
 func (h *mcpHandler) toolListMemories(ctx context.Context, args map[string]any) mcpToolResult {
-	if h.cfg.DB == nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "[]"}}}
-	}
-
-	filterType, _ := args["type"].(string)
-	collectionName, _ := args["collection"].(string)
-	room, _ := args["room"].(string)
-	hall, _ := args["hall"].(string)
-
-	var conds []string
-	var qargs []any
-	pos := 1
-	if filterType != "" {
-		conds = append(conds, fmt.Sprintf("type = $%d", pos))
-		qargs = append(qargs, filterType)
-		pos++
-	}
-	if collectionName != "" {
-		conds = append(conds, fmt.Sprintf("collection_name = $%d", pos))
-		qargs = append(qargs, collectionName)
-		pos++
-	}
-	if room != "" {
-		conds = append(conds, fmt.Sprintf("room = $%d", pos))
-		qargs = append(qargs, room)
-		pos++
-	}
-	if hall != "" {
-		conds = append(conds, fmt.Sprintf("hall = $%d", pos))
-		qargs = append(qargs, hall)
-		pos++
-	}
-	sqlStr := `SELECT id, key, value, type, owner_id, room, hall, is_pinned, pin_priority, created_at, updated_at FROM memories`
-	if len(conds) > 0 {
-		sqlStr += " WHERE " + strings.Join(conds, " AND ")
-	}
-	sqlStr += " ORDER BY updated_at DESC LIMIT 100"
-
-	rows, err := h.cfg.DB.QueryContext(ctx, Q(sqlStr), qargs...)
-	if err != nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "[]"}}}
-	}
-	defer rows.Close()
-
-	var results []map[string]any
-	for rows.Next() {
-		var id, key, value, typ, ownerID, rm, hl, ca, ua string
-		var pinned, prio int
-		if err := rows.Scan(&id, &key, &value, &typ, &ownerID, &rm, &hl, &pinned, &prio, &ca, &ua); err != nil {
-			continue
-		}
-		results = append(results, map[string]any{
-			"id": id, "key": key, "value": value, "type": typ,
-			"owner_id": ownerID, "room": rm, "hall": hl,
-			"is_pinned": pinned == 1, "pin_priority": prio,
-			"created_at": ca, "updated_at": ua,
-		})
-	}
-
-	if results == nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "[]"}}}
-	}
-	out, _ := json.MarshalIndent(results, "", "  ")
-	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(out)}}}
+	return mcp.ToolListMemories(ctx, h, args)
 }
 
 // ── Chat History handlers ──

--- a/Levara/internal/http/mcp_palace.go
+++ b/Levara/internal/http/mcp_palace.go
@@ -23,154 +23,20 @@ import (
 
 // ── wake_up ──
 
-// toolWakeUp returns a small bundle of critical context for session start:
-//   - all pinned memories in the requested collection (priority-ordered)
-//   - top-N currently-active graph entities (highest edge degree)
-// The result is capped at max_tokens (approximated as chars/4).
+// toolWakeUp is a thin shim over mcp.ToolWakeUp (F-4 wave 3f).
 func (h *mcpHandler) toolWakeUp(ctx context.Context, args map[string]any) mcpToolResult {
-	if h.cfg.DB == nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: database not configured"}}, IsError: true}
-	}
-	collectionName, _ := args["collection"].(string)
-	maxTokens := 200
-	if mt, ok := args["max_tokens"].(float64); ok && mt > 0 {
-		maxTokens = int(mt)
-	}
-	topEntities := 5
-	if te, ok := args["top_entities"].(float64); ok && te > 0 {
-		topEntities = int(te)
-	}
-	maxChars := maxTokens * 4
-
-	ownerID := ""
-	if uid, ok := ctx.Value(mcpUserIDKey).(string); ok {
-		ownerID = uid
-	}
-
-	// 1. Pinned memories — pin_priority DESC, updated_at DESC
-	var pinned []map[string]any
-	pinnedSQL := `SELECT key, value, hall, room, pin_priority FROM memories
-		WHERE is_pinned = 1 AND (owner_id = $1 OR owner_id = '')`
-	pinnedArgs := []any{ownerID}
-	if collectionName != "" {
-		pinnedSQL += " AND collection_name = $2"
-		pinnedArgs = append(pinnedArgs, collectionName)
-	}
-	pinnedSQL += " ORDER BY pin_priority DESC, updated_at DESC LIMIT 50"
-	if rows, err := h.cfg.DB.QueryContext(ctx, Q(pinnedSQL), pinnedArgs...); err == nil {
-		defer rows.Close()
-		for rows.Next() {
-			var k, v, hl, rm string
-			var prio int
-			if err := rows.Scan(&k, &v, &hl, &rm, &prio); err != nil {
-				continue
-			}
-			pinned = append(pinned, map[string]any{
-				"key": k, "value": v, "hall": hl, "room": rm, "priority": prio,
-			})
-		}
-	}
-
-	// 2. Top entities by active-edge degree
-	var entities []map[string]any
-	entSQL := `SELECT n.name, n.type, COUNT(e.id) AS deg
-		FROM graph_nodes n
-		LEFT JOIN graph_edges e ON (e.source_id = n.id OR e.target_id = n.id)
-			AND (e.valid_until IS NULL OR e.valid_until > $1)
-		GROUP BY n.id, n.name, n.type
-		ORDER BY deg DESC, n.updated_at DESC
-		LIMIT $2`
-	now := time.Now().UTC().Format(time.RFC3339)
-	if rows, err := h.cfg.DB.QueryContext(ctx, Q(entSQL), now, topEntities); err == nil {
-		defer rows.Close()
-		for rows.Next() {
-			var name, typ string
-			var deg int
-			if err := rows.Scan(&name, &typ, &deg); err != nil {
-				continue
-			}
-			if name == "" {
-				continue
-			}
-			entities = append(entities, map[string]any{
-				"name": name, "type": typ, "degree": deg,
-			})
-		}
-	}
-
-	// 3. Trim to budget — pinned first, then entities.
-	bundle := map[string]any{
-		"collection":   collectionName,
-		"max_tokens":   maxTokens,
-		"pinned":       pinned,
-		"top_entities": entities,
-	}
-	out, _ := json.MarshalIndent(bundle, "", "  ")
-	if len(out) > maxChars {
-		// Drop entities first, then trim pinned to fit
-		bundle["top_entities"] = []any{}
-		out, _ = json.MarshalIndent(bundle, "", "  ")
-		for len(out) > maxChars && len(pinned) > 0 {
-			pinned = pinned[:len(pinned)-1]
-			bundle["pinned"] = pinned
-			out, _ = json.MarshalIndent(bundle, "", "  ")
-		}
-	}
-
-	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(out)}}}
+	return mcp.ToolWakeUp(ctx, h, args)
 }
 
 // ── pin / unpin ──
 
+// toolPinMemory / toolUnpinMemory are thin shims over pkg/mcp (F-4 wave 3f).
 func (h *mcpHandler) toolPinMemory(ctx context.Context, args map[string]any) mcpToolResult {
-	if h.cfg.DB == nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: database not configured"}}, IsError: true}
-	}
-	key, _ := args["key"].(string)
-	if key == "" {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: 'key' required"}}, IsError: true}
-	}
-	priority := 1
-	if p, ok := args["priority"].(float64); ok {
-		priority = int(p)
-	}
-	ownerID := ""
-	if uid, ok := ctx.Value(mcpUserIDKey).(string); ok {
-		ownerID = uid
-	}
-	q, qargs := QArgs(`UPDATE memories SET is_pinned = 1, pin_priority = $1, updated_at = $2
-		WHERE key = $3 AND (owner_id = $4 OR owner_id = '')`,
-		priority, time.Now().UTC().Format(time.RFC3339), key, ownerID)
-	res, err := h.cfg.DB.ExecContext(ctx, q, qargs...)
-	if err != nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: " + err.Error()}}, IsError: true}
-	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "No memory matched key " + key}}, IsError: true}
-	}
-	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: fmt.Sprintf("Pinned %s (priority=%d)", key, priority)}}}
+	return mcp.ToolPinMemory(ctx, h, args)
 }
 
 func (h *mcpHandler) toolUnpinMemory(ctx context.Context, args map[string]any) mcpToolResult {
-	if h.cfg.DB == nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: database not configured"}}, IsError: true}
-	}
-	key, _ := args["key"].(string)
-	if key == "" {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: 'key' required"}}, IsError: true}
-	}
-	ownerID := ""
-	if uid, ok := ctx.Value(mcpUserIDKey).(string); ok {
-		ownerID = uid
-	}
-	q, qargs := QArgs(`UPDATE memories SET is_pinned = 0, pin_priority = 0, updated_at = $1
-		WHERE key = $2 AND (owner_id = $3 OR owner_id = '')`,
-		time.Now().UTC().Format(time.RFC3339), key, ownerID)
-	if _, err := h.cfg.DB.ExecContext(ctx, q, qargs...); err != nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: " + err.Error()}}, IsError: true}
-	}
-	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Unpinned " + key}}}
+	return mcp.ToolUnpinMemory(ctx, h, args)
 }
 
 // ── query_entity ──

--- a/Levara/pkg/mcp/deps.go
+++ b/Levara/pkg/mcp/deps.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stek0v/cognevra/pkg/ingest"
@@ -439,4 +440,308 @@ func ToolSetContext(sess *Session, deps Deps, args map[string]any) ToolResult {
 		Type: "text",
 		Text: fmt.Sprintf("Context %s: default collection = '%s'", status, collection),
 	}}}
+}
+
+// ── memory (palace) tools ──
+
+// listMemoriesCap bounds the rows returned by ToolListMemories.
+// Matches pre-refactor LIMIT.
+const listMemoriesCap = 100
+
+// ToolListMemories returns rows from the memories table with optional
+// type / collection / room / hall filters.
+//
+// Nil DB returns "[]" rather than an error, so clients built against a
+// deployment without the palace table keep working.
+func ToolListMemories(ctx context.Context, deps Deps, args map[string]any) ToolResult {
+	db := deps.DB()
+	if db == nil {
+		return ToolResult{Content: []Content{{Type: "text", Text: "[]"}}}
+	}
+
+	filterType, _ := args["type"].(string)
+	collectionName, _ := args["collection"].(string)
+	room, _ := args["room"].(string)
+	hall, _ := args["hall"].(string)
+
+	var conds []string
+	var qargs []any
+	pos := 1
+	if filterType != "" {
+		conds = append(conds, fmt.Sprintf("type = $%d", pos))
+		qargs = append(qargs, filterType)
+		pos++
+	}
+	if collectionName != "" {
+		conds = append(conds, fmt.Sprintf("collection_name = $%d", pos))
+		qargs = append(qargs, collectionName)
+		pos++
+	}
+	if room != "" {
+		conds = append(conds, fmt.Sprintf("room = $%d", pos))
+		qargs = append(qargs, room)
+		pos++
+	}
+	if hall != "" {
+		conds = append(conds, fmt.Sprintf("hall = $%d", pos))
+		qargs = append(qargs, hall)
+		pos++
+	}
+
+	sqlStr := `SELECT id, key, value, type, owner_id, room, hall, is_pinned, pin_priority, created_at, updated_at FROM memories`
+	if len(conds) > 0 {
+		sqlStr += " WHERE " + strings.Join(conds, " AND ")
+	}
+	sqlStr += fmt.Sprintf(" ORDER BY updated_at DESC LIMIT %d", listMemoriesCap)
+
+	rows, err := db.QueryContext(ctx, deps.Q(sqlStr), qargs...)
+	if err != nil {
+		return ToolResult{Content: []Content{{Type: "text", Text: "[]"}}}
+	}
+	defer rows.Close()
+
+	var results []map[string]any
+	for rows.Next() {
+		var id, key, value, typ, ownerID, rm, hl, ca, ua string
+		var pinned, prio int
+		if err := rows.Scan(&id, &key, &value, &typ, &ownerID, &rm, &hl, &pinned, &prio, &ca, &ua); err != nil {
+			continue
+		}
+		results = append(results, map[string]any{
+			"id": id, "key": key, "value": value, "type": typ,
+			"owner_id": ownerID, "room": rm, "hall": hl,
+			"is_pinned": pinned == 1, "pin_priority": prio,
+			"created_at": ca, "updated_at": ua,
+		})
+	}
+
+	if results == nil {
+		return ToolResult{Content: []Content{{Type: "text", Text: "[]"}}}
+	}
+	out, _ := json.MarshalIndent(results, "", "  ")
+	return ToolResult{Content: []Content{{Type: "text", Text: string(out)}}}
+}
+
+// extractOwnerID reads the MCP user ID from the request context (set by
+// the HTTP handler on auth). Returns empty string for anonymous tool
+// calls. Used by the ownership-scoped memory tools.
+func extractOwnerID(ctx context.Context) string {
+	if uid, ok := ctx.Value(UserIDKey).(string); ok {
+		return uid
+	}
+	return ""
+}
+
+// ToolPinMemory flags a memory row as pinned with the given priority.
+//
+// Ownership scope: the update only matches rows owned by the caller or
+// owned by the empty string (shared memories). Zero rows affected is
+// surfaced as IsError so the client knows the pin had no effect.
+func ToolPinMemory(ctx context.Context, deps Deps, args map[string]any) ToolResult {
+	db := deps.DB()
+	if db == nil {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: database not configured"}},
+			IsError: true,
+		}
+	}
+	key, _ := args["key"].(string)
+	if key == "" {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: 'key' required"}},
+			IsError: true,
+		}
+	}
+	priority := 1
+	if p, ok := args["priority"].(float64); ok {
+		priority = int(p)
+	}
+	ownerID := extractOwnerID(ctx)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// Placeholders $1..$4 are each used once — Q (not QArgs) is sufficient.
+	res, err := db.ExecContext(ctx, deps.Q(`
+		UPDATE memories SET is_pinned = 1, pin_priority = $1, updated_at = $2
+		WHERE key = $3 AND (owner_id = $4 OR owner_id = '')
+	`), priority, now, key, ownerID)
+	if err != nil {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: " + err.Error()}},
+			IsError: true,
+		}
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "No memory matched key " + key}},
+			IsError: true,
+		}
+	}
+	return ToolResult{Content: []Content{{
+		Type: "text",
+		Text: fmt.Sprintf("Pinned %s (priority=%d)", key, priority),
+	}}}
+}
+
+// ToolUnpinMemory clears the pin flag and priority on a memory row.
+//
+// Unlike Pin, a missing row is NOT reported as an error — the target
+// state (unpinned) is already satisfied, so the call is idempotent by
+// design. Matches pre-refactor behavior.
+func ToolUnpinMemory(ctx context.Context, deps Deps, args map[string]any) ToolResult {
+	db := deps.DB()
+	if db == nil {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: database not configured"}},
+			IsError: true,
+		}
+	}
+	key, _ := args["key"].(string)
+	if key == "" {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: 'key' required"}},
+			IsError: true,
+		}
+	}
+	ownerID := extractOwnerID(ctx)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	if _, err := db.ExecContext(ctx, deps.Q(`
+		UPDATE memories SET is_pinned = 0, pin_priority = 0, updated_at = $1
+		WHERE key = $2 AND (owner_id = $3 OR owner_id = '')
+	`), now, key, ownerID); err != nil {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: " + err.Error()}},
+			IsError: true,
+		}
+	}
+	return ToolResult{Content: []Content{{Type: "text", Text: "Unpinned " + key}}}
+}
+
+// Defaults for ToolWakeUp. max_tokens caps total response size;
+// top_entities limits the graph-entity section; chars/4 approximates
+// token count (matches pre-refactor tokenizer-free heuristic).
+const (
+	wakeUpDefaultMaxTokens   = 200
+	wakeUpDefaultTopEntities = 5
+	wakeUpPinnedRowLimit     = 50
+	wakeUpCharsPerToken      = 4
+)
+
+// ToolWakeUp returns a small bundle of critical context for session
+// start: pinned memories + top-N active graph entities, trimmed to a
+// token budget.
+//
+// Trim strategy matches pre-refactor: if the initial bundle exceeds
+// max_tokens*4 chars, drop all entities first, then pop pinned entries
+// from the tail until it fits.
+func ToolWakeUp(ctx context.Context, deps Deps, args map[string]any) ToolResult {
+	db := deps.DB()
+	if db == nil {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: database not configured"}},
+			IsError: true,
+		}
+	}
+	collectionName, _ := args["collection"].(string)
+	maxTokens := wakeUpDefaultMaxTokens
+	if mt, ok := args["max_tokens"].(float64); ok && mt > 0 {
+		maxTokens = int(mt)
+	}
+	topEntities := wakeUpDefaultTopEntities
+	if te, ok := args["top_entities"].(float64); ok && te > 0 {
+		topEntities = int(te)
+	}
+	maxChars := maxTokens * wakeUpCharsPerToken
+	ownerID := extractOwnerID(ctx)
+
+	pinned := wakeUpPinned(ctx, db, deps.Q, ownerID, collectionName)
+	entities := wakeUpEntities(ctx, db, deps.Q, topEntities)
+
+	bundle := map[string]any{
+		"collection":   collectionName,
+		"max_tokens":   maxTokens,
+		"pinned":       pinned,
+		"top_entities": entities,
+	}
+	out, _ := json.MarshalIndent(bundle, "", "  ")
+	if len(out) > maxChars {
+		// Drop entities first, then trim pinned to fit.
+		bundle["top_entities"] = []any{}
+		out, _ = json.MarshalIndent(bundle, "", "  ")
+		for len(out) > maxChars && len(pinned) > 0 {
+			pinned = pinned[:len(pinned)-1]
+			bundle["pinned"] = pinned
+			out, _ = json.MarshalIndent(bundle, "", "  ")
+		}
+	}
+
+	return ToolResult{Content: []Content{{Type: "text", Text: string(out)}}}
+}
+
+// wakeUpPinned loads pinned memories owned by ownerID (or the empty
+// shared owner) in priority-desc order.
+func wakeUpPinned(ctx context.Context, db *sql.DB, rewrite func(string) string, ownerID, collectionName string) []map[string]any {
+	sqlStr := `SELECT key, value, hall, room, pin_priority FROM memories
+		WHERE is_pinned = 1 AND (owner_id = $1 OR owner_id = '')`
+	qargs := []any{ownerID}
+	if collectionName != "" {
+		sqlStr += " AND collection_name = $2"
+		qargs = append(qargs, collectionName)
+	}
+	sqlStr += fmt.Sprintf(" ORDER BY pin_priority DESC, updated_at DESC LIMIT %d", wakeUpPinnedRowLimit)
+
+	rows, err := db.QueryContext(ctx, rewrite(sqlStr), qargs...)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var out []map[string]any
+	for rows.Next() {
+		var k, v, hl, rm string
+		var prio int
+		if err := rows.Scan(&k, &v, &hl, &rm, &prio); err != nil {
+			continue
+		}
+		out = append(out, map[string]any{
+			"key": k, "value": v, "hall": hl, "room": rm, "priority": prio,
+		})
+	}
+	return out
+}
+
+// wakeUpEntities loads the top-N graph nodes by active-edge degree.
+// Edges are "active" if their valid_until is NULL or in the future.
+func wakeUpEntities(ctx context.Context, db *sql.DB, rewrite func(string) string, topN int) []map[string]any {
+	now := time.Now().UTC().Format(time.RFC3339)
+	sqlStr := `SELECT n.name, n.type, COUNT(e.id) AS deg
+		FROM graph_nodes n
+		LEFT JOIN graph_edges e ON (e.source_id = n.id OR e.target_id = n.id)
+			AND (e.valid_until IS NULL OR e.valid_until > $1)
+		GROUP BY n.id, n.name, n.type
+		ORDER BY deg DESC, n.updated_at DESC
+		LIMIT $2`
+
+	rows, err := db.QueryContext(ctx, rewrite(sqlStr), now, topN)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var out []map[string]any
+	for rows.Next() {
+		var name, typ string
+		var deg int
+		if err := rows.Scan(&name, &typ, &deg); err != nil {
+			continue
+		}
+		if name == "" {
+			continue
+		}
+		out = append(out, map[string]any{
+			"name": name, "type": typ, "degree": deg,
+		})
+	}
+	return out
 }

--- a/Levara/pkg/mcp/tool_memory_test.go
+++ b/Levara/pkg/mcp/tool_memory_test.go
@@ -1,0 +1,434 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"database/sql"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/ncruces/go-sqlite3/driver"
+)
+
+// setupMemoryTestDB builds the memories schema used by the palace
+// tools. Columns match the production schema's shape; only the ones
+// the four tools under test touch matter here.
+func setupMemoryTestDB(t *testing.T) *fakeDeps {
+	t.Helper()
+	f, _ := os.CreateTemp("", "mcp-memory-test-*.db")
+	path := f.Name()
+	f.Close()
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(path)
+	})
+
+	stmts := []string{
+		`CREATE TABLE memories (
+			id TEXT PRIMARY KEY, key TEXT, value TEXT, type TEXT, owner_id TEXT,
+			collection_name TEXT, room TEXT, hall TEXT,
+			is_pinned INTEGER DEFAULT 0, pin_priority INTEGER DEFAULT 0,
+			created_at TEXT, updated_at TEXT
+		)`,
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+	}
+	return &fakeDeps{db: db}
+}
+
+// seedMemory is a compact helper for inserting memory rows in tests.
+// Ignores errors since test setup should never hit real failures.
+func seedMemory(t *testing.T, db *sql.DB, id, key, value, typ, owner, coll, room, hall string, pinned int, prio int) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := db.Exec(`INSERT INTO memories (
+		id, key, value, type, owner_id, collection_name, room, hall,
+		is_pinned, pin_priority, created_at, updated_at
+	) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
+		id, key, value, typ, owner, coll, room, hall, pinned, prio, now, now)
+	if err != nil {
+		t.Fatalf("seed %s: %v", key, err)
+	}
+}
+
+// ── ToolListMemories ──
+
+func TestToolListMemories_NilDBReturnsEmpty(t *testing.T) {
+	// No DB configured → "[]" (not an error), so MCP clients that only
+	// read memory still work in deployments without the palace schema.
+	got := ToolListMemories(context.Background(), nilDBDeps{}, map[string]any{})
+	if got.IsError {
+		t.Fatalf("IsError = true, want false")
+	}
+	if got.Content[0].Text != "[]" {
+		t.Errorf("content = %q, want []", got.Content[0].Text)
+	}
+}
+
+func TestToolListMemories_NoRowsReturnsEmpty(t *testing.T) {
+	// Empty DB (schema present but no rows) must still return "[]"
+	// rather than "null" — some JSON consumers choke on null arrays.
+	deps := setupMemoryTestDB(t)
+
+	got := ToolListMemories(context.Background(), deps, map[string]any{})
+	if got.Content[0].Text != "[]" {
+		t.Errorf("content = %q, want []", got.Content[0].Text)
+	}
+}
+
+func TestToolListMemories_TypeFilter(t *testing.T) {
+	// "type" filter narrows the result set by the memory type column.
+	deps := setupMemoryTestDB(t)
+	seedMemory(t, deps.db, "m1", "k1", "v1", "project", "", "", "", "", 0, 0)
+	seedMemory(t, deps.db, "m2", "k2", "v2", "preference", "", "", "", "", 0, 0)
+	seedMemory(t, deps.db, "m3", "k3", "v3", "project", "", "", "", "", 0, 0)
+
+	got := ToolListMemories(context.Background(), deps, map[string]any{"type": "project"})
+	var items []map[string]any
+	if err := json.Unmarshal([]byte(got.Content[0].Text), &items); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("got %d project items, want 2", len(items))
+	}
+	for _, it := range items {
+		if it["type"] != "project" {
+			t.Errorf("item type = %v, want project", it["type"])
+		}
+	}
+}
+
+func TestToolListMemories_CombinedFilters(t *testing.T) {
+	// Multiple filters AND together. Seeding 4 rows with different
+	// combinations ensures the filter is applied on every axis.
+	deps := setupMemoryTestDB(t)
+	seedMemory(t, deps.db, "m1", "a", "v", "project", "", "levara", "auth", "decision", 0, 0)
+	seedMemory(t, deps.db, "m2", "b", "v", "project", "", "levara", "auth", "fact", 0, 0)
+	seedMemory(t, deps.db, "m3", "c", "v", "project", "", "other", "auth", "decision", 0, 0)
+	seedMemory(t, deps.db, "m4", "d", "v", "feedback", "", "levara", "auth", "decision", 0, 0)
+
+	// Only m1 matches all three: levara collection, auth room, decision hall.
+	got := ToolListMemories(context.Background(), deps, map[string]any{
+		"type":       "project",
+		"collection": "levara",
+		"room":       "auth",
+		"hall":       "decision",
+	})
+	var items []map[string]any
+	json.Unmarshal([]byte(got.Content[0].Text), &items)
+	if len(items) != 1 || items[0]["key"] != "a" {
+		t.Errorf("got %+v, want single m1/a", items)
+	}
+}
+
+func TestToolListMemories_FormatsPinnedAsBool(t *testing.T) {
+	// is_pinned is stored as INTEGER (0/1) in SQL but returned as bool
+	// in the JSON output. Locks in the pre-refactor shape that clients
+	// rely on.
+	deps := setupMemoryTestDB(t)
+	seedMemory(t, deps.db, "m1", "k", "v", "project", "", "", "", "", 1, 10)
+
+	got := ToolListMemories(context.Background(), deps, map[string]any{})
+	var items []map[string]any
+	json.Unmarshal([]byte(got.Content[0].Text), &items)
+	if len(items) != 1 {
+		t.Fatalf("got %d items, want 1", len(items))
+	}
+	if items[0]["is_pinned"] != true {
+		t.Errorf("is_pinned = %v (type %T), want bool true", items[0]["is_pinned"], items[0]["is_pinned"])
+	}
+	if int(items[0]["pin_priority"].(float64)) != 10 {
+		t.Errorf("pin_priority = %v, want 10", items[0]["pin_priority"])
+	}
+}
+
+// ── ToolPinMemory ──
+
+func TestToolPinMemory_RequiresKey(t *testing.T) {
+	// 'key' arg is required.
+	deps := setupMemoryTestDB(t)
+	got := ToolPinMemory(context.Background(), deps, map[string]any{})
+	if !got.IsError {
+		t.Fatalf("missing key: IsError = false, want true")
+	}
+	if !strings.Contains(got.Content[0].Text, "'key' required") {
+		t.Errorf("content = %q, want 'key' required", got.Content[0].Text)
+	}
+}
+
+func TestToolPinMemory_NilDBIsError(t *testing.T) {
+	// No DB → hard error, matches the pin/unpin contract for a
+	// write-only tool.
+	got := ToolPinMemory(context.Background(), nilDBDeps{}, map[string]any{"key": "k"})
+	if !got.IsError {
+		t.Fatalf("nil DB: IsError = false, want true")
+	}
+	if !strings.Contains(got.Content[0].Text, "database not configured") {
+		t.Errorf("content = %q", got.Content[0].Text)
+	}
+}
+
+func TestToolPinMemory_NoMatchingRowIsError(t *testing.T) {
+	// Pinning a non-existent key is IsError (unlike Delete/Prune which
+	// are best-effort). Pin is a state-change request; the caller
+	// needs to know it had no effect.
+	deps := setupMemoryTestDB(t)
+
+	got := ToolPinMemory(context.Background(), deps, map[string]any{"key": "ghost"})
+	if !got.IsError {
+		t.Fatalf("missing row: IsError = false, want true")
+	}
+	if !strings.Contains(got.Content[0].Text, "No memory matched key ghost") {
+		t.Errorf("content = %q", got.Content[0].Text)
+	}
+}
+
+func TestToolPinMemory_HappyPathUpdatesRow(t *testing.T) {
+	// Pin sets is_pinned=1 + pin_priority=requested + updated_at.
+	// Message echoes the key and priority.
+	deps := setupMemoryTestDB(t)
+	seedMemory(t, deps.db, "m1", "config", "v", "fact", "", "", "", "", 0, 0)
+
+	got := ToolPinMemory(context.Background(), deps, map[string]any{
+		"key":      "config",
+		"priority": float64(8),
+	})
+	if got.IsError {
+		t.Fatalf("IsError = true; content=%+v", got.Content)
+	}
+	if !strings.Contains(got.Content[0].Text, "Pinned config (priority=8)") {
+		t.Errorf("content = %q", got.Content[0].Text)
+	}
+
+	var pinned, prio int
+	deps.db.QueryRow("SELECT is_pinned, pin_priority FROM memories WHERE key = 'config'").Scan(&pinned, &prio)
+	if pinned != 1 {
+		t.Errorf("is_pinned = %d, want 1", pinned)
+	}
+	if prio != 8 {
+		t.Errorf("pin_priority = %d, want 8", prio)
+	}
+}
+
+func TestToolPinMemory_DefaultPriorityIsOne(t *testing.T) {
+	// Missing 'priority' arg → priority=1 (pre-refactor default).
+	deps := setupMemoryTestDB(t)
+	seedMemory(t, deps.db, "m1", "config", "v", "fact", "", "", "", "", 0, 0)
+
+	got := ToolPinMemory(context.Background(), deps, map[string]any{"key": "config"})
+	if got.IsError {
+		t.Fatalf("IsError = true")
+	}
+	if !strings.Contains(got.Content[0].Text, "priority=1") {
+		t.Errorf("content = %q, want priority=1 default", got.Content[0].Text)
+	}
+}
+
+// ── ToolUnpinMemory ──
+
+func TestToolUnpinMemory_RequiresKey(t *testing.T) {
+	deps := setupMemoryTestDB(t)
+	got := ToolUnpinMemory(context.Background(), deps, map[string]any{})
+	if !got.IsError {
+		t.Fatalf("missing key: IsError = false, want true")
+	}
+}
+
+func TestToolUnpinMemory_NilDBIsError(t *testing.T) {
+	got := ToolUnpinMemory(context.Background(), nilDBDeps{}, map[string]any{"key": "k"})
+	if !got.IsError {
+		t.Fatalf("nil DB: IsError = false, want true")
+	}
+}
+
+func TestToolUnpinMemory_MissingRowIsNotError(t *testing.T) {
+	// Unpin is idempotent — asking to unpin a non-existent row is fine,
+	// the target state (unpinned) is already satisfied. This is the
+	// opposite of Pin's strict semantics.
+	deps := setupMemoryTestDB(t)
+
+	got := ToolUnpinMemory(context.Background(), deps, map[string]any{"key": "ghost"})
+	if got.IsError {
+		t.Errorf("missing row: IsError = true, want false (unpin is idempotent)")
+	}
+	if !strings.Contains(got.Content[0].Text, "Unpinned ghost") {
+		t.Errorf("content = %q", got.Content[0].Text)
+	}
+}
+
+func TestToolUnpinMemory_ClearsFlagsOnRealRow(t *testing.T) {
+	// Unpin flips is_pinned=0 and pin_priority=0 regardless of prior
+	// priority. Tests lock in both, not just the flag.
+	deps := setupMemoryTestDB(t)
+	seedMemory(t, deps.db, "m1", "config", "v", "fact", "", "", "", "", 1, 10)
+
+	got := ToolUnpinMemory(context.Background(), deps, map[string]any{"key": "config"})
+	if got.IsError {
+		t.Fatalf("IsError = true")
+	}
+
+	var pinned, prio int
+	deps.db.QueryRow("SELECT is_pinned, pin_priority FROM memories WHERE key = 'config'").Scan(&pinned, &prio)
+	if pinned != 0 || prio != 0 {
+		t.Errorf("after unpin: is_pinned=%d pin_priority=%d, want 0/0", pinned, prio)
+	}
+}
+
+// ── ToolWakeUp ──
+
+// setupWakeUpTestDB builds both memories and graph tables so ToolWakeUp
+// can exercise the pinned + entities branches end-to-end.
+func setupWakeUpTestDB(t *testing.T) *fakeDeps {
+	t.Helper()
+	deps := setupMemoryTestDB(t)
+
+	stmts := []string{
+		`CREATE TABLE graph_nodes (id TEXT PRIMARY KEY, name TEXT, type TEXT, updated_at TEXT)`,
+		`CREATE TABLE graph_edges (
+			id TEXT PRIMARY KEY, source_id TEXT, target_id TEXT,
+			valid_until TEXT, updated_at TEXT
+		)`,
+	}
+	for _, s := range stmts {
+		if _, err := deps.db.Exec(s); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+	}
+	return deps
+}
+
+func TestToolWakeUp_NilDBIsError(t *testing.T) {
+	got := ToolWakeUp(context.Background(), nilDBDeps{}, map[string]any{})
+	if !got.IsError {
+		t.Fatalf("nil DB: IsError = false, want true")
+	}
+}
+
+func TestToolWakeUp_EmptyDBReturnsEmptyBundle(t *testing.T) {
+	// Fresh DB (schema but no rows) → bundle with empty pinned +
+	// empty entities, not an error.
+	deps := setupWakeUpTestDB(t)
+
+	got := ToolWakeUp(context.Background(), deps, map[string]any{})
+	if got.IsError {
+		t.Fatalf("IsError = true")
+	}
+	var bundle map[string]any
+	json.Unmarshal([]byte(got.Content[0].Text), &bundle)
+	if bundle["pinned"] != nil {
+		t.Errorf("pinned = %v, want nil/empty", bundle["pinned"])
+	}
+}
+
+func TestToolWakeUp_ReturnsPinnedOrderedByPriority(t *testing.T) {
+	// Pinned memories come back in pin_priority DESC order. updated_at
+	// is the tiebreaker — covered by the default seed timestamps.
+	deps := setupWakeUpTestDB(t)
+	seedMemory(t, deps.db, "m1", "low", "v1", "fact", "", "", "", "", 1, 1)
+	seedMemory(t, deps.db, "m2", "high", "v2", "fact", "", "", "", "", 1, 10)
+	seedMemory(t, deps.db, "m3", "unpinned", "v3", "fact", "", "", "", "", 0, 0)
+
+	got := ToolWakeUp(context.Background(), deps, map[string]any{})
+	var bundle map[string]any
+	json.Unmarshal([]byte(got.Content[0].Text), &bundle)
+
+	pinned := bundle["pinned"].([]any)
+	if len(pinned) != 2 {
+		t.Fatalf("got %d pinned, want 2 (unpinned row must be excluded)", len(pinned))
+	}
+	first := pinned[0].(map[string]any)
+	if first["key"] != "high" {
+		t.Errorf("first pinned = %v, want 'high' (priority 10)", first["key"])
+	}
+}
+
+func TestToolWakeUp_CollectionScopingFiltersPinned(t *testing.T) {
+	// Passing a "collection" arg restricts pinned to that collection_name.
+	deps := setupWakeUpTestDB(t)
+	seedMemory(t, deps.db, "m1", "a", "v", "fact", "", "levara", "", "", 1, 5)
+	seedMemory(t, deps.db, "m2", "b", "v", "fact", "", "other", "", "", 1, 5)
+
+	got := ToolWakeUp(context.Background(), deps, map[string]any{"collection": "levara"})
+	var bundle map[string]any
+	json.Unmarshal([]byte(got.Content[0].Text), &bundle)
+
+	pinned := bundle["pinned"].([]any)
+	if len(pinned) != 1 {
+		t.Fatalf("got %d pinned, want 1 (other collection must be excluded)", len(pinned))
+	}
+	if pinned[0].(map[string]any)["key"] != "a" {
+		t.Errorf("pinned key = %v, want 'a'", pinned[0].(map[string]any)["key"])
+	}
+}
+
+func TestToolWakeUp_TrimsToMaxTokens(t *testing.T) {
+	// Seeding 30 pinned rows then passing max_tokens=20 (= 80 chars)
+	// forces the trim loop. Entities drop first; then pinned pops from
+	// the tail until the encoded bundle fits.
+	deps := setupWakeUpTestDB(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	for i := 0; i < 30; i++ {
+		_, _ = deps.db.Exec(`INSERT INTO memories (
+			id, key, value, type, owner_id, collection_name, room, hall,
+			is_pinned, pin_priority, created_at, updated_at
+		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
+			"m"+string(rune('a'+i)), "key"+string(rune('a'+i)),
+			strings.Repeat("x", 50), "fact", "", "", "", "",
+			1, 30-i, now, now)
+	}
+
+	got := ToolWakeUp(context.Background(), deps, map[string]any{
+		"max_tokens": float64(20), // 80 chars budget
+	})
+	// Success — the bundle still encodes, even if it's near-empty.
+	if got.IsError {
+		t.Fatalf("IsError = true; content=%+v", got.Content)
+	}
+	// Size is bounded (some slack for JSON overhead of the wrapper).
+	if len(got.Content[0].Text) > 200 {
+		t.Errorf("trim ineffective: output length %d bytes for max_tokens=20 (budget 80 chars)", len(got.Content[0].Text))
+	}
+}
+
+func TestToolWakeUp_EntityDegreeCountsActiveEdges(t *testing.T) {
+	// Graph entities section counts ACTIVE edges per node. Expired
+	// edges (valid_until in the past) are excluded from the degree.
+	deps := setupWakeUpTestDB(t)
+	past := "2000-01-01T00:00:00Z"
+	// Nodes.
+	deps.db.Exec(`INSERT INTO graph_nodes (id, name, type, updated_at) VALUES ('n1', 'auth', 'service', ?)`, past)
+	deps.db.Exec(`INSERT INTO graph_nodes (id, name, type, updated_at) VALUES ('n2', 'deploy', 'service', ?)`, past)
+	// Active edges touching n1 (x2), expired edge touching n2 (x1).
+	deps.db.Exec(`INSERT INTO graph_edges (id, source_id, target_id, valid_until, updated_at) VALUES ('e1', 'n1', 'n2', NULL, ?)`, past)
+	deps.db.Exec(`INSERT INTO graph_edges (id, source_id, target_id, valid_until, updated_at) VALUES ('e2', 'n1', 'n2', NULL, ?)`, past)
+	deps.db.Exec(`INSERT INTO graph_edges (id, source_id, target_id, valid_until, updated_at) VALUES ('e3', 'n2', 'n1', ?, ?)`, past, past)
+
+	got := ToolWakeUp(context.Background(), deps, map[string]any{})
+	var bundle map[string]any
+	json.Unmarshal([]byte(got.Content[0].Text), &bundle)
+
+	entities := bundle["top_entities"].([]any)
+	if len(entities) == 0 {
+		t.Fatalf("no entities returned")
+	}
+	// n1 has 2 active edges (e1, e2), plus e3 (expired) which touches
+	// it as target. The expired-edge check is against e3.valid_until
+	// (past), so e3 should be excluded → n1 degree = 2.
+	top := entities[0].(map[string]any)
+	if top["name"] != "auth" {
+		t.Errorf("top entity = %v, want 'auth'", top["name"])
+	}
+	if int(top["degree"].(float64)) != 2 {
+		t.Errorf("auth degree = %v, want 2 (expired edge excluded)", top["degree"])
+	}
+}


### PR DESCRIPTION
## Summary

Bundle of four memory-palace tools whose bodies are all pure DB (no embedding, no vector search). Together with wave 3e, brings migrated-tool count to 11.

- \`toolListMemories\` — multi-filter SELECT over memories.
- \`toolPinMemory\` — ownership-scoped UPDATE, strict (no matching row → IsError).
- \`toolUnpinMemory\` — ownership-scoped UPDATE, idempotent (missing row is a no-op).
- \`toolWakeUp\` — pinned-memories + top-entities bundle, trimmed to a token budget. Split into \`wakeUpPinned\` + \`wakeUpEntities\` helpers.

**Deps interface unchanged** — all four tools fit on existing methods (DB, Q, plus \`extractOwnerID\` helper for pulling \`mcp.UserIDKey\` from ctx).

## Deferred to later wave

\`toolSaveMemory\` and \`toolRecallMemory\` use \`embed.Client\` for vector indexing + \`Collections.Insert/Search\` for semantic recall. These need a dedicated Deps seam for embeddings (first AI dependency), which deserves its own wave.

## Changes

- \`pkg/mcp/deps.go\`: four tool functions + helpers + constants.
- \`pkg/mcp/tool_memory_test.go\`: 20 new tests in a new file (first split — \`deps_test.go\` was already 964 LOC).
- \`internal/http/mcp.go\`: \`toolListMemories\` → one-line shim.
- \`internal/http/mcp_palace.go\`: three shims for wake_up, pin, unpin.

## Simplifications during move

- Pre-refactor pin/unpin used \`QArgs()\` even though no placeholder was reused. Switched to \`Q()\` — semantically identical, one less indirection.
- Magic numbers lifted to named constants: \`listMemoriesCap\`, \`wakeUpDefaultMaxTokens\`, \`wakeUpDefaultTopEntities\`, \`wakeUpPinnedRowLimit\`, \`wakeUpCharsPerToken\`.
- WakeUp body split into two helper functions so the orchestration function (parse args → gather data → trim → return) reads linearly.

## Contract preservation

- Same error strings per tool.
- Same success message formats.
- Same SQL output shapes (including \`is_pinned\` as JSON bool despite SQL integer).
- Same idempotent unpin semantics (contrast with strict pin).
- Same wake_up trim strategy: drop entities first, then pop pinned from the tail.
- Same pin-priority default (1) when arg is missing.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] 20 new tests in pkg/mcp cover nil DB paths, happy paths, edge cases (missing rows, idempotency, trim behavior, entity validity filter).
- [x] \`go test -race -count=1 ./...\` — 34 PASS / 0 FAIL

## Deps surface after 3f

| Method | Wave | Used by |
|---|---|---|
| \`DB() *sql.DB\` | 3a | all DB tools (11 and counting) |
| \`Q(string) string\` | 3a | most DB tools |
| \`HasCollections() bool\` | 3c | ListData |
| \`ListCollections() []string\` | 3c | ListData |
| \`StoragePath() string\` | 3d | Add |
| \`CollectionExists(string) bool\` | 3e | SetContext |

**6 methods / 11 migrated tools ≈ 0.55 methods per tool.** Most tools reuse DB+Q.

## Migrated tools (11/25)

Delete, Prune, ListData, Add, AddFeedback, GetFeedbackStats, SetContext, ListMemories, PinMemory, UnpinMemory, WakeUp.

## Remaining

- **Memory wave 3g (AI-dependent):** SaveMemory, RecallMemory — needs Embed + CollectionsSearch on Deps.
- **Chat history bundle:** SaveChat, RecallChat, SearchChats — pure DB.
- **Diary bundle:** DiaryWrite, DiaryRead — pure DB + DiaryOwner helper.
- **Cognify status + cognify:** blocked on \`pipelineRuns sync.Map\` decoupling.
- **Big tools last:** Search, Cognify, CrossSearch, Sync, GetProjectContext, AnalyzeCommits, GitSearch, Codify, CheckDrift, PruneGraph, ListCommunities, QueryEntity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)