### PR TITLE
refactor(mcp): F-4 wave 3p — ToolCodify moves behind Deps

### DIFF
--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -23,10 +23,8 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/google/uuid"
 	"github.com/stek0v/cognevra/internal/metrics"
 	"github.com/stek0v/cognevra/pkg/embed"
-	"github.com/stek0v/cognevra/pkg/extract"
 	"github.com/stek0v/cognevra/pkg/llm"
 	"github.com/stek0v/cognevra/pkg/mcp"
 	"github.com/stek0v/cognevra/pkg/orchestrator"
@@ -832,68 +830,13 @@ func (h *mcpHandler) resourceMemories(ctx context.Context, memType, collName str
 
 // ── Cross-Project Tools ──
 
+// toolCodify is a thin shim over mcp.ToolCodify. F-4 wave 3p moved the
+// body (extract.AnalyzeCode + graph upserts + optional embed) into
+// pkg/mcp. The pre-refactor QArgs call for ON CONFLICT parameter reuse
+// was replaced by excluded.* syntax (SQLite 3.24+ / PostgreSQL 9.5+) so
+// no QArgs method is needed on Deps.
 func (h *mcpHandler) toolCodify(ctx context.Context, args map[string]any) mcpToolResult {
-	code, _ := args["code"].(string)
-	filename, _ := args["filename"].(string)
-	if code == "" || filename == "" {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: 'code' and 'filename' required"}}, IsError: true}
-	}
-
-	analysis := extract.AnalyzeCode(code, filename)
-
-	// Store entities in graph if DB available
-	if h.cfg.DB != nil {
-		for _, e := range analysis.Entities {
-			props := fmt.Sprintf(`{"file":"%s","line":%d}`, e.File, e.Line)
-			if e.Parent != "" {
-				props = fmt.Sprintf(`{"file":"%s","line":%d,"parent":"%s"}`, e.File, e.Line, e.Parent)
-			}
-			q, qargs := QArgs(`INSERT INTO graph_nodes (id, name, type, description, properties)
-				VALUES ($1, $2, $3, $4, $5)
-				ON CONFLICT(id) DO UPDATE SET name = $2, type = $3, properties = $5`,
-				uuid.NewSHA1(uuid.NameSpaceOID, []byte(e.Name+e.Type+e.File)).String(),
-				e.Name, e.Type, filename, props)
-			h.cfg.DB.ExecContext(ctx, q, qargs...)
-		}
-		for _, r := range analysis.Relations {
-			srcID := uuid.NewSHA1(uuid.NameSpaceOID, []byte(r.Source)).String()
-			tgtID := uuid.NewSHA1(uuid.NameSpaceOID, []byte(r.Target)).String()
-			edgeID := uuid.NewSHA1(uuid.NameSpaceOID, []byte(r.Source+r.Relationship+r.Target)).String()
-			q, qargs := QArgs(`INSERT INTO graph_edges (id, source_id, target_id, relationship_name, properties)
-				VALUES ($1, $2, $3, $4, '{}')
-				ON CONFLICT(id) DO NOTHING`,
-				edgeID, srcID, tgtID, r.Relationship)
-			h.cfg.DB.ExecContext(ctx, q, qargs...)
-		}
-	}
-
-	// Embed code entities into collection if configured
-	collection, _ := args["collection"].(string)
-	if collection != "" && h.cfg.EmbedEndpoint != "" && h.cfg.Collections != nil {
-		embedClient := embed.NewClient(h.cfg.EmbedEndpoint, h.cfg.EmbedModel, 16, 3)
-		var texts []string
-		var ids []string
-		for _, e := range analysis.Entities {
-			texts = append(texts, e.Name+": "+e.Type+" in "+e.File)
-			ids = append(ids, uuid.NewSHA1(uuid.NameSpaceOID, []byte(e.Name+e.Type+e.File)).String())
-		}
-		if len(texts) > 0 {
-			if vecs, err := embedClient.EmbedTexts(ctx, texts); err == nil {
-				for i, vec := range vecs {
-					meta := fmt.Sprintf(`{"name":"%s","type":"%s","file":"%s"}`, analysis.Entities[i].Name, analysis.Entities[i].Type, analysis.Entities[i].File)
-					h.cfg.Collections.Insert(collection, ids[i], vec, meta)
-				}
-			}
-		}
-	}
-
-	out, _ := json.MarshalIndent(map[string]any{
-		"language":  analysis.Language,
-		"entities":  len(analysis.Entities),
-		"relations": len(analysis.Relations),
-		"details":   analysis,
-	}, "", "  ")
-	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(out)}}}
+	return mcp.ToolCodify(ctx, h, args)
 }
 
 // toolAddFeedback / toolGetFeedbackStats / toolSetContext are thin

--- a/Levara/pkg/mcp/tool_codify.go
+++ b/Levara/pkg/mcp/tool_codify.go
@@ -1,0 +1,110 @@
+package mcp
+
+// Codify tool: static code analysis → graph + vector index.
+// Migrated in F-4 wave 3p. No new Deps methods:
+//   - DB() + Q() for graph_nodes / graph_edges upserts
+//   - BaseCognifyConfig() for embed endpoint/model
+//   - HasCollections() as a vector-engine gate
+//   - CollectionInsert() for the per-entity vector upsert
+//
+// The original QArgs call for parameter reuse in the ON CONFLICT clause
+// is replaced with excluded.* syntax (SQLite 3.24+ / PostgreSQL 9.5+),
+// which works on both engines without the QArgs machinery.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/stek0v/cognevra/pkg/embed"
+	"github.com/stek0v/cognevra/pkg/extract"
+)
+
+// ToolCodify parses code with extract.AnalyzeCode, stores extracted
+// entities + relations as graph nodes/edges (when DB is configured), and
+// optionally embeds entity descriptions into a named collection (when an
+// embed service + collection manager are configured).
+//
+// Returns a JSON summary:
+//
+//	{"language": "...", "entities": N, "relations": M, "details": {...}}
+//
+// Error branch: missing code or filename → IsError.
+// Non-error branches: DB-nil / embed-nil produce partial results without
+// error — callers receive whatever was analysed.
+func ToolCodify(ctx context.Context, deps Deps, args map[string]any) ToolResult {
+	code, _ := args["code"].(string)
+	filename, _ := args["filename"].(string)
+	if code == "" || filename == "" {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: 'code' and 'filename' required"}},
+			IsError: true,
+		}
+	}
+
+	analysis := extract.AnalyzeCode(code, filename)
+
+	db := deps.DB()
+	if db != nil {
+		// Upsert entities as graph nodes.
+		// excluded.* replaces the pre-refactor QArgs($2, $3, $5) pattern
+		// — identical semantics on SQLite 3.24+ and PostgreSQL 9.5+.
+		for _, e := range analysis.Entities {
+			props := fmt.Sprintf(`{"file":"%s","line":%d}`, e.File, e.Line)
+			if e.Parent != "" {
+				props = fmt.Sprintf(`{"file":"%s","line":%d,"parent":"%s"}`, e.File, e.Line, e.Parent)
+			}
+			nodeID := uuid.NewSHA1(uuid.NameSpaceOID, []byte(e.Name+e.Type+e.File)).String()
+			db.ExecContext(ctx, deps.Q(`
+				INSERT INTO graph_nodes (id, name, type, description, properties)
+				VALUES ($1, $2, $3, $4, $5)
+				ON CONFLICT(id) DO UPDATE SET
+					name = excluded.name,
+					type = excluded.type,
+					properties = excluded.properties`),
+				nodeID, e.Name, e.Type, filename, props)
+		}
+
+		// Upsert relations as graph edges (DO NOTHING — idempotent).
+		for _, r := range analysis.Relations {
+			srcID := uuid.NewSHA1(uuid.NameSpaceOID, []byte(r.Source)).String()
+			tgtID := uuid.NewSHA1(uuid.NameSpaceOID, []byte(r.Target)).String()
+			edgeID := uuid.NewSHA1(uuid.NameSpaceOID, []byte(r.Source+r.Relationship+r.Target)).String()
+			db.ExecContext(ctx, deps.Q(`
+				INSERT INTO graph_edges (id, source_id, target_id, relationship_name, properties)
+				VALUES ($1, $2, $3, $4, '{}')
+				ON CONFLICT(id) DO NOTHING`),
+				edgeID, srcID, tgtID, r.Relationship)
+		}
+	}
+
+	// Embed entity descriptions into collection when configured.
+	collection, _ := args["collection"].(string)
+	embedCfg := deps.BaseCognifyConfig()
+	if collection != "" && embedCfg.EmbedEndpoint != "" && deps.HasCollections() {
+		embedClient := embed.NewClient(embedCfg.EmbedEndpoint, embedCfg.EmbedModel, 16, 3)
+		var texts, ids []string
+		for _, e := range analysis.Entities {
+			texts = append(texts, e.Name+": "+e.Type+" in "+e.File)
+			ids = append(ids, uuid.NewSHA1(uuid.NameSpaceOID, []byte(e.Name+e.Type+e.File)).String())
+		}
+		if len(texts) > 0 {
+			if vecs, err := embedClient.EmbedTexts(ctx, texts); err == nil {
+				for i, vec := range vecs {
+					meta := fmt.Sprintf(`{"name":"%s","type":"%s","file":"%s"}`,
+						analysis.Entities[i].Name, analysis.Entities[i].Type, analysis.Entities[i].File)
+					deps.CollectionInsert(collection, ids[i], vec, meta)
+				}
+			}
+		}
+	}
+
+	out, _ := json.MarshalIndent(map[string]any{
+		"language":  analysis.Language,
+		"entities":  len(analysis.Entities),
+		"relations": len(analysis.Relations),
+		"details":   analysis,
+	}, "", "  ")
+	return ToolResult{Content: []Content{{Type: "text", Text: string(out)}}}
+}

--- a/Levara/pkg/mcp/tool_codify_test.go
+++ b/Levara/pkg/mcp/tool_codify_test.go
@@ -1,0 +1,183 @@
+package mcp
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// setupCodifyDB creates a SQLite test DB with graph_nodes and graph_edges tables.
+func setupCodifyDB(t *testing.T) *fakeDeps {
+	t.Helper()
+	f, _ := os.CreateTemp("", "mcp-codify-test-*.db")
+	path := f.Name()
+	f.Close()
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(path)
+	})
+
+	_, err = db.Exec(`
+		CREATE TABLE graph_nodes (
+			id TEXT PRIMARY KEY,
+			name TEXT,
+			type TEXT,
+			description TEXT,
+			properties TEXT
+		);
+		CREATE TABLE graph_edges (
+			id TEXT PRIMARY KEY,
+			source_id TEXT NOT NULL,
+			target_id TEXT NOT NULL,
+			relationship_name TEXT NOT NULL,
+			properties TEXT NOT NULL DEFAULT '{}'
+		);
+	`)
+	if err != nil {
+		t.Fatalf("create tables: %v", err)
+	}
+	return &fakeDeps{db: db}
+}
+
+// ── ToolCodify ──
+
+func TestToolCodify_MissingArgs(t *testing.T) {
+	res := ToolCodify(context.Background(), &fakeDeps{}, map[string]any{})
+	if !res.IsError {
+		t.Fatal("want IsError when code/filename missing")
+	}
+	if !strings.Contains(res.Content[0].Text, "'code' and 'filename' required") {
+		t.Errorf("wrong error text: %q", res.Content[0].Text)
+	}
+}
+
+func TestToolCodify_MissingFilename(t *testing.T) {
+	res := ToolCodify(context.Background(), &fakeDeps{}, map[string]any{
+		"code": "package foo",
+	})
+	if !res.IsError {
+		t.Fatal("want IsError when filename missing")
+	}
+}
+
+func TestToolCodify_ReturnsSummary(t *testing.T) {
+	goCode := `package main
+func Hello() string { return "hello" }
+`
+	res := ToolCodify(context.Background(), &fakeDeps{}, map[string]any{
+		"code":     goCode,
+		"filename": "main.go",
+	})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &out); err != nil {
+		t.Fatalf("response not JSON: %s", res.Content[0].Text)
+	}
+	if _, ok := out["language"]; !ok {
+		t.Error("missing 'language' field")
+	}
+	if _, ok := out["entities"]; !ok {
+		t.Error("missing 'entities' field")
+	}
+	if _, ok := out["relations"]; !ok {
+		t.Error("missing 'relations' field")
+	}
+}
+
+func TestToolCodify_InsertsGraphNodes(t *testing.T) {
+	deps := setupCodifyDB(t)
+	goCode := `package main
+func Hello() string { return "hello" }
+`
+	res := ToolCodify(context.Background(), deps, map[string]any{
+		"code":     goCode,
+		"filename": "main.go",
+	})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+
+	// Check that at least one graph_node was inserted.
+	var count int
+	deps.db.QueryRow("SELECT COUNT(*) FROM graph_nodes").Scan(&count)
+	if count == 0 {
+		t.Error("expected graph_nodes to be populated after codify")
+	}
+}
+
+func TestToolCodify_UpsertIdempotent(t *testing.T) {
+	deps := setupCodifyDB(t)
+	goCode := `package main
+func Hello() string { return "hello" }
+`
+	args := map[string]any{"code": goCode, "filename": "main.go"}
+
+	// Run twice — ON CONFLICT DO UPDATE should not error or duplicate rows.
+	res1 := ToolCodify(context.Background(), deps, args)
+	res2 := ToolCodify(context.Background(), deps, args)
+	if res1.IsError || res2.IsError {
+		t.Fatal("unexpected IsError on upsert")
+	}
+
+	var count int
+	deps.db.QueryRow("SELECT COUNT(*) FROM graph_nodes").Scan(&count)
+	// Count after two calls should equal count after one call.
+	var countOnce int
+	deps.db.QueryRow("SELECT COUNT(*) FROM graph_nodes").Scan(&countOnce)
+	if count != countOnce {
+		t.Errorf("duplicate nodes after second codify: first=%d, second=%d", countOnce, count)
+	}
+}
+
+func TestToolCodify_NilDB(t *testing.T) {
+	// No DB configured — should still return analysis JSON, just no graph writes.
+	goCode := `package main
+func Hello() string { return "hello" }
+`
+	res := ToolCodify(context.Background(), &fakeDeps{}, map[string]any{
+		"code":     goCode,
+		"filename": "main.go",
+	})
+	if res.IsError {
+		t.Fatalf("unexpected IsError with nil DB: %q", res.Content[0].Text)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &out); err != nil {
+		t.Fatalf("response not JSON: %s", res.Content[0].Text)
+	}
+}
+
+func TestToolCodify_NoEmbedWhenNotConfigured(t *testing.T) {
+	deps := setupCodifyDB(t)
+	// No embed endpoint → CollectionInsert should never be called.
+	inserted := 0
+	deps.embedAvailable = false
+
+	goCode := `package main
+func Hello() string { return "hello" }
+`
+	res := ToolCodify(context.Background(), deps, map[string]any{
+		"code":       goCode,
+		"filename":   "main.go",
+		"collection": "mycode",
+	})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+
+	// No insertions via CollectionInsert because embed not configured.
+	rows := deps.getInserted()
+	if len(rows) != inserted {
+		t.Errorf("expected 0 vector inserts, got %d", len(rows))
+	}
+}


### PR DESCRIPTION
## Summary
- **ToolCodify** migrated to `pkg/mcp/tool_codify.go`
- Pre-refactor `QArgs` for `ON CONFLICT` parameter reuse replaced with `excluded.*` column syntax (SQLite 3.24+ / PostgreSQL 9.5+) — cleaner SQL, no new Deps method needed
- Drops `pkg/extract` and `github.com/google/uuid` from `internal/http` imports (no longer used there)

## Test plan
- [x] 7 tests: missing args, missing filename, returns JSON summary, inserts graph nodes, upsert idempotent, nil DB graceful, no embed when not configured
- [x] 35/35 packages pass `go test -race ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)