### PR TITLE
refactor(mcp): F-4 wave 3n — ToolListCommunities + ToolPruneGraph move behind Deps

### DIFF
--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 	"github.com/stek0v/cognevra/internal/metrics"
-	"github.com/stek0v/cognevra/pkg/community"
 	"github.com/stek0v/cognevra/pkg/embed"
 	"github.com/stek0v/cognevra/pkg/extract"
 	"github.com/stek0v/cognevra/pkg/llm"
@@ -1369,87 +1368,13 @@ func strIn(s string, list []string) bool {
 	return false
 }
 
-// toolListCommunities returns detected communities from graph_communities table.
+// toolListCommunities is a thin shim over mcp.ToolListCommunities. F-4
+// wave 3n moved the body (SQL query + JSON marshal) into pkg/mcp. No
+// new Deps methods — DB() and Q() were already in the interface.
 func (h *mcpHandler) toolListCommunities(ctx context.Context, args map[string]any) mcpToolResult {
-	if h.cfg.DB == nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "[]"}}}
-	}
-
-	limit := 20
-	if lim, ok := args["limit"].(float64); ok && lim > 0 {
-		limit = int(lim)
-	}
-	minMembers := 2
-	if mm, ok := args["min_members"].(float64); ok {
-		minMembers = int(mm)
-	}
-
-	query := "SELECT id, level, parent_id, member_count, summary FROM graph_communities WHERE member_count >= ? ORDER BY level ASC, member_count DESC LIMIT ?"
-	queryArgs := []any{minMembers, limit}
-
-	if levelVal, ok := args["level"].(float64); ok {
-		query = "SELECT id, level, parent_id, member_count, summary FROM graph_communities WHERE member_count >= ? AND level = ? ORDER BY member_count DESC LIMIT ?"
-		queryArgs = []any{minMembers, int(levelVal), limit}
-	}
-
-	rows, err := h.cfg.DB.QueryContext(ctx, query, queryArgs...)
-	if err != nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "[]"}}}
-	}
-	defer rows.Close()
-
-	var communities []map[string]any
-	for rows.Next() {
-		var id, parentID, summary string
-		var level, memberCount int
-		if rows.Scan(&id, &level, &parentID, &memberCount, &summary) != nil {
-			continue
-		}
-		communities = append(communities, map[string]any{
-			"id": id, "level": level, "parent_id": parentID,
-			"member_count": memberCount, "summary": summary,
-		})
-	}
-
-	if communities == nil {
-		communities = []map[string]any{}
-	}
-
-	out, _ := json.MarshalIndent(communities, "", "  ")
-	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(out)}}}
+	return mcp.ToolListCommunities(ctx, h, args)
 }
 
-// searchTypesForMode returns allowed search types for a given mode.
-// Returns nil (= all allowed) for "full" and "auto".
-func searchTypesForMode(mode string) map[string]bool {
-	switch mode {
-	case "rag":
-		return map[string]bool{
-			"CHUNKS": true, "HYBRID": true, "CHUNKS_LEXICAL": true,
-			"RAG_COMPLETION": true, "SUMMARIES": true, "WEIGHTED_HYBRID": true,
-		}
-	case "graph":
-		return map[string]bool{
-			"GRAPH_COMPLETION": true, "GRAPH_COMPLETION_COT": true,
-			"GRAPH_COMPLETION_CONTEXT_EXTENSION": true, "GRAPH_SUMMARY_COMPLETION": true,
-			"COMMUNITY_LOCAL": true, "COMMUNITY_GLOBAL": true,
-			"CYPHER": true, "TRIPLET_COMPLETION": true, "TEMPORAL": true,
-		}
-	default:
-		return nil
-	}
-}
-
-func defaultTypeForMode(mode string) string {
-	switch mode {
-	case "rag":
-		return "CHUNKS"
-	case "graph":
-		return "GRAPH_COMPLETION"
-	default:
-		return "AUTO"
-	}
-}
 
 // toolCheckDrift reports embedding model drift across collections.
 func (h *mcpHandler) toolCheckDrift(ctx context.Context, args map[string]any) mcpToolResult {
@@ -1476,36 +1401,9 @@ func (h *mcpHandler) toolCheckDrift(ctx context.Context, args map[string]any) mc
 	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(out)}}}
 }
 
-// toolPruneGraph cleans up old superseded graph edges.
+// toolPruneGraph is a thin shim over mcp.ToolPruneGraph. F-4 wave 3n
+// moved the body (community.PruneGraph + LogHeartbeat) into pkg/mcp.
+// No new Deps methods — DB() and LogHeartbeat() already in interface.
 func (h *mcpHandler) toolPruneGraph(ctx context.Context, args map[string]any) mcpToolResult {
-	if h.cfg.DB == nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: `{"edges_deleted":0}`}}}
-	}
-
-	cfg := community.PruneConfig{
-		MaxAgeDays:      90,
-		KeepSuperseding: true,
-		DryRun:          true,
-	}
-	if days, ok := args["max_age_days"].(float64); ok && days > 0 {
-		cfg.MaxAgeDays = int(days)
-	}
-	if dr, ok := args["dry_run"].(bool); ok {
-		cfg.DryRun = dr
-	}
-	if io, ok := args["include_orphan_nodes"].(bool); ok {
-		cfg.IncludeOrphans = io
-	}
-
-	result, err := community.PruneGraph(ctx, h.cfg.DB, cfg)
-	if err != nil {
-		return mcpToolResult{
-			Content: []mcpContent{{Type: "text", Text: fmt.Sprintf("Error: %v", err)}},
-			IsError: true,
-		}
-	}
-
-	h.logHeartbeat("prune", result)
-	out, _ := json.MarshalIndent(result, "", "  ")
-	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(out)}}}
+	return mcp.ToolPruneGraph(ctx, h, args)
 }

--- a/Levara/pkg/mcp/tool_community.go
+++ b/Levara/pkg/mcp/tool_community.go
@@ -1,0 +1,123 @@
+package mcp
+
+// Graph community tools: list_communities + prune_graph.
+// Migrated in F-4 wave 3n. Grouped together because both operate on
+// graph metadata and neither needs new Deps methods — DB() and
+// LogHeartbeat() were added in earlier waves.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/stek0v/cognevra/pkg/community"
+)
+
+// ToolListCommunities queries the graph_communities table and returns a
+// JSON array of community objects. Returns "[]" (not IsError) on nil DB
+// or SQL error — empty is a valid state for graphs with no communities
+// yet.
+//
+// Args: limit (float64, default 20), min_members (float64, default 2),
+// level (float64, optional).
+func ToolListCommunities(ctx context.Context, deps Deps, args map[string]any) ToolResult {
+	db := deps.DB()
+	if db == nil {
+		return ToolResult{Content: []Content{{Type: "text", Text: "[]"}}}
+	}
+
+	limit := 20
+	if lim, ok := args["limit"].(float64); ok && lim > 0 {
+		limit = int(lim)
+	}
+	minMembers := 2
+	if mm, ok := args["min_members"].(float64); ok {
+		minMembers = int(mm)
+	}
+
+	var (
+		query     string
+		queryArgs []any
+	)
+	if levelVal, ok := args["level"].(float64); ok {
+		query = deps.Q(`SELECT id, level, parent_id, member_count, summary
+			FROM graph_communities
+			WHERE member_count >= $1 AND level = $2
+			ORDER BY member_count DESC LIMIT $3`)
+		queryArgs = []any{minMembers, int(levelVal), limit}
+	} else {
+		query = deps.Q(`SELECT id, level, parent_id, member_count, summary
+			FROM graph_communities
+			WHERE member_count >= $1
+			ORDER BY level ASC, member_count DESC LIMIT $2`)
+		queryArgs = []any{minMembers, limit}
+	}
+
+	rows, err := db.QueryContext(ctx, query, queryArgs...)
+	if err != nil {
+		return ToolResult{Content: []Content{{Type: "text", Text: "[]"}}}
+	}
+	defer rows.Close()
+
+	var communities []map[string]any
+	for rows.Next() {
+		var id, parentID, summary string
+		var level, memberCount int
+		if rows.Scan(&id, &level, &parentID, &memberCount, &summary) != nil {
+			continue
+		}
+		communities = append(communities, map[string]any{
+			"id": id, "level": level, "parent_id": parentID,
+			"member_count": memberCount, "summary": summary,
+		})
+	}
+
+	if communities == nil {
+		communities = []map[string]any{}
+	}
+
+	out, _ := json.MarshalIndent(communities, "", "  ")
+	return ToolResult{Content: []Content{{Type: "text", Text: string(out)}}}
+}
+
+// ToolPruneGraph removes superseded graph edges (and optionally orphan
+// nodes) according to community.PruneConfig. Defaults to dry-run=true
+// so the first call is always a preview.
+//
+// Args: max_age_days (float64), dry_run (bool), include_orphan_nodes (bool).
+//
+// Error branch: DB nil → `{"edges_deleted":0}` (not IsError);
+// community.PruneGraph error → IsError.
+func ToolPruneGraph(ctx context.Context, deps Deps, args map[string]any) ToolResult {
+	db := deps.DB()
+	if db == nil {
+		return ToolResult{Content: []Content{{Type: "text", Text: `{"edges_deleted":0}`}}}
+	}
+
+	cfg := community.PruneConfig{
+		MaxAgeDays:      90,
+		KeepSuperseding: true,
+		DryRun:          true,
+	}
+	if days, ok := args["max_age_days"].(float64); ok && days > 0 {
+		cfg.MaxAgeDays = int(days)
+	}
+	if dr, ok := args["dry_run"].(bool); ok {
+		cfg.DryRun = dr
+	}
+	if io, ok := args["include_orphan_nodes"].(bool); ok {
+		cfg.IncludeOrphans = io
+	}
+
+	result, err := community.PruneGraph(ctx, db, cfg)
+	if err != nil {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: fmt.Sprintf("Error: %v", err)}},
+			IsError: true,
+		}
+	}
+
+	deps.LogHeartbeat("prune", result)
+	out, _ := json.MarshalIndent(result, "", "  ")
+	return ToolResult{Content: []Content{{Type: "text", Text: string(out)}}}
+}

--- a/Levara/pkg/mcp/tool_community_test.go
+++ b/Levara/pkg/mcp/tool_community_test.go
@@ -1,0 +1,206 @@
+package mcp
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// setupCommunityDB creates a SQLite test DB with the tables that
+// ToolListCommunities and ToolPruneGraph need.
+func setupCommunityDB(t *testing.T) *fakeDeps {
+	t.Helper()
+	f, _ := os.CreateTemp("", "mcp-community-test-*.db")
+	path := f.Name()
+	f.Close()
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(path)
+	})
+
+	_, err = db.Exec(`
+		CREATE TABLE graph_communities (
+			id TEXT PRIMARY KEY,
+			level INTEGER NOT NULL DEFAULT 0,
+			parent_id TEXT NOT NULL DEFAULT '',
+			member_count INTEGER NOT NULL DEFAULT 0,
+			summary TEXT NOT NULL DEFAULT ''
+		);
+		CREATE TABLE graph_edges (
+			id TEXT PRIMARY KEY,
+			source_id TEXT NOT NULL,
+			target_id TEXT NOT NULL,
+			relationship_name TEXT NOT NULL,
+			properties TEXT NOT NULL DEFAULT '{}',
+			superseded_by TEXT NOT NULL DEFAULT '',
+			valid_until TEXT
+		);
+		CREATE TABLE graph_nodes (
+			id TEXT PRIMARY KEY,
+			name TEXT,
+			type TEXT,
+			description TEXT,
+			properties TEXT
+		);
+		CREATE TABLE community_members (
+			id TEXT PRIMARY KEY,
+			community_id TEXT NOT NULL,
+			node_id TEXT NOT NULL
+		);
+	`)
+	if err != nil {
+		t.Fatalf("create tables: %v", err)
+	}
+	return &fakeDeps{db: db}
+}
+
+// ── ToolListCommunities ──
+
+func TestToolListCommunities_NilDB(t *testing.T) {
+	res := ToolListCommunities(context.Background(), nilDBDeps{}, map[string]any{})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	if res.Content[0].Text != "[]" {
+		t.Errorf("want []  got %q", res.Content[0].Text)
+	}
+}
+
+func TestToolListCommunities_EmptyTable(t *testing.T) {
+	deps := setupCommunityDB(t)
+	res := ToolListCommunities(context.Background(), deps, map[string]any{})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	var out []map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &out); err != nil {
+		t.Fatalf("response not JSON: %s", res.Content[0].Text)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected empty array, got %d items", len(out))
+	}
+}
+
+func TestToolListCommunities_ReturnsRows(t *testing.T) {
+	deps := setupCommunityDB(t)
+	db := deps.db
+
+	db.Exec(`INSERT INTO graph_communities (id, level, parent_id, member_count, summary)
+		VALUES ('c1', 0, '', 5, 'auth'), ('c2', 1, 'c1', 3, 'users')`)
+
+	res := ToolListCommunities(context.Background(), deps, map[string]any{})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	var out []map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &out); err != nil {
+		t.Fatalf("response not JSON: %s", res.Content[0].Text)
+	}
+	if len(out) != 2 {
+		t.Errorf("expected 2 rows, got %d", len(out))
+	}
+	// Spot-check first result has all expected fields.
+	if _, ok := out[0]["id"]; !ok {
+		t.Error("missing 'id' field")
+	}
+	if _, ok := out[0]["member_count"]; !ok {
+		t.Error("missing 'member_count' field")
+	}
+}
+
+func TestToolListCommunities_LevelFilter(t *testing.T) {
+	deps := setupCommunityDB(t)
+	db := deps.db
+
+	db.Exec(`INSERT INTO graph_communities (id, level, parent_id, member_count, summary)
+		VALUES ('c1', 0, '', 5, 'L0'), ('c2', 1, 'c1', 3, 'L1'), ('c3', 0, '', 4, 'L0b')`)
+
+	res := ToolListCommunities(context.Background(), deps, map[string]any{
+		"level": float64(0),
+	})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	var out []map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &out); err != nil {
+		t.Fatalf("response not JSON: %s", res.Content[0].Text)
+	}
+	// Only level=0 rows (c1, c3).
+	if len(out) != 2 {
+		t.Errorf("level filter: expected 2, got %d", len(out))
+	}
+}
+
+func TestToolListCommunities_MinMembersFilter(t *testing.T) {
+	deps := setupCommunityDB(t)
+	db := deps.db
+
+	db.Exec(`INSERT INTO graph_communities (id, level, parent_id, member_count, summary)
+		VALUES ('c1', 0, '', 5, 'big'), ('c2', 0, '', 1, 'tiny')`)
+
+	res := ToolListCommunities(context.Background(), deps, map[string]any{
+		"min_members": float64(3),
+	})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	var out []map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &out); err != nil {
+		t.Fatalf("response not JSON: %s", res.Content[0].Text)
+	}
+	if len(out) != 1 {
+		t.Errorf("min_members filter: expected 1, got %d", len(out))
+	}
+}
+
+// ── ToolPruneGraph ──
+
+func TestToolPruneGraph_NilDB(t *testing.T) {
+	res := ToolPruneGraph(context.Background(), nilDBDeps{}, map[string]any{})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	if !strings.Contains(res.Content[0].Text, "edges_deleted") {
+		t.Errorf("expected edges_deleted in response, got %q", res.Content[0].Text)
+	}
+}
+
+func TestToolPruneGraph_DryRunDefault(t *testing.T) {
+	deps := setupCommunityDB(t)
+
+	res := ToolPruneGraph(context.Background(), deps, map[string]any{})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &out); err != nil {
+		t.Fatalf("response not JSON: %s", res.Content[0].Text)
+	}
+	// Default is dry_run=true → edges_would_delete present, edges_deleted=0.
+	if out["edges_deleted"] != float64(0) {
+		t.Errorf("edges_deleted=%v, want 0", out["edges_deleted"])
+	}
+}
+
+func TestToolPruneGraph_HeartbeatFired(t *testing.T) {
+	deps := setupCommunityDB(t)
+	fired := false
+	deps.heartbeatFn = func(eventType string, payload any) {
+		if eventType == "prune" {
+			fired = true
+		}
+	}
+
+	ToolPruneGraph(context.Background(), deps, map[string]any{})
+	if !fired {
+		t.Error("heartbeat 'prune' not fired")
+	}
+}


### PR DESCRIPTION
## Summary
- **ToolListCommunities** migrated to `pkg/mcp/tool_community.go`; raw `?` SQLite placeholders converted to `deps.Q($N)` for portability
- **ToolPruneGraph** migrated to same file; wraps `community.PruneGraph` + `LogHeartbeat`, default dry_run=true preserved
- **Orphaned cleanup**: removed `searchTypesForMode` + `defaultTypeForMode` from `internal/http/mcp.go` (exact duplicates of copies in `pkg/mcp/tool_search.go` since wave 3k)
- **Import cleanup**: dropped `pkg/community` from `internal/http` imports (no longer needed there)
- No new Deps interface methods — DB() + Q() + LogHeartbeat() already sufficient

## Test plan
- [x] 8 new tests in `pkg/mcp/tool_community_test.go`: nil DB guard, empty table, rows returned, level filter, min_members filter, dry-run default, heartbeat fired
- [x] 35/35 packages pass `go test -race ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)