### PR TITLE
refactor(mcp): F-4 wave 3h — toolQueryEntity moves behind Deps

### DIFF
--- a/Levara/internal/http/mcp_palace.go
+++ b/Levara/internal/http/mcp_palace.go
@@ -9,9 +9,6 @@ package http
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"strings"
 
 	"github.com/stek0v/cognevra/pkg/mcp"
 )
@@ -39,109 +36,9 @@ func (h *mcpHandler) toolUnpinMemory(ctx context.Context, args map[string]any) m
 
 // ── query_entity ──
 
-// toolQueryEntity returns all graph edges touching the named entity. Filters
-// by validity: by default only currently-active edges; if as_of is supplied,
-// returns the snapshot at that point in time (edges whose validity window
-// included as_of).
+// toolQueryEntity is a thin shim over mcp.ToolQueryEntity (F-4 wave 3h).
 func (h *mcpHandler) toolQueryEntity(ctx context.Context, args map[string]any) mcpToolResult {
-	if h.cfg.DB == nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: database not configured"}}, IsError: true}
-	}
-	name, _ := args["name"].(string)
-	if name == "" {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: 'name' required"}}, IsError: true}
-	}
-	asOf, _ := args["as_of"].(string)
-	limit := 50
-	if l, ok := args["limit"].(float64); ok && l > 0 {
-		limit = int(l)
-	}
-
-	// Resolve entity → node IDs
-	var nodeIDs []string
-	if rows, err := h.cfg.DB.QueryContext(ctx,
-		Q(`SELECT id FROM graph_nodes WHERE name = $1 LIMIT 10`), name); err == nil {
-		defer rows.Close()
-		for rows.Next() {
-			var id string
-			if err := rows.Scan(&id); err == nil {
-				nodeIDs = append(nodeIDs, id)
-			}
-		}
-	}
-	if len(nodeIDs) == 0 {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: fmt.Sprintf("No entity found with name '%s'", name)}}}
-	}
-
-	// Build IN clause and validity predicate
-	placeholders := make([]string, 0, len(nodeIDs)*2)
-	qargs := make([]any, 0, len(nodeIDs)*2+2)
-	pos := 1
-	for _, id := range nodeIDs {
-		placeholders = append(placeholders, fmt.Sprintf("$%d", pos))
-		qargs = append(qargs, id)
-		pos++
-	}
-	srcIn := strings.Join(placeholders, ",")
-	tgtPlaceholders := make([]string, 0, len(nodeIDs))
-	for _, id := range nodeIDs {
-		tgtPlaceholders = append(tgtPlaceholders, fmt.Sprintf("$%d", pos))
-		qargs = append(qargs, id)
-		pos++
-	}
-	tgtIn := strings.Join(tgtPlaceholders, ",")
-
-	validityClause := ""
-	if asOf == "" {
-		validityClause = " AND (valid_until IS NULL OR valid_until > CURRENT_TIMESTAMP)"
-	} else {
-		// Edge was valid at as_of: valid_from is null OR <= as_of, AND valid_until is null OR > as_of
-		validityClause = fmt.Sprintf(" AND (valid_from IS NULL OR valid_from <= $%d) AND (valid_until IS NULL OR valid_until > $%d)", pos, pos+1)
-		qargs = append(qargs, asOf, asOf)
-		pos += 2
-	}
-
-	sqlStr := fmt.Sprintf(`SELECT id, source_id, target_id, relationship_name, properties,
-			COALESCE(valid_from, ''), COALESCE(valid_until, ''), superseded_by, confidence
-		FROM graph_edges
-		WHERE (source_id IN (%s) OR target_id IN (%s))%s
-		ORDER BY updated_at DESC LIMIT $%d`, srcIn, tgtIn, validityClause, pos)
-	qargs = append(qargs, limit)
-
-	rows, err := h.cfg.DB.QueryContext(ctx, Q(sqlStr), qargs...)
-	if err != nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: " + err.Error()}}, IsError: true}
-	}
-	defer rows.Close()
-
-	var edges []map[string]any
-	for rows.Next() {
-		var id, src, tgt, rel, props, vf, vu, sb string
-		var conf float64
-		if err := rows.Scan(&id, &src, &tgt, &rel, &props, &vf, &vu, &sb, &conf); err != nil {
-			continue
-		}
-		edges = append(edges, map[string]any{
-			"id":               id,
-			"source_id":        src,
-			"target_id":        tgt,
-			"relationship":     rel,
-			"properties":       json.RawMessage(props),
-			"valid_from":       vf,
-			"valid_until":      vu,
-			"superseded_by":    sb,
-			"confidence":       conf,
-		})
-	}
-
-	resp := map[string]any{
-		"entity":   name,
-		"as_of":    asOf,
-		"node_ids": nodeIDs,
-		"edges":    edges,
-	}
-	out, _ := json.MarshalIndent(resp, "", "  ")
-	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(out)}}}
+	return mcp.ToolQueryEntity(ctx, h, args)
 }
 
 // ── Agent diaries ──

--- a/Levara/pkg/mcp/deps.go
+++ b/Levara/pkg/mcp/deps.go
@@ -1056,3 +1056,165 @@ func ToolDiaryRead(ctx context.Context, deps Deps, args map[string]any) ToolResu
 	out, _ := json.MarshalIndent(entries, "", "  ")
 	return ToolResult{Content: []Content{{Type: "text", Text: string(out)}}}
 }
+
+// ── knowledge graph query ──
+
+const (
+	// queryEntityNodeResolveLimit caps how many nodes we resolve for a
+	// given entity name. Rarely more than one, but duplicates can exist
+	// if the same name was imported from distinct sources.
+	queryEntityNodeResolveLimit = 10
+	// queryEntityEdgeLimit caps the number of edges returned per call.
+	// Default value used when no "limit" arg is supplied.
+	queryEntityEdgeLimit = 50
+)
+
+// ToolQueryEntity returns all graph edges touching the named entity,
+// filtered by validity.
+//
+// Validity modes:
+//  - No "as_of": only currently-active edges (valid_until is NULL or
+//    in the future relative to CURRENT_TIMESTAMP).
+//  - "as_of" supplied: temporal snapshot — edges whose validity window
+//    (valid_from, valid_until) includes the given timestamp.
+//
+// Returns a not-found message (IsError=false) when the entity name
+// resolves to zero nodes — an unknown name is a reasonable query, not
+// a client error.
+func ToolQueryEntity(ctx context.Context, deps Deps, args map[string]any) ToolResult {
+	db := deps.DB()
+	if db == nil {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: database not configured"}},
+			IsError: true,
+		}
+	}
+	name, _ := args["name"].(string)
+	if name == "" {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: 'name' required"}},
+			IsError: true,
+		}
+	}
+	asOf, _ := args["as_of"].(string)
+	limit := queryEntityEdgeLimit
+	if l, ok := args["limit"].(float64); ok && l > 0 {
+		limit = int(l)
+	}
+
+	nodeIDs := resolveEntityNodes(ctx, db, deps.Q, name)
+	if len(nodeIDs) == 0 {
+		return ToolResult{Content: []Content{{
+			Type: "text",
+			Text: fmt.Sprintf("No entity found with name '%s'", name),
+		}}}
+	}
+
+	edges, err := queryEntityEdges(ctx, db, deps.Q, nodeIDs, asOf, limit)
+	if err != nil {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: " + err.Error()}},
+			IsError: true,
+		}
+	}
+
+	resp := map[string]any{
+		"entity":   name,
+		"as_of":    asOf,
+		"node_ids": nodeIDs,
+		"edges":    edges,
+	}
+	out, _ := json.MarshalIndent(resp, "", "  ")
+	return ToolResult{Content: []Content{{Type: "text", Text: string(out)}}}
+}
+
+// resolveEntityNodes returns the graph node IDs that share the given
+// entity name. Capped at queryEntityNodeResolveLimit; silent failure
+// returns an empty slice (callers surface "No entity found").
+func resolveEntityNodes(ctx context.Context, db *sql.DB, rewrite func(string) string, name string) []string {
+	rows, err := db.QueryContext(ctx, rewrite(fmt.Sprintf(
+		"SELECT id FROM graph_nodes WHERE name = $1 LIMIT %d", queryEntityNodeResolveLimit,
+	)), name)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err == nil {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// queryEntityEdges fetches edges touching any of nodeIDs (as source
+// or target), applying the active-now or as_of-based validity filter.
+// Returns SQL errors to the caller since a malformed query here is a
+// real fault, not a not-found.
+func queryEntityEdges(ctx context.Context, db *sql.DB, rewrite func(string) string, nodeIDs []string, asOf string, limit int) ([]map[string]any, error) {
+	srcPlaceholders := make([]string, 0, len(nodeIDs))
+	tgtPlaceholders := make([]string, 0, len(nodeIDs))
+	qargs := make([]any, 0, len(nodeIDs)*2+2)
+	pos := 1
+	for _, id := range nodeIDs {
+		srcPlaceholders = append(srcPlaceholders, fmt.Sprintf("$%d", pos))
+		qargs = append(qargs, id)
+		pos++
+	}
+	for _, id := range nodeIDs {
+		tgtPlaceholders = append(tgtPlaceholders, fmt.Sprintf("$%d", pos))
+		qargs = append(qargs, id)
+		pos++
+	}
+
+	var validityClause string
+	if asOf == "" {
+		validityClause = " AND (valid_until IS NULL OR valid_until > CURRENT_TIMESTAMP)"
+	} else {
+		validityClause = fmt.Sprintf(
+			" AND (valid_from IS NULL OR valid_from <= $%d) AND (valid_until IS NULL OR valid_until > $%d)",
+			pos, pos+1,
+		)
+		qargs = append(qargs, asOf, asOf)
+		pos += 2
+	}
+
+	sqlStr := fmt.Sprintf(`
+		SELECT id, source_id, target_id, relationship_name, properties,
+			COALESCE(valid_from, ''), COALESCE(valid_until, ''), superseded_by, confidence
+		FROM graph_edges
+		WHERE (source_id IN (%s) OR target_id IN (%s))%s
+		ORDER BY updated_at DESC LIMIT $%d
+	`, strings.Join(srcPlaceholders, ","), strings.Join(tgtPlaceholders, ","), validityClause, pos)
+	qargs = append(qargs, limit)
+
+	rows, err := db.QueryContext(ctx, rewrite(sqlStr), qargs...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var edges []map[string]any
+	for rows.Next() {
+		var id, src, tgt, rel, props, vf, vu, sb string
+		var conf float64
+		if err := rows.Scan(&id, &src, &tgt, &rel, &props, &vf, &vu, &sb, &conf); err != nil {
+			continue
+		}
+		edges = append(edges, map[string]any{
+			"id":            id,
+			"source_id":     src,
+			"target_id":     tgt,
+			"relationship":  rel,
+			"properties":    json.RawMessage(props),
+			"valid_from":    vf,
+			"valid_until":   vu,
+			"superseded_by": sb,
+			"confidence":    conf,
+		})
+	}
+	return edges, nil
+}

--- a/Levara/pkg/mcp/tool_query_entity_test.go
+++ b/Levara/pkg/mcp/tool_query_entity_test.go
@@ -1,0 +1,237 @@
+package mcp
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	_ "github.com/ncruces/go-sqlite3/driver"
+)
+
+// setupQueryEntityDB builds the graph_nodes + graph_edges schema
+// ToolQueryEntity reads. Columns match production shape; only the
+// ones the tool scans matter for assertions.
+func setupQueryEntityDB(t *testing.T) *fakeDeps {
+	t.Helper()
+	f, _ := os.CreateTemp("", "mcp-queryentity-test-*.db")
+	path := f.Name()
+	f.Close()
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(path)
+	})
+
+	stmts := []string{
+		`CREATE TABLE graph_nodes (
+			id TEXT PRIMARY KEY, name TEXT, type TEXT, updated_at TEXT
+		)`,
+		`CREATE TABLE graph_edges (
+			id TEXT PRIMARY KEY, source_id TEXT, target_id TEXT,
+			relationship_name TEXT, properties TEXT,
+			valid_from TEXT, valid_until TEXT, superseded_by TEXT,
+			confidence REAL, updated_at TEXT
+		)`,
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+	}
+	return &fakeDeps{db: db}
+}
+
+func TestToolQueryEntity_NilDBIsError(t *testing.T) {
+	got := ToolQueryEntity(context.Background(), nilDBDeps{}, map[string]any{"name": "x"})
+	if !got.IsError {
+		t.Fatalf("nil DB: IsError = false, want true")
+	}
+}
+
+func TestToolQueryEntity_RequiresName(t *testing.T) {
+	deps := setupQueryEntityDB(t)
+	got := ToolQueryEntity(context.Background(), deps, map[string]any{})
+	if !got.IsError {
+		t.Fatalf("missing name: IsError = false, want true")
+	}
+	if !strings.Contains(got.Content[0].Text, "'name' required") {
+		t.Errorf("content = %q", got.Content[0].Text)
+	}
+}
+
+func TestToolQueryEntity_UnknownNameIsNotError(t *testing.T) {
+	// Unknown entity → specific message, IsError=false. Querying a
+	// non-existent name is a reasonable read, not a client fault.
+	deps := setupQueryEntityDB(t)
+	got := ToolQueryEntity(context.Background(), deps, map[string]any{"name": "ghost"})
+	if got.IsError {
+		t.Fatalf("IsError = true, want false for unknown name")
+	}
+	if !strings.Contains(got.Content[0].Text, "No entity found with name 'ghost'") {
+		t.Errorf("content = %q", got.Content[0].Text)
+	}
+}
+
+func TestToolQueryEntity_ReturnsActiveEdgesByDefault(t *testing.T) {
+	// Without as_of: only edges whose valid_until is NULL or in the
+	// future. An expired edge must not appear.
+	deps := setupQueryEntityDB(t)
+	deps.db.Exec(`INSERT INTO graph_nodes (id, name, type, updated_at) VALUES ('n1', 'auth', 'service', '2026-01-01T00:00:00Z')`)
+	deps.db.Exec(`INSERT INTO graph_nodes (id, name, type, updated_at) VALUES ('n2', 'db', 'service', '2026-01-01T00:00:00Z')`)
+	// Active edge (valid_until NULL).
+	deps.db.Exec(`INSERT INTO graph_edges (id, source_id, target_id, relationship_name, properties, valid_from, valid_until, superseded_by, confidence, updated_at)
+		VALUES ('e1', 'n1', 'n2', 'calls', '{}', '2026-01-01T00:00:00Z', NULL, '', 0.9, '2026-03-01T00:00:00Z')`)
+	// Expired edge (valid_until in the past).
+	deps.db.Exec(`INSERT INTO graph_edges (id, source_id, target_id, relationship_name, properties, valid_from, valid_until, superseded_by, confidence, updated_at)
+		VALUES ('e2', 'n1', 'n2', 'old_rel', '{}', '2020-01-01T00:00:00Z', '2021-01-01T00:00:00Z', '', 0.5, '2021-01-01T00:00:00Z')`)
+
+	got := ToolQueryEntity(context.Background(), deps, map[string]any{"name": "auth"})
+	if got.IsError {
+		t.Fatalf("IsError = true; content=%+v", got.Content)
+	}
+	var resp map[string]any
+	json.Unmarshal([]byte(got.Content[0].Text), &resp)
+
+	if resp["entity"] != "auth" {
+		t.Errorf("entity = %v, want auth", resp["entity"])
+	}
+	edges := resp["edges"].([]any)
+	if len(edges) != 1 {
+		t.Fatalf("got %d edges, want 1 (expired edge must be filtered)", len(edges))
+	}
+	if edges[0].(map[string]any)["id"] != "e1" {
+		t.Errorf("edge id = %v, want e1", edges[0].(map[string]any)["id"])
+	}
+}
+
+func TestToolQueryEntity_AsOfIncludesHistoricallyValid(t *testing.T) {
+	// With as_of supplied, edges whose validity window (valid_from
+	// through valid_until) includes the timestamp are returned —
+	// even if they've since expired.
+	deps := setupQueryEntityDB(t)
+	deps.db.Exec(`INSERT INTO graph_nodes (id, name, type, updated_at) VALUES ('n1', 'auth', 'service', '2026-01-01T00:00:00Z')`)
+	deps.db.Exec(`INSERT INTO graph_nodes (id, name, type, updated_at) VALUES ('n2', 'db', 'service', '2026-01-01T00:00:00Z')`)
+	// Edge valid only in 2020.
+	deps.db.Exec(`INSERT INTO graph_edges (id, source_id, target_id, relationship_name, properties, valid_from, valid_until, superseded_by, confidence, updated_at)
+		VALUES ('historic', 'n1', 'n2', 'called', '{}', '2020-01-01T00:00:00Z', '2021-01-01T00:00:00Z', '', 0.5, '2021-01-01T00:00:00Z')`)
+
+	// Snapshot at 2020-06-01 — should see the historic edge.
+	got := ToolQueryEntity(context.Background(), deps, map[string]any{
+		"name":  "auth",
+		"as_of": "2020-06-01T00:00:00Z",
+	})
+	if got.IsError {
+		t.Fatalf("IsError = true")
+	}
+	var resp map[string]any
+	json.Unmarshal([]byte(got.Content[0].Text), &resp)
+	edges := resp["edges"].([]any)
+	if len(edges) != 1 || edges[0].(map[string]any)["id"] != "historic" {
+		t.Errorf("got %+v, want single 'historic' edge", edges)
+	}
+	if resp["as_of"] != "2020-06-01T00:00:00Z" {
+		t.Errorf("as_of in response = %v, want echoed back", resp["as_of"])
+	}
+
+	// Snapshot before the edge — should be excluded (valid_from > as_of).
+	got = ToolQueryEntity(context.Background(), deps, map[string]any{
+		"name":  "auth",
+		"as_of": "2019-01-01T00:00:00Z",
+	})
+	json.Unmarshal([]byte(got.Content[0].Text), &resp)
+	edges, _ = resp["edges"].([]any)
+	if len(edges) != 0 {
+		t.Errorf("got %d edges at 2019, want 0 (valid_from is 2020)", len(edges))
+	}
+}
+
+func TestToolQueryEntity_MatchesSourceOrTarget(t *testing.T) {
+	// An edge counts if the entity's node is on EITHER side.
+	deps := setupQueryEntityDB(t)
+	deps.db.Exec(`INSERT INTO graph_nodes (id, name, type, updated_at) VALUES ('n1', 'auth', 'service', '2026-01-01T00:00:00Z')`)
+	deps.db.Exec(`INSERT INTO graph_nodes (id, name, type, updated_at) VALUES ('n2', 'db', 'service', '2026-01-01T00:00:00Z')`)
+	deps.db.Exec(`INSERT INTO graph_nodes (id, name, type, updated_at) VALUES ('n3', 'api', 'service', '2026-01-01T00:00:00Z')`)
+	// auth as source.
+	deps.db.Exec(`INSERT INTO graph_edges (id, source_id, target_id, relationship_name, properties, valid_from, valid_until, superseded_by, confidence, updated_at)
+		VALUES ('e1', 'n1', 'n2', 'calls', '{}', NULL, NULL, '', 1.0, '2026-03-01T00:00:00Z')`)
+	// auth as target.
+	deps.db.Exec(`INSERT INTO graph_edges (id, source_id, target_id, relationship_name, properties, valid_from, valid_until, superseded_by, confidence, updated_at)
+		VALUES ('e2', 'n3', 'n1', 'invokes', '{}', NULL, NULL, '', 1.0, '2026-03-02T00:00:00Z')`)
+	// unrelated edge.
+	deps.db.Exec(`INSERT INTO graph_edges (id, source_id, target_id, relationship_name, properties, valid_from, valid_until, superseded_by, confidence, updated_at)
+		VALUES ('e3', 'n2', 'n3', 'reads', '{}', NULL, NULL, '', 1.0, '2026-03-01T00:00:00Z')`)
+
+	got := ToolQueryEntity(context.Background(), deps, map[string]any{"name": "auth"})
+	var resp map[string]any
+	json.Unmarshal([]byte(got.Content[0].Text), &resp)
+	edges := resp["edges"].([]any)
+	if len(edges) != 2 {
+		t.Fatalf("got %d edges, want 2 (source + target)", len(edges))
+	}
+	// Results are ordered by updated_at DESC: e2 (Mar 2) then e1 (Mar 1).
+	ids := []string{
+		edges[0].(map[string]any)["id"].(string),
+		edges[1].(map[string]any)["id"].(string),
+	}
+	if ids[0] != "e2" || ids[1] != "e1" {
+		t.Errorf("edge order = %v, want [e2, e1] (updated_at DESC)", ids)
+	}
+}
+
+func TestToolQueryEntity_LimitBounds(t *testing.T) {
+	// The "limit" arg caps the edge count returned.
+	deps := setupQueryEntityDB(t)
+	deps.db.Exec(`INSERT INTO graph_nodes (id, name, type, updated_at) VALUES ('n1', 'auth', 'service', '2026-01-01T00:00:00Z')`)
+	deps.db.Exec(`INSERT INTO graph_nodes (id, name, type, updated_at) VALUES ('n2', 'db', 'service', '2026-01-01T00:00:00Z')`)
+	// Seed 5 edges.
+	for i := 0; i < 5; i++ {
+		deps.db.Exec(`INSERT INTO graph_edges (id, source_id, target_id, relationship_name, properties, valid_from, valid_until, superseded_by, confidence, updated_at)
+			VALUES (?, 'n1', 'n2', 'rel', '{}', NULL, NULL, '', 1.0, '2026-03-01T00:00:00Z')`,
+			"e"+string(rune('a'+i)))
+	}
+
+	got := ToolQueryEntity(context.Background(), deps, map[string]any{
+		"name":  "auth",
+		"limit": float64(2),
+	})
+	var resp map[string]any
+	json.Unmarshal([]byte(got.Content[0].Text), &resp)
+	edges := resp["edges"].([]any)
+	if len(edges) != 2 {
+		t.Errorf("got %d edges with limit=2, want 2", len(edges))
+	}
+}
+
+func TestToolQueryEntity_ResolvesMultipleNodesByName(t *testing.T) {
+	// Same entity name pointing to two nodes (imported from different
+	// sources) — both contribute to the edge search.
+	deps := setupQueryEntityDB(t)
+	deps.db.Exec(`INSERT INTO graph_nodes (id, name, type, updated_at) VALUES ('n1', 'auth', 'service', '2026-01-01T00:00:00Z')`)
+	deps.db.Exec(`INSERT INTO graph_nodes (id, name, type, updated_at) VALUES ('n2', 'auth', 'module',  '2026-01-01T00:00:00Z')`)
+	deps.db.Exec(`INSERT INTO graph_nodes (id, name, type, updated_at) VALUES ('n3', 'db',   'service', '2026-01-01T00:00:00Z')`)
+	// Edge touching n1 only.
+	deps.db.Exec(`INSERT INTO graph_edges (id, source_id, target_id, relationship_name, properties, valid_from, valid_until, superseded_by, confidence, updated_at)
+		VALUES ('eA', 'n1', 'n3', 'a', '{}', NULL, NULL, '', 1.0, '2026-03-01T00:00:00Z')`)
+	// Edge touching n2 only.
+	deps.db.Exec(`INSERT INTO graph_edges (id, source_id, target_id, relationship_name, properties, valid_from, valid_until, superseded_by, confidence, updated_at)
+		VALUES ('eB', 'n2', 'n3', 'b', '{}', NULL, NULL, '', 1.0, '2026-03-02T00:00:00Z')`)
+
+	got := ToolQueryEntity(context.Background(), deps, map[string]any{"name": "auth"})
+	var resp map[string]any
+	json.Unmarshal([]byte(got.Content[0].Text), &resp)
+	nodeIDs := resp["node_ids"].([]any)
+	if len(nodeIDs) != 2 {
+		t.Errorf("node_ids = %v, want 2 resolutions", nodeIDs)
+	}
+	edges := resp["edges"].([]any)
+	if len(edges) != 2 {
+		t.Errorf("got %d edges, want 2 (one per node)", len(edges))
+	}
+}


### PR DESCRIPTION
## Summary

Single-tool wave: \`ToolQueryEntity\` — the graph-traversal reader with optional temporal filtering. DB-only — no Deps growth (still 6 methods). Migrated-tool count hits 17/25.

## Changes

- \`pkg/mcp/deps.go\`: \`ToolQueryEntity\` + \`resolveEntityNodes\` + \`queryEntityEdges\` helpers. Two named constants (\`queryEntityNodeResolveLimit\`=10, \`queryEntityEdgeLimit\`=50) lift the inline LIMITs.
- \`pkg/mcp/tool_query_entity_test.go\`: 8 tests in a new file.
- \`internal/http/mcp_palace.go\`:
  - \`toolQueryEntity\` collapses from ~100 LOC to a one-line shim.
  - Dropped now-unused \`encoding/json\`, \`fmt\`, \`strings\` imports.

## Design note

Body split into two helpers (\`resolveEntityNodes\`, \`queryEntityEdges\`) keeps each function under 60 LOC. The original inlined both phases; splitting makes the two-phase shape explicit (name → node IDs → edges).

## Contract preservation (tested)

- **Unknown name is not an error.** Returns \"No entity found with name '%s'\" with \`IsError=false\`. Matches pre-refactor \"reads never fault the client.\"
- **Default validity filter:** only edges where \`valid_until\` is NULL or future.
- **\`as_of\` snapshot:** edges whose validity window includes the timestamp (even if now expired).
- **Source OR target match:** edge counts if entity's node is on either side.
- **Order preserved:** \`ORDER BY updated_at DESC\`.
- **Response JSON shape:** \`entity\` / \`as_of\` / \`node_ids\` / \`edges\` keys identical.
- **Multi-node name resolution:** when the same name maps to multiple nodes, all contribute.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] 8 new tests pass.
- [x] \`go test -race -count=1 ./...\` — 34 PASS / 0 FAIL.

## Migrated tools (17/25)

Delete, Prune, ListData, Add, AddFeedback, GetFeedbackStats, SetContext, ListMemories, PinMemory, UnpinMemory, WakeUp, SaveChat, RecallChat, SearchChats, DiaryWrite, DiaryRead, QueryEntity.

## Remaining

- **3i — SaveMemory + RecallMemory.** First AI dep on Deps (needs Embed + CollectionsSearch).
- **3j — CognifyStatus + Cognify.** Blocked on \`pipelineRuns sync.Map\` decoupling.
- **3k+ — big tools:** Search, Cognify, CrossSearch, Sync, GetProjectContext, AnalyzeCommits, GitSearch, Codify, CheckDrift, PruneGraph, ListCommunities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)