### PR TITLE
refactor(mcp): F-4 wave 3j-prep — extract pipeline-run registry into pkg/runreg

### DIFF
--- a/Levara/cmd/server/main.go
+++ b/Levara/cmd/server/main.go
@@ -65,6 +65,7 @@ import (
 	"github.com/stek0v/cognevra/pkg/llmproxy"
 	"github.com/stek0v/cognevra/pkg/observe"
 	"github.com/stek0v/cognevra/pkg/router"
+	"github.com/stek0v/cognevra/pkg/runreg"
 	"github.com/stek0v/cognevra/pkg/storage"
 	pb "github.com/stek0v/cognevra/proto/pb"
 	"google.golang.org/grpc"
@@ -470,6 +471,11 @@ func main() {
 	// Adaptive router weights (feedback-driven learning)
 	adaptiveWeights := router.NewAdaptiveWeights(pgDB, 0.1)
 
+	// Shared background-pipeline registry. Must be the same *runreg.Registry
+	// for both REST and MCP so a cognify run started via /api/v1/cognify is
+	// visible to MCP's cognify_status, and vice versa.
+	runs := runreg.New()
+
 	// Protected routes: Cognee-compatible API (datasets, upload, cognify, search)
 	vectorHttp.RegisterCogneeAPI(api, vectorHttp.APIConfig{
 		PostgresDSN:     pgDSN,
@@ -486,18 +492,20 @@ func main() {
 		FileStorage:     fileStore,
 		Logger:          srvLog,
 		AdaptiveWeights: adaptiveWeights,
+		Runs:            runs,
 	})
 
 	// MCP (Model Context Protocol) server — JSON-RPC 2.0 for AI agent integration
 	vectorHttp.RegisterMCPAPI(app, vectorHttp.APIConfig{
-		EmbedEndpoint:   embedEndpoint,
-		EmbedModel:      embedModel,
-		Collections:     colManager,
-		DB:              pgDB,
-		BM25Indexes:     grpcSvc.BM25Indexes(),
-		LLMCache:        llmCache,
-		RerankEndpoint:  os.Getenv("RERANK_ENDPOINT"),
-		RerankModel:     os.Getenv("RERANK_MODEL"),
+		EmbedEndpoint:  embedEndpoint,
+		EmbedModel:     embedModel,
+		Collections:    colManager,
+		DB:             pgDB,
+		BM25Indexes:    grpcSvc.BM25Indexes(),
+		LLMCache:       llmCache,
+		RerankEndpoint: os.Getenv("RERANK_ENDPOINT"),
+		RerankModel:    os.Getenv("RERANK_MODEL"),
+		Runs:           runs,
 	})
 
 	// Cache stats endpoint

--- a/Levara/internal/http/api.go
+++ b/Levara/internal/http/api.go
@@ -38,6 +38,7 @@ import (
 	"github.com/stek0v/cognevra/pkg/orchestrator"
 	"github.com/stek0v/cognevra/pkg/rerank"
 	"github.com/stek0v/cognevra/pkg/router"
+	"github.com/stek0v/cognevra/pkg/runreg"
 	"github.com/stek0v/cognevra/pkg/storage"
 	"github.com/stek0v/cognevra/pkg/temporal"
 	"github.com/stek0v/cognevra/pipeline"
@@ -64,6 +65,10 @@ type APIConfig struct {
 	RerankTimeoutMs int    // HTTP timeout in ms, 0 = default 5000ms
 	// Adaptive router (feedback-driven weight learning)
 	AdaptiveWeights *router.AdaptiveWeights // nil = no adaptive routing
+	// Runs tracks background cognify / analyze-commits pipelines. Must be
+	// the same *runreg.Registry as the one passed to RegisterMCPAPI so that
+	// MCP clients can poll REST-initiated runs and vice versa.
+	Runs *runreg.Registry
 }
 
 // RegisterCogneeAPI registers all Cognee-compatible endpoints on the Fiber app.
@@ -92,8 +97,8 @@ func RegisterCogneeAPI(app fiber.Router, cfg APIConfig) {
 
 	// U4: Cognify trigger + status + SSE stream
 	app.Post("/cognify", cognifyHandler(cfg))
-	app.Get("/cognify/:runId/status", cognifyStatusHandler())
-	app.Get("/cognify/:runId/stream", cognifyStreamHandler())
+	app.Get("/cognify/:runId/status", cognifyStatusHandler(cfg))
+	app.Get("/cognify/:runId/stream", cognifyStreamHandler(cfg))
 
 	// U6: Memify — post-cognify graph enrichment + SSE stream
 	app.Post("/memify", memifyHandler(cfg))
@@ -537,21 +542,10 @@ func addHandler(cfg APIConfig) fiber.Handler {
 }
 
 // ── U4: Cognify ──
-
-// pipelineRuns tracks background cognify pipeline statuses.
-var pipelineRuns sync.Map // runID → *pipelineRunStatus
-
-type pipelineRunStatus struct {
-	RunID     string    `json:"pipeline_run_id"`
-	Status    string    `json:"status"` // RUNNING, COMPLETED, FAILED
-	Stage     string    `json:"stage"`
-	Message   string    `json:"message"`
-	Chunks    int       `json:"chunks_created"`
-	Entities  int       `json:"entities_extracted"`
-	Edges     int       `json:"edges_extracted"`
-	ElapsedMs int64     `json:"elapsed_ms"`
-	StartedAt time.Time `json:"started_at"`
-}
+//
+// Background run status lives in pkg/runreg. F-4 wave 3j-prep moved the
+// package-level sync.Map + pipelineRunStatus type into that package so the
+// cognify tools in pkg/mcp can share it without importing internal/http.
 
 // PersistPipelineStatus writes pipeline completion status to the data table.
 // Called after cognify finishes (success or failure) to enable skip-if-done.
@@ -755,13 +749,13 @@ func cognifyHandler(cfg APIConfig) fiber.Handler {
 			})
 		}
 
-		runStatus := &pipelineRunStatus{
+		runStatus := &runreg.Status{
 			RunID:     runID,
 			Status:    "RUNNING",
 			Stage:     "starting",
 			StartedAt: time.Now(),
 		}
-		pipelineRuns.Store(runID, runStatus)
+		cfg.Runs.Store(runID, runStatus)
 
 		// P2.1: Load session context if session_id provided
 		var sessionContext string
@@ -851,10 +845,10 @@ func cognifyHandler(cfg APIConfig) fiber.Handler {
 	}
 }
 
-func cognifyStatusHandler() fiber.Handler {
+func cognifyStatusHandler(cfg APIConfig) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		runID := c.Params("runId")
-		if val, ok := pipelineRuns.Load(runID); ok {
+		if val, ok := cfg.Runs.Load(runID); ok {
 			return c.JSON(val)
 		}
 		return c.Status(404).JSON(fiber.Map{"detail": "run not found"})
@@ -864,10 +858,10 @@ func cognifyStatusHandler() fiber.Handler {
 // cognifyStreamHandler streams pipeline progress via Server-Sent Events (SSE).
 // GET /cognify/:runId/stream
 // React frontend: const es = new EventSource("/api/v1/cognify/{runId}/stream")
-func cognifyStreamHandler() fiber.Handler {
+func cognifyStreamHandler(cfg APIConfig) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		runID := c.Params("runId")
-		if _, ok := pipelineRuns.Load(runID); !ok {
+		if _, ok := cfg.Runs.Load(runID); !ok {
 			return c.Status(404).JSON(fiber.Map{"detail": "run not found"})
 		}
 
@@ -879,13 +873,12 @@ func cognifyStreamHandler() fiber.Handler {
 		c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
 			lastStage := ""
 			for {
-				val, ok := pipelineRuns.Load(runID)
+				status, ok := cfg.Runs.Load(runID)
 				if !ok {
 					fmt.Fprintf(w, "event: error\ndata: {\"error\":\"run not found\"}\n\n")
 					w.Flush()
 					return
 				}
-				status := val.(*pipelineRunStatus)
 
 				// Send update if stage changed or terminal
 				if status.Stage != lastStage || status.Status != "RUNNING" {

--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stek0v/cognevra/pkg/orchestrator"
 	"github.com/stek0v/cognevra/pkg/rerank"
 	"github.com/stek0v/cognevra/pkg/router"
+	"github.com/stek0v/cognevra/pkg/runreg"
 	"github.com/stek0v/cognevra/pipeline"
 )
 
@@ -429,10 +430,10 @@ func (h *mcpHandler) toolCognify(ctx context.Context, args map[string]any) mcpTo
 		collection = "default"
 	}
 
-	status := &pipelineRunStatus{
+	status := &runreg.Status{
 		RunID: runID, Status: "RUNNING", Stage: "starting", StartedAt: time.Now(),
 	}
-	pipelineRuns.Store(runID, status)
+	h.cfg.Runs.Store(runID, status)
 
 	// Validate that embedding service is configured
 	if h.cfg.EmbedEndpoint == "" {
@@ -798,7 +799,7 @@ func (h *mcpHandler) toolCognifyStatus(args map[string]any) mcpToolResult {
 		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: 'run_id' required"}}, IsError: true}
 	}
 
-	val, ok := pipelineRuns.Load(runID)
+	val, ok := h.cfg.Runs.Load(runID)
 	if !ok {
 		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: fmt.Sprintf("Run %s not found.", runID)}}, IsError: true}
 	}
@@ -845,10 +846,10 @@ func (h *mcpHandler) toolAnalyzeCommits(ctx context.Context, args map[string]any
 		runID := uuid.New().String()
 		collection := "git_commits"
 
-		status := &pipelineRunStatus{
+		status := &runreg.Status{
 			RunID: runID, Status: "RUNNING", Stage: "starting", StartedAt: time.Now(),
 		}
-		pipelineRuns.Store(runID, status)
+		h.cfg.Runs.Store(runID, status)
 
 		pipeCfg := orchestrator.Config{
 			ChunkStrategy:  "merged",

--- a/Levara/pkg/runreg/runreg.go
+++ b/Levara/pkg/runreg/runreg.go
@@ -1,0 +1,54 @@
+// Package runreg is an in-memory registry of background pipeline runs
+// (cognify, analyze-commits, ...). It was extracted from internal/http as
+// preparation for F-4 wave 3j, which moves the cognify tools out of
+// internal/http and into pkg/mcp. The registry is the shared mutable state
+// those tools need, so it must live in a neutral package both packages can
+// import without creating a cycle.
+//
+// Behavior matches the pre-refactor sync.Map: each run is a *Status pointer
+// and Store/Load callers mutate the struct directly. Fire-and-forget update
+// goroutines therefore do not require the registry to expose an update API.
+package runreg
+
+import (
+	"sync"
+	"time"
+)
+
+// Status is the public view of a single background run. JSON tags match the
+// pre-refactor internal/http.pipelineRunStatus so REST and SSE clients see
+// identical payloads.
+type Status struct {
+	RunID     string    `json:"pipeline_run_id"`
+	Status    string    `json:"status"` // RUNNING, COMPLETED, FAILED
+	Stage     string    `json:"stage"`
+	Message   string    `json:"message"`
+	Chunks    int       `json:"chunks_created"`
+	Entities  int       `json:"entities_extracted"`
+	Edges     int       `json:"edges_extracted"`
+	ElapsedMs int64     `json:"elapsed_ms"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+// Registry stores *Status by run ID. Safe for concurrent use. The zero value
+// is usable but prefer New() for clarity at the call site.
+type Registry struct {
+	runs sync.Map // runID → *Status
+}
+
+// New returns an empty Registry.
+func New() *Registry { return &Registry{} }
+
+// Store associates s with runID, overwriting any previous value.
+func (r *Registry) Store(runID string, s *Status) {
+	r.runs.Store(runID, s)
+}
+
+// Load returns the Status for runID, or nil and false if absent.
+func (r *Registry) Load(runID string) (*Status, bool) {
+	v, ok := r.runs.Load(runID)
+	if !ok {
+		return nil, false
+	}
+	return v.(*Status), true
+}

--- a/Levara/pkg/runreg/runreg_test.go
+++ b/Levara/pkg/runreg/runreg_test.go
@@ -1,0 +1,125 @@
+package runreg
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRegistry_StoreLoadRoundTrip(t *testing.T) {
+	r := New()
+	s := &Status{
+		RunID:     "abc",
+		Status:    "RUNNING",
+		Stage:     "chunk",
+		Chunks:    3,
+		StartedAt: time.Unix(0, 0),
+	}
+	r.Store("abc", s)
+
+	got, ok := r.Load("abc")
+	if !ok {
+		t.Fatal("Load after Store returned ok=false")
+	}
+	if got != s {
+		t.Errorf("Load returned a different pointer (got %p want %p)", got, s)
+	}
+}
+
+func TestRegistry_LoadAbsent(t *testing.T) {
+	r := New()
+	got, ok := r.Load("missing")
+	if ok {
+		t.Error("Load on empty registry returned ok=true")
+	}
+	if got != nil {
+		t.Errorf("Load on empty registry returned non-nil pointer: %+v", got)
+	}
+}
+
+func TestRegistry_StoreOverwrites(t *testing.T) {
+	r := New()
+	first := &Status{RunID: "x", Status: "RUNNING"}
+	second := &Status{RunID: "x", Status: "COMPLETED"}
+	r.Store("x", first)
+	r.Store("x", second)
+	got, _ := r.Load("x")
+	if got != second {
+		t.Errorf("Store should overwrite; got %p want %p", got, second)
+	}
+}
+
+func TestRegistry_MutationThroughLoadedPointerIsVisible(t *testing.T) {
+	// This is the pre-refactor contract: background goroutines mutate the
+	// struct they stored and readers see those changes through Load. Lock
+	// it in so future refactors that copy the value by mistake blow up here.
+	r := New()
+	s := &Status{RunID: "r1", Status: "RUNNING"}
+	r.Store("r1", s)
+	s.Status = "COMPLETED"
+	s.Message = "done"
+
+	got, _ := r.Load("r1")
+	if got.Status != "COMPLETED" || got.Message != "done" {
+		t.Errorf("Load did not observe mutations: %+v", got)
+	}
+}
+
+func TestRegistry_ConcurrentStoreLoad(t *testing.T) {
+	// Smoke test: hammer Store+Load from many goroutines, expect no races
+	// under -race and no panics from the underlying sync.Map.
+	r := New()
+	var wg sync.WaitGroup
+	const goroutines = 32
+	const perG = 200
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < perG; i++ {
+				id := "run-" + string(rune('a'+g%26))
+				r.Store(id, &Status{RunID: id, Status: "RUNNING"})
+				r.Load(id)
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+func TestStatus_JSONTagsMatchPreRefactor(t *testing.T) {
+	// The REST/SSE clients consume these fields verbatim; changing a tag
+	// would be a silent breaking change. Guard them here.
+	s := Status{
+		RunID:     "id1",
+		Status:    "COMPLETED",
+		Stage:     "done",
+		Message:   "ok",
+		Chunks:    1,
+		Entities:  2,
+		Edges:     3,
+		ElapsedMs: 42,
+		StartedAt: time.Unix(1, 0).UTC(),
+	}
+	out, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := []string{
+		`"pipeline_run_id":"id1"`,
+		`"status":"COMPLETED"`,
+		`"stage":"done"`,
+		`"message":"ok"`,
+		`"chunks_created":1`,
+		`"entities_extracted":2`,
+		`"edges_extracted":3`,
+		`"elapsed_ms":42`,
+	}
+	got := string(out)
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("marshal missing %s; got %s", w, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Preparatory refactor for wave 3j (migrating `toolCognify` + `toolCognifyStatus` into `pkg/mcp`). Extracts the shared background-pipeline run registry out of `internal/http` into a neutral `pkg/runreg` so `pkg/mcp` and `internal/http` can both use it without import cycles.

- **`pkg/runreg`** — `Registry` wraps a `sync.Map`, typed `Load(id) (*Status, bool)` / `Store(id, *Status)`. `Status` preserves every JSON tag from the old `pipelineRunStatus` verbatim, so REST + SSE payloads remain byte-identical.
- **`internal/http`** — deletes `var pipelineRuns sync.Map` and `type pipelineRunStatus`; adds `Runs *runreg.Registry` to `APIConfig`; `cognifyStatusHandler`/`cognifyStreamHandler` now take `cfg`; MCP tools (`toolCognify`, `toolCognifyStatus`, `toolAnalyzeCommits`) reach the registry via `h.cfg.Runs`.
- **`cmd/server/main.go`** — single `runs := runreg.New()` is shared between `RegisterCogneeAPI` and `RegisterMCPAPI` so `cognify_status` can observe runs started via `/api/v1/cognify` (and vice versa).

## Behavior preserved

- Identical JSON tags (`pipeline_run_id`, `chunks_created`, `entities_extracted`, ...).
- Same `404 {"detail": "run not found"}` from REST status + stream.
- Same stored-pointer contract: update goroutines mutate `Status` fields through the stored pointer; SSE reads them back. A test in `pkg/runreg` locks in this contract so future "safe" refactors don't silently switch to copy-by-value.
- No new synchronization — the pre-refactor code was already relying on `sync.Map` + mutate-through-pointer. Nothing changes about the race-detector surface.

## Why split this PR

Per the F-4 wave plan in memory: wave 3j-prep is a pure move with no interface growth on `mcp.Deps`. Shipping it alone keeps the diff mechanical and reviewable. Wave 3j will add the actual `Deps` methods (`Runs() *runreg.Registry` or narrower `RunStore` methods) and migrate the tool bodies.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` → 35 PASS / 0 FAIL (new `pkg/runreg` adds one)
- [x] `pkg/runreg/runreg_test.go` covers: Store/Load round-trip, absent Load, Store overwrites, mutate-through-loaded-pointer, concurrent hammer under `-race`, JSON-tag regression guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)