### PR TITLE
refactor(mcp): F-4 wave 3o — ToolGetProjectContext + ToolCheckDrift move behind Deps

### DIFF
--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -291,6 +291,28 @@ func (h *mcpHandler) SearchCapabilities() router.Capabilities {
 	return capabilitiesFromConfig(h.cfg)
 }
 
+// CollectionMeta implements mcp.Deps: returns observable metadata for the
+// named collection without exposing the internal/store.CollectionMeta pointer
+// to pkg/mcp. Returns zero CollectionInfo when the collection manager is nil
+// or the collection doesn't exist. Added in F-4 wave 3o for
+// toolGetProjectContext and toolCheckDrift.
+func (h *mcpHandler) CollectionMeta(name string) mcp.CollectionInfo {
+	if h.cfg.Collections == nil {
+		return mcp.CollectionInfo{}
+	}
+	m := h.cfg.Collections.GetMeta(name)
+	if m == nil {
+		return mcp.CollectionInfo{}
+	}
+	return mcp.CollectionInfo{
+		Name:       m.Name,
+		Records:    m.RecordCount,
+		Dim:        m.EmbeddingDim,
+		Metric:     m.DistanceMetric,
+		EmbedModel: m.EmbeddingModel,
+	}
+}
+
 // getOrValidateSession returns the session for the given ID, or nil if invalid.
 func (h *mcpHandler) getOrValidateSession(sessionID string) *mcpSession {
 	return h.sessions.Get(sessionID)
@@ -1142,123 +1164,13 @@ func syncPushCollections(ctx context.Context, cfg APIConfig, remoteURL string, c
 	return results
 }
 
+// toolGetProjectContext is a thin shim over mcp.ToolGetProjectContext.
+// F-4 wave 3o moved the body (collection stats + memories + graph
+// entities + interactions + related projects) into pkg/mcp. Uses the
+// new CollectionMeta Deps method for vector stats so pkg/mcp stays free
+// of internal/store pointers.
 func (h *mcpHandler) toolGetProjectContext(ctx context.Context, args map[string]any) mcpToolResult {
-	collection, _ := args["collection"].(string)
-	if collection == "" {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: 'collection' required"}}, IsError: true}
-	}
-
-	var sb strings.Builder
-
-	// 1. Collection stats
-	sb.WriteString("## Collection Stats\n")
-	if h.cfg.Collections != nil {
-		meta := h.cfg.Collections.GetMeta(collection)
-		if meta != nil {
-			sb.WriteString(fmt.Sprintf("- Name: %s\n- Records: %d\n- Dimension: %d\n- Metric: %s\n\n",
-				meta.Name, meta.RecordCount, meta.EmbeddingDim, meta.DistanceMetric))
-		} else {
-			sb.WriteString(fmt.Sprintf("- Collection '%s' not found (no vectors indexed yet)\n\n", collection))
-		}
-	}
-
-	// 2. Memories
-	sb.WriteString("## Project Memories\n")
-	if h.cfg.DB != nil {
-		rows, err := h.cfg.DB.QueryContext(ctx,
-			Q(`SELECT key, value, type FROM memories
-			 WHERE collection_name = $1 ORDER BY updated_at DESC LIMIT 20`), collection)
-		if err == nil {
-			defer rows.Close()
-			count := 0
-			for rows.Next() {
-				var key, value, typ string
-				rows.Scan(&key, &value, &typ)
-				sb.WriteString(fmt.Sprintf("- [%s] %s: %s\n", typ, key, truncate(value, 200)))
-				count++
-			}
-			if count == 0 {
-				sb.WriteString("- (no memories saved for this collection)\n")
-			}
-			sb.WriteString("\n")
-		}
-	}
-
-	// 3. Graph entities (top types)
-	sb.WriteString("## Key Entity Types\n")
-	if h.cfg.DB != nil {
-		rows, err := h.cfg.DB.QueryContext(ctx,
-			Q(`SELECT type, COUNT(*) as cnt FROM graph_nodes GROUP BY type ORDER BY cnt DESC LIMIT 10`))
-		if err == nil {
-			defer rows.Close()
-			count := 0
-			for rows.Next() {
-				var typ string
-				var cnt int
-				rows.Scan(&typ, &cnt)
-				sb.WriteString(fmt.Sprintf("- %s: %d entities\n", typ, cnt))
-				count++
-			}
-			if count == 0 {
-				sb.WriteString("- (no entities extracted yet)\n")
-			}
-			sb.WriteString("\n")
-		}
-	}
-
-	// 4. Recent interactions
-	sb.WriteString("## Recent Interactions\n")
-	if h.cfg.DB != nil {
-		rows, err := h.cfg.DB.QueryContext(ctx,
-			Q(`SELECT query, response, created_at FROM interactions
-			 ORDER BY created_at DESC LIMIT 5`))
-		if err == nil {
-			defer rows.Close()
-			count := 0
-			for rows.Next() {
-				var query, response, createdAt string
-				rows.Scan(&query, &response, &createdAt)
-				sb.WriteString(fmt.Sprintf("- Q: %s\n  A: %s\n", truncate(query, 100), truncate(response, 150)))
-				count++
-			}
-			if count == 0 {
-				sb.WriteString("- (no interactions recorded)\n")
-			}
-		}
-	}
-
-	// 5. Related projects (compact summaries)
-	if related, ok := args["include_related"].([]any); ok && len(related) > 0 {
-		sb.WriteString("\n## Related Projects\n")
-		for _, r := range related {
-			relColl, ok := r.(string)
-			if !ok || relColl == "" {
-				continue
-			}
-			sb.WriteString(fmt.Sprintf("\n### %s\n", relColl))
-			if h.cfg.Collections != nil {
-				if meta := h.cfg.Collections.GetMeta(relColl); meta != nil {
-					sb.WriteString(fmt.Sprintf("- Records: %d, Dim: %d\n", meta.RecordCount, meta.EmbeddingDim))
-				} else {
-					sb.WriteString("- (no vectors)\n")
-				}
-			}
-			if h.cfg.DB != nil {
-				rows, err := h.cfg.DB.QueryContext(ctx,
-					Q(`SELECT key, value FROM memories WHERE collection_name = $1 ORDER BY updated_at DESC LIMIT 3`), relColl)
-				if err == nil {
-					defer rows.Close()
-					for rows.Next() {
-						var key, value string
-						rows.Scan(&key, &value)
-						sb.WriteString(fmt.Sprintf("- %s: %s\n", key, truncate(value, 100)))
-					}
-				}
-			}
-		}
-	}
-
-	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: sb.String()}}}
+	return mcp.ToolGetProjectContext(ctx, h, args)
 }
 
 // ── Session Cleanup ───────────────────────────────────────────────────────
@@ -1376,29 +1288,12 @@ func (h *mcpHandler) toolListCommunities(ctx context.Context, args map[string]an
 }
 
 
-// toolCheckDrift reports embedding model drift across collections.
+// toolCheckDrift is a thin shim over mcp.ToolCheckDrift. F-4 wave 3o
+// moved the body into pkg/mcp using CollectionMeta so pkg/mcp stays free
+// of the *store.CollectionManager pointer. The embedded drift logic
+// (iterate → skip empty/"_" → compare model+dim) is inlined there.
 func (h *mcpHandler) toolCheckDrift(ctx context.Context, args map[string]any) mcpToolResult {
-	drifted := embed.CheckDrift(h.cfg.Collections, h.cfg.EmbedModel, 0)
-	// Try to get actual dim from first collection
-	dim := 0
-	if h.cfg.Collections != nil {
-		for _, name := range h.cfg.Collections.List() {
-			m := h.cfg.Collections.GetMeta(name)
-			if m.EmbeddingDim > 0 {
-				dim = m.EmbeddingDim
-				break
-			}
-		}
-	}
-	if dim > 0 {
-		drifted = embed.CheckDrift(h.cfg.Collections, h.cfg.EmbedModel, dim)
-	}
-
-	if drifted == nil {
-		drifted = []embed.DriftCheckResult{}
-	}
-	out, _ := json.MarshalIndent(drifted, "", "  ")
-	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(out)}}}
+	return mcp.ToolCheckDrift(ctx, h, args)
 }
 
 // toolPruneGraph is a thin shim over mcp.ToolPruneGraph. F-4 wave 3n

--- a/Levara/pkg/mcp/deps.go
+++ b/Levara/pkg/mcp/deps.go
@@ -47,6 +47,9 @@ import (
 //              supply a stub. Pkg/mcp now imports pipeline + router +
 //              llm; graphrank stays inside tool_search.go (used only
 //              there).
+//   - wave 3o: + CollectionMeta (toolGetProjectContext + toolCheckDrift).
+//              Returns CollectionInfo value type so pkg/mcp stays free of
+//              internal/store.CollectionMeta pointer.
 type Deps interface {
 	// DB returns the shared *sql.DB used for palace / datasets / graph
 	// tables. May be nil when no PostgresDSN is configured — tool
@@ -147,6 +150,12 @@ type Deps interface {
 	// relatively expensive call — the production implementation hits
 	// the DB to detect communities.
 	SearchCapabilities() router.Capabilities
+	// CollectionMeta returns observable metadata for a named collection.
+	// Returns zero CollectionInfo when the collection doesn't exist or
+	// HasCollections() is false. Used by toolGetProjectContext and
+	// toolCheckDrift to read per-collection stats without leaking the
+	// internal/store.CollectionMeta pointer into pkg/mcp.
+	CollectionMeta(name string) CollectionInfo
 }
 
 // SearchPipeline is the narrow interface toolSearch calls into. The
@@ -181,4 +190,15 @@ type SearchResult struct {
 	ID    string
 	Score float32
 	Data  []byte
+}
+
+// CollectionInfo is the observable metadata for a single collection
+// returned by Deps.CollectionMeta. It is a plain value type — no
+// internal/store pointers — so pkg/mcp stays free of that import.
+type CollectionInfo struct {
+	Name       string
+	Records    int
+	Dim        int
+	Metric     string
+	EmbedModel string
 }

--- a/Levara/pkg/mcp/deps_test.go
+++ b/Levara/pkg/mcp/deps_test.go
@@ -68,6 +68,10 @@ type fakeDeps struct {
 	llmProvider      llm.Provider
 	llmModel         string
 	capabilities     router.Capabilities
+
+	// collectionMetas is keyed by collection name. Tests that exercise
+	// toolGetProjectContext or toolCheckDrift populate this map.
+	collectionMetas map[string]CollectionInfo
 }
 
 // insertedRow records a single CollectionInsert call so tests can
@@ -196,9 +200,15 @@ func (f *fakeDeps) NewSearchPipeline(doRerank bool) SearchPipeline {
 	return nil
 }
 
-func (f *fakeDeps) LLMProvider() llm.Provider         { return f.llmProvider }
-func (f *fakeDeps) LLMModel() string                  { return f.llmModel }
-func (f *fakeDeps) SearchCapabilities() router.Capabilities { return f.capabilities }
+func (f *fakeDeps) LLMProvider() llm.Provider               { return f.llmProvider }
+func (f *fakeDeps) LLMModel() string                         { return f.llmModel }
+func (f *fakeDeps) SearchCapabilities() router.Capabilities  { return f.capabilities }
+func (f *fakeDeps) CollectionMeta(name string) CollectionInfo {
+	if f.collectionMetas == nil {
+		return CollectionInfo{}
+	}
+	return f.collectionMetas[name]
+}
 
 // fakeSearchPipeline is a programmable SearchPipeline stub. Each method
 // consults a matching function field; when nil, returns empty results
@@ -266,10 +276,11 @@ func (nilDBDeps) LogHeartbeat(string, any)                                      
 func (nilDBDeps) RunPipeline(context.Context, []string, orchestrator.Config, chan<- orchestrator.Progress) error {
 	return nil
 }
-func (nilDBDeps) NewSearchPipeline(bool) SearchPipeline     { return nil }
-func (nilDBDeps) LLMProvider() llm.Provider                 { return nil }
-func (nilDBDeps) LLMModel() string                          { return "" }
-func (nilDBDeps) SearchCapabilities() router.Capabilities   { return router.Capabilities{} }
+func (nilDBDeps) NewSearchPipeline(bool) SearchPipeline          { return nil }
+func (nilDBDeps) LLMProvider() llm.Provider                      { return nil }
+func (nilDBDeps) LLMModel() string                               { return "" }
+func (nilDBDeps) SearchCapabilities() router.Capabilities        { return router.Capabilities{} }
+func (nilDBDeps) CollectionMeta(string) CollectionInfo           { return CollectionInfo{} }
 
 func setupDepsTestDB(t *testing.T) *fakeDeps {
 	t.Helper()

--- a/Levara/pkg/mcp/tool_project.go
+++ b/Levara/pkg/mcp/tool_project.go
@@ -1,0 +1,218 @@
+package mcp
+
+// Project-context and embedding-drift tools: get_project_context + check_drift.
+// Migrated in F-4 wave 3o. Both tools read collection metadata through the new
+// CollectionMeta(name) Deps method added in this wave — avoids leaking
+// internal/store.CollectionMeta into pkg/mcp.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ToolGetProjectContext assembles a context summary for a collection:
+// collection stats, recent memories, graph entity-type counts, and
+// recent interactions. Optional "include_related" arg appends summaries
+// of sibling collections.
+//
+// Error branch: missing collection arg → IsError.
+// Non-error branches: any section that errors (DB nil, missing table) is
+// silently skipped — a partial context is more useful than an error.
+func ToolGetProjectContext(ctx context.Context, deps Deps, args map[string]any) ToolResult {
+	collection, _ := args["collection"].(string)
+	if collection == "" {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: 'collection' required"}},
+			IsError: true,
+		}
+	}
+
+	var sb strings.Builder
+	db := deps.DB()
+
+	// 1. Collection stats
+	sb.WriteString("## Collection Stats\n")
+	meta := deps.CollectionMeta(collection)
+	if meta.Records > 0 || meta.Dim > 0 {
+		sb.WriteString(fmt.Sprintf("- Name: %s\n- Records: %d\n- Dimension: %d\n- Metric: %s\n\n",
+			meta.Name, meta.Records, meta.Dim, meta.Metric))
+	} else {
+		sb.WriteString(fmt.Sprintf("- Collection '%s' not found (no vectors indexed yet)\n\n", collection))
+	}
+
+	// 2. Memories
+	sb.WriteString("## Project Memories\n")
+	if db != nil {
+		rows, err := db.QueryContext(ctx,
+			deps.Q(`SELECT key, value, type FROM memories
+			 WHERE collection_name = $1 ORDER BY updated_at DESC LIMIT 20`), collection)
+		if err == nil {
+			defer rows.Close()
+			count := 0
+			for rows.Next() {
+				var key, value, typ string
+				rows.Scan(&key, &value, &typ)
+				sb.WriteString(fmt.Sprintf("- [%s] %s: %s\n", typ, key, Truncate(value, 200)))
+				count++
+			}
+			if count == 0 {
+				sb.WriteString("- (no memories saved for this collection)\n")
+			}
+			sb.WriteString("\n")
+		}
+	}
+
+	// 3. Graph entities (top types)
+	sb.WriteString("## Key Entity Types\n")
+	if db != nil {
+		rows, err := db.QueryContext(ctx,
+			deps.Q(`SELECT type, COUNT(*) as cnt FROM graph_nodes GROUP BY type ORDER BY cnt DESC LIMIT 10`))
+		if err == nil {
+			defer rows.Close()
+			count := 0
+			for rows.Next() {
+				var typ string
+				var cnt int
+				rows.Scan(&typ, &cnt)
+				sb.WriteString(fmt.Sprintf("- %s: %d entities\n", typ, cnt))
+				count++
+			}
+			if count == 0 {
+				sb.WriteString("- (no entities extracted yet)\n")
+			}
+			sb.WriteString("\n")
+		}
+	}
+
+	// 4. Recent interactions
+	sb.WriteString("## Recent Interactions\n")
+	if db != nil {
+		rows, err := db.QueryContext(ctx,
+			deps.Q(`SELECT query, response, created_at FROM interactions
+			 ORDER BY created_at DESC LIMIT 5`))
+		if err == nil {
+			defer rows.Close()
+			count := 0
+			for rows.Next() {
+				var query, response, createdAt string
+				rows.Scan(&query, &response, &createdAt)
+				sb.WriteString(fmt.Sprintf("- Q: %s\n  A: %s\n", Truncate(query, 100), Truncate(response, 150)))
+				count++
+			}
+			if count == 0 {
+				sb.WriteString("- (no interactions recorded)\n")
+			}
+		}
+	}
+
+	// 5. Related projects (compact summaries)
+	if related, ok := args["include_related"].([]any); ok && len(related) > 0 {
+		sb.WriteString("\n## Related Projects\n")
+		for _, r := range related {
+			relColl, ok := r.(string)
+			if !ok || relColl == "" {
+				continue
+			}
+			sb.WriteString(fmt.Sprintf("\n### %s\n", relColl))
+			relMeta := deps.CollectionMeta(relColl)
+			if relMeta.Records > 0 || relMeta.Dim > 0 {
+				sb.WriteString(fmt.Sprintf("- Records: %d, Dim: %d\n", relMeta.Records, relMeta.Dim))
+			} else {
+				sb.WriteString("- (no vectors)\n")
+			}
+			if db != nil {
+				relRows, err := db.QueryContext(ctx,
+					deps.Q(`SELECT key, value FROM memories WHERE collection_name = $1 ORDER BY updated_at DESC LIMIT 3`), relColl)
+				if err == nil {
+					defer relRows.Close()
+					for relRows.Next() {
+						var key, value string
+						relRows.Scan(&key, &value)
+						sb.WriteString(fmt.Sprintf("- %s: %s\n", key, Truncate(value, 100)))
+					}
+				}
+			}
+		}
+	}
+
+	return ToolResult{Content: []Content{{Type: "text", Text: sb.String()}}}
+}
+
+// driftResult mirrors embed.DriftCheckResult JSON shape without importing
+// pkg/embed into pkg/mcp. The JSON keys are identical — callers parsing
+// the output of toolCheckDrift before and after the migration see no diff.
+type driftResult struct {
+	Collection    string `json:"collection"`
+	ExpectedModel string `json:"expected_model"`
+	ExpectedDim   int    `json:"expected_dim"`
+	ActualModel   string `json:"actual_model"`
+	ActualDim     int    `json:"actual_dim"`
+	IsDrifted     bool   `json:"is_drifted"`
+	RecordCount   int    `json:"record_count"`
+}
+
+// ToolCheckDrift reports embedding model drift across all non-empty,
+// non-internal collections. "Drift" means the collection was indexed with
+// a different model or dimension than the current deployment config.
+//
+// Algorithm matches embed.CheckDrift exactly: iterate collections, skip
+// empty and "_"-prefixed, compare model+dim. Uses Deps.CollectionMeta
+// instead of the *store.CollectionManager pointer, and derives currentDim
+// by scanning collections for the first non-zero dim rather than relying
+// on a deployment-level constant (mirrors the two-step logic in the
+// pre-refactor mcpHandler.toolCheckDrift).
+//
+// Returns "[]" (empty JSON array, not IsError) when nothing is drifted.
+func ToolCheckDrift(ctx context.Context, deps Deps, args map[string]any) ToolResult {
+	currentModel := deps.BaseCognifyConfig().EmbedModel
+
+	// Find the representative dimension by looking at the first collection
+	// that reports a non-zero dim. This matches the pre-refactor two-step
+	// approach where dim was probed before the authoritative CheckDrift call.
+	currentDim := 0
+	for _, name := range deps.ListCollections() {
+		m := deps.CollectionMeta(name)
+		if m.Dim > 0 {
+			currentDim = m.Dim
+			break
+		}
+	}
+
+	var results []driftResult
+	for _, name := range deps.ListCollections() {
+		// Skip internal collections (matching embed.CheckDrift behaviour).
+		if strings.HasPrefix(name, "_") {
+			continue
+		}
+		m := deps.CollectionMeta(name)
+		if m.Records == 0 {
+			continue
+		}
+		isDrifted := false
+		if m.EmbedModel != "" && m.EmbedModel != currentModel {
+			isDrifted = true
+		}
+		if currentDim > 0 && m.Dim > 0 && m.Dim != currentDim {
+			isDrifted = true
+		}
+		if isDrifted {
+			results = append(results, driftResult{
+				Collection:    name,
+				ExpectedModel: currentModel,
+				ExpectedDim:   currentDim,
+				ActualModel:   m.EmbedModel,
+				ActualDim:     m.Dim,
+				IsDrifted:     true,
+				RecordCount:   m.Records,
+			})
+		}
+	}
+
+	if results == nil {
+		results = []driftResult{}
+	}
+	out, _ := json.MarshalIndent(results, "", "  ")
+	return ToolResult{Content: []Content{{Type: "text", Text: string(out)}}}
+}

--- a/Levara/pkg/mcp/tool_project_test.go
+++ b/Levara/pkg/mcp/tool_project_test.go
@@ -1,0 +1,291 @@
+package mcp
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stek0v/cognevra/pkg/orchestrator"
+)
+
+// testBaseCfg returns an orchestrator.Config with just EmbedModel set
+// so ToolCheckDrift can compare models without a real LLM stack.
+func testBaseCfg(model string, dim int) orchestrator.Config {
+	return orchestrator.Config{EmbedModel: model}
+}
+
+// setupProjectDB creates a SQLite test DB with the tables that
+// ToolGetProjectContext needs.
+func setupProjectDB(t *testing.T) *fakeDeps {
+	t.Helper()
+	f, _ := os.CreateTemp("", "mcp-project-test-*.db")
+	path := f.Name()
+	f.Close()
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(path)
+	})
+
+	_, err = db.Exec(`
+		CREATE TABLE memories (
+			id TEXT PRIMARY KEY,
+			key TEXT NOT NULL,
+			value TEXT NOT NULL,
+			type TEXT NOT NULL DEFAULT 'fact',
+			owner_id TEXT NOT NULL DEFAULT '',
+			collection_name TEXT NOT NULL DEFAULT '',
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE graph_nodes (
+			id TEXT PRIMARY KEY,
+			name TEXT,
+			type TEXT,
+			description TEXT,
+			properties TEXT
+		);
+		CREATE TABLE interactions (
+			id TEXT PRIMARY KEY,
+			query TEXT NOT NULL DEFAULT '',
+			response TEXT NOT NULL DEFAULT '',
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+	`)
+	if err != nil {
+		t.Fatalf("create tables: %v", err)
+	}
+	return &fakeDeps{db: db}
+}
+
+// ── ToolGetProjectContext ──
+
+func TestToolGetProjectContext_MissingCollection(t *testing.T) {
+	res := ToolGetProjectContext(context.Background(), &fakeDeps{}, map[string]any{})
+	if !res.IsError {
+		t.Fatal("want IsError when collection missing")
+	}
+	if !strings.Contains(res.Content[0].Text, "'collection' required") {
+		t.Errorf("wrong error text: %q", res.Content[0].Text)
+	}
+}
+
+func TestToolGetProjectContext_NoVectors(t *testing.T) {
+	deps := setupProjectDB(t)
+	res := ToolGetProjectContext(context.Background(), deps, map[string]any{
+		"collection": "test",
+	})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	text := res.Content[0].Text
+	if !strings.Contains(text, "Collection Stats") {
+		t.Error("missing Collection Stats section")
+	}
+	if !strings.Contains(text, "not found") {
+		t.Errorf("expected 'not found' msg for empty collection; got %q", text)
+	}
+}
+
+func TestToolGetProjectContext_WithVectors(t *testing.T) {
+	deps := setupProjectDB(t)
+	deps.collectionMetas = map[string]CollectionInfo{
+		"myproj": {Name: "myproj", Records: 42, Dim: 768, Metric: "cosine"},
+	}
+	res := ToolGetProjectContext(context.Background(), deps, map[string]any{
+		"collection": "myproj",
+	})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	text := res.Content[0].Text
+	if !strings.Contains(text, "Records: 42") {
+		t.Errorf("collection stats not shown; text=%q", text)
+	}
+}
+
+func TestToolGetProjectContext_MemoriesListed(t *testing.T) {
+	deps := setupProjectDB(t)
+	db := deps.db
+
+	db.Exec(`INSERT INTO memories (id, key, value, type, collection_name) VALUES
+		('m1', 'arch', 'HNSW vector DB', 'fact', 'proj'),
+		('m2', 'deploy', 'docker compose', 'event', 'proj')`)
+
+	res := ToolGetProjectContext(context.Background(), deps, map[string]any{
+		"collection": "proj",
+	})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	text := res.Content[0].Text
+	if !strings.Contains(text, "HNSW vector DB") {
+		t.Errorf("memory value not in output; text=%q", text)
+	}
+	if !strings.Contains(text, "docker compose") {
+		t.Errorf("second memory not in output; text=%q", text)
+	}
+}
+
+func TestToolGetProjectContext_EntitiesListed(t *testing.T) {
+	deps := setupProjectDB(t)
+	db := deps.db
+
+	db.Exec(`INSERT INTO graph_nodes (id, name, type) VALUES
+		('n1', 'Auth', 'module'),
+		('n2', 'DB', 'module'),
+		('n3', 'User', 'entity')`)
+
+	res := ToolGetProjectContext(context.Background(), deps, map[string]any{
+		"collection": "proj",
+	})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	text := res.Content[0].Text
+	if !strings.Contains(text, "Key Entity Types") {
+		t.Error("missing Key Entity Types section")
+	}
+	if !strings.Contains(text, "module") {
+		t.Errorf("entity type not shown; text=%q", text)
+	}
+}
+
+func TestToolGetProjectContext_NilDB(t *testing.T) {
+	// With nil DB, the response should still contain section headers and
+	// not error — useful for vector-only deployments.
+	deps := &fakeDeps{}
+	res := ToolGetProjectContext(context.Background(), deps, map[string]any{
+		"collection": "test",
+	})
+	if res.IsError {
+		t.Fatalf("unexpected IsError with nil DB: %q", res.Content[0].Text)
+	}
+	text := res.Content[0].Text
+	if !strings.Contains(text, "Collection Stats") {
+		t.Errorf("expected Collection Stats header; got %q", text)
+	}
+}
+
+func TestToolGetProjectContext_IncludeRelated(t *testing.T) {
+	deps := setupProjectDB(t)
+	deps.collectionMetas = map[string]CollectionInfo{
+		"related": {Name: "related", Records: 10, Dim: 768, Metric: "l2"},
+	}
+
+	res := ToolGetProjectContext(context.Background(), deps, map[string]any{
+		"collection":      "main",
+		"include_related": []any{"related"},
+	})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	text := res.Content[0].Text
+	if !strings.Contains(text, "Related Projects") {
+		t.Errorf("missing Related Projects section; text=%q", text)
+	}
+	if !strings.Contains(text, "related") {
+		t.Errorf("related collection not shown; text=%q", text)
+	}
+}
+
+// ── ToolCheckDrift ──
+
+func TestToolCheckDrift_NoDrift(t *testing.T) {
+	deps := &fakeDeps{
+		collections: []string{"col1", "col2"},
+		baseCfg:     testBaseCfg("nomic-v2", 768),
+		collectionMetas: map[string]CollectionInfo{
+			"col1": {EmbedModel: "nomic-v2", Dim: 768, Records: 10},
+			"col2": {EmbedModel: "nomic-v2", Dim: 768, Records: 5},
+		},
+	}
+	res := ToolCheckDrift(context.Background(), deps, map[string]any{})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	// No drift → should be empty JSON array.
+	if strings.TrimSpace(res.Content[0].Text) != "[]" {
+		t.Errorf("expected [] for no drift, got %q", res.Content[0].Text)
+	}
+}
+
+func TestToolCheckDrift_ModelMismatch(t *testing.T) {
+	deps := &fakeDeps{
+		collections: []string{"old"},
+		baseCfg:     testBaseCfg("nomic-v2", 768),
+		collectionMetas: map[string]CollectionInfo{
+			"old": {EmbedModel: "nomic-v1", Dim: 768, Records: 5},
+		},
+	}
+	res := ToolCheckDrift(context.Background(), deps, map[string]any{})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	if !strings.Contains(res.Content[0].Text, "is_drifted") {
+		t.Errorf("expected drift result; got %q", res.Content[0].Text)
+	}
+	if !strings.Contains(res.Content[0].Text, "nomic-v1") {
+		t.Errorf("actual_model not in response; got %q", res.Content[0].Text)
+	}
+}
+
+func TestToolCheckDrift_EmptyCollectionSkipped(t *testing.T) {
+	deps := &fakeDeps{
+		collections: []string{"empty"},
+		baseCfg:     testBaseCfg("nomic-v2", 768),
+		collectionMetas: map[string]CollectionInfo{
+			"empty": {EmbedModel: "old-model", Dim: 512, Records: 0}, // 0 records → skip
+		},
+	}
+	res := ToolCheckDrift(context.Background(), deps, map[string]any{})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	if strings.TrimSpace(res.Content[0].Text) != "[]" {
+		t.Errorf("empty collection should be skipped; got %q", res.Content[0].Text)
+	}
+}
+
+func TestToolCheckDrift_InternalCollectionSkipped(t *testing.T) {
+	deps := &fakeDeps{
+		collections: []string{"_internal"},
+		baseCfg:     testBaseCfg("nomic-v2", 768),
+		collectionMetas: map[string]CollectionInfo{
+			"_internal": {EmbedModel: "old-model", Dim: 512, Records: 10},
+		},
+	}
+	res := ToolCheckDrift(context.Background(), deps, map[string]any{})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	if strings.TrimSpace(res.Content[0].Text) != "[]" {
+		t.Errorf("internal collection should be skipped; got %q", res.Content[0].Text)
+	}
+}
+
+func TestToolCheckDrift_DimMismatch(t *testing.T) {
+	// Two collections: "reference" establishes currentDim=768; "narrow"
+	// was indexed with dim=512 → should report as drifted.
+	deps := &fakeDeps{
+		collections: []string{"reference", "narrow"},
+		baseCfg:     testBaseCfg("nomic-v2", 768),
+		collectionMetas: map[string]CollectionInfo{
+			"reference": {EmbedModel: "nomic-v2", Dim: 768, Records: 10},
+			"narrow":    {EmbedModel: "nomic-v2", Dim: 512, Records: 3},
+		},
+	}
+	res := ToolCheckDrift(context.Background(), deps, map[string]any{})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	if !strings.Contains(res.Content[0].Text, "is_drifted") {
+		t.Errorf("dim mismatch should produce drift result; got %q", res.Content[0].Text)
+	}
+}


### PR DESCRIPTION
## Summary
- **New Deps method**: `CollectionMeta(name string) CollectionInfo` — value type, keeps pkg/mcp free of `internal/store` pointers
- **ToolGetProjectContext** migrated to `pkg/mcp/tool_project.go` — 5-section context report (collection stats, memories, entity types, interactions, related projects)
- **ToolCheckDrift** migrated to same file — drift-check logic inlined from `embed.CheckDrift` using `ListCollections()` + `CollectionMeta()` instead of raw `*store.CollectionManager`; identical JSON output

## Test plan
- [x] 7 tests for ToolGetProjectContext: missing arg, nil DB, vectors shown, memories listed, entities listed, nil DB graceful, include_related
- [x] 5 tests for ToolCheckDrift: no drift, model mismatch, empty collection skipped, internal collection skipped, dim mismatch
- [x] 35/35 packages pass `go test -race ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)