### PR TITLE
refactor(mcp): F-4 wave 3q — ToolSync moves behind Deps (all tools migrated)

### DIFF
--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -289,6 +289,40 @@ func (h *mcpHandler) SearchCapabilities() router.Capabilities {
 	return capabilitiesFromConfig(h.cfg)
 }
 
+// DoSync implements mcp.Deps: orchestrates a bidirectional sync operation
+// with a remote Levara instance, wrapping all the internal/http sync helpers
+// (SyncManifestFromRemote, SyncPull, syncPush, syncPullCollections,
+// syncPushCollections) so pkg/mcp doesn't need to know about APIConfig or
+// *store.CollectionManager. Added in F-4 wave 3q for toolSync.
+func (h *mcpHandler) DoSync(ctx context.Context, remoteURL, direction string, types []string, since string, collections []string) (map[string]any, map[string]any, error) {
+	rawManifest, err := SyncManifestFromRemote(remoteURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Convert *syncManifest to map[string]any by round-tripping through JSON
+	// so the tool body stays type-clean (no internal/http types in pkg/mcp).
+	var manifest map[string]any
+	if rawManifest != nil {
+		if b, err := json.Marshal(rawManifest); err == nil {
+			json.Unmarshal(b, &manifest)
+		}
+	}
+
+	var result map[string]any
+	if direction == "pull" {
+		result = SyncPull(h.cfg, remoteURL, types, since)
+		if containsType(types, "collections") && len(collections) > 0 {
+			result["collections_sync"] = syncPullCollections(h.cfg, remoteURL, collections)
+		}
+	} else {
+		result = syncPush(ctx, h.cfg, remoteURL, types, since)
+		if containsType(types, "collections") && len(collections) > 0 {
+			result["collections_sync"] = syncPushCollections(ctx, h.cfg, remoteURL, collections)
+		}
+	}
+	return result, manifest, nil
+}
+
 // CollectionMeta implements mcp.Deps: returns observable metadata for the
 // named collection without exposing the internal/store.CollectionMeta pointer
 // to pkg/mcp. Returns zero CollectionInfo when the collection manager is nil
@@ -861,66 +895,12 @@ func (h *mcpHandler) toolCrossSearch(ctx context.Context, args map[string]any) m
 	return mcp.ToolCrossSearch(ctx, h, args)
 }
 
+// toolSync is a thin shim over mcp.ToolSync. F-4 wave 3q moved the body
+// (arg parsing, direction gate, manifest fetch, SyncPull/Push, heartbeat)
+// into pkg/mcp. DoSync wraps all the internal/http sync helpers so
+// pkg/mcp stays free of APIConfig and *store.CollectionManager.
 func (h *mcpHandler) toolSync(ctx context.Context, args map[string]any) mcpToolResult {
-	remoteURL, _ := args["remote_url"].(string)
-	if remoteURL == "" {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: 'remote_url' required (e.g., http://10.23.0.53:8080/api/v1)"}}, IsError: true}
-	}
-	direction, _ := args["direction"].(string)
-	if direction == "" {
-		direction = "pull"
-	}
-	since, _ := args["since"].(string)
-
-	var types []string
-	if typesRaw, ok := args["types"].([]any); ok {
-		for _, t := range typesRaw {
-			if s, ok := t.(string); ok {
-				types = append(types, s)
-			}
-		}
-	}
-
-	var collectionNames []string
-	if collsRaw, ok := args["collections"].([]any); ok {
-		for _, c := range collsRaw {
-			if s, ok := c.(string); ok && s != "" {
-				collectionNames = append(collectionNames, s)
-			}
-		}
-	}
-
-	if h.cfg.DB == nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: database not configured"}}, IsError: true}
-	}
-
-	// First, get remote manifest
-	manifest, err := SyncManifestFromRemote(remoteURL)
-	if err != nil {
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: "Error: " + err.Error()}}, IsError: true}
-	}
-
-	if direction == "pull" {
-		result := SyncPull(h.cfg, remoteURL, types, since)
-		// Collection sync (pull: fetch text from remote → re-embed locally)
-		if containsType(types, "collections") && len(collectionNames) > 0 {
-			result["collections_sync"] = syncPullCollections(h.cfg, remoteURL, collectionNames)
-		}
-		result["remote_manifest"] = manifest
-		h.logHeartbeat("sync", map[string]any{"direction": "pull", "remote": remoteURL, "types": types})
-		out, _ := json.MarshalIndent(result, "", "  ")
-		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(out)}}}
-	}
-
-	// Push: export local data, POST to remote
-	result := syncPush(ctx, h.cfg, remoteURL, types, since)
-	if containsType(types, "collections") && len(collectionNames) > 0 {
-		result["collections_sync"] = syncPushCollections(ctx, h.cfg, remoteURL, collectionNames)
-	}
-	result["remote_manifest"] = manifest
-	h.logHeartbeat("sync", map[string]any{"direction": "push", "remote": remoteURL, "types": types})
-	out, _ := json.MarshalIndent(result, "", "  ")
-	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(out)}}}
+	return mcp.ToolSync(ctx, h, args)
 }
 
 func syncPush(ctx context.Context, cfg APIConfig, remoteURL string, types []string, since string) map[string]any {

--- a/Levara/pkg/mcp/deps.go
+++ b/Levara/pkg/mcp/deps.go
@@ -50,6 +50,10 @@ import (
 //   - wave 3o: + CollectionMeta (toolGetProjectContext + toolCheckDrift).
 //              Returns CollectionInfo value type so pkg/mcp stays free of
 //              internal/store.CollectionMeta pointer.
+//   - wave 3q: + DoSync (toolSync). One high-level method absorbs all
+//              internal/http sync helpers (SyncPull, syncPush,
+//              syncPullCollections, syncPushCollections) so pkg/mcp doesn't
+//              need to know about APIConfig or *store.CollectionManager.
 type Deps interface {
 	// DB returns the shared *sql.DB used for palace / datasets / graph
 	// tables. May be nil when no PostgresDSN is configured — tool
@@ -156,6 +160,16 @@ type Deps interface {
 	// toolCheckDrift to read per-collection stats without leaking the
 	// internal/store.CollectionMeta pointer into pkg/mcp.
 	CollectionMeta(name string) CollectionInfo
+	// DoSync orchestrates a bidirectional sync operation with a remote
+	// Levara instance. It returns the per-type sync result map and the
+	// remote manifest map. The caller is responsible for adding
+	// remote_manifest to result and calling LogHeartbeat. error is
+	// returned only for connectivity failures (manifest fetch); per-type
+	// sync errors are folded into the result map under "<type>_error"
+	// keys, matching the pre-refactor behaviour. One method absorbs all
+	// internal/http sync helpers so pkg/mcp doesn't need APIConfig or
+	// *store.CollectionManager.
+	DoSync(ctx context.Context, remoteURL, direction string, types []string, since string, collections []string) (result, manifest map[string]any, err error)
 }
 
 // SearchPipeline is the narrow interface toolSearch calls into. The

--- a/Levara/pkg/mcp/deps_test.go
+++ b/Levara/pkg/mcp/deps_test.go
@@ -72,6 +72,10 @@ type fakeDeps struct {
 	// collectionMetas is keyed by collection name. Tests that exercise
 	// toolGetProjectContext or toolCheckDrift populate this map.
 	collectionMetas map[string]CollectionInfo
+
+	// doSyncFn stubs DoSync. When nil, returns empty result + empty
+	// manifest + nil error (happy-path default).
+	doSyncFn func(ctx context.Context, remoteURL, direction string, types []string, since string, collections []string) (map[string]any, map[string]any, error)
 }
 
 // insertedRow records a single CollectionInsert call so tests can
@@ -209,6 +213,12 @@ func (f *fakeDeps) CollectionMeta(name string) CollectionInfo {
 	}
 	return f.collectionMetas[name]
 }
+func (f *fakeDeps) DoSync(ctx context.Context, remoteURL, direction string, types []string, since string, collections []string) (map[string]any, map[string]any, error) {
+	if f.doSyncFn != nil {
+		return f.doSyncFn(ctx, remoteURL, direction, types, since, collections)
+	}
+	return map[string]any{}, map[string]any{}, nil
+}
 
 // fakeSearchPipeline is a programmable SearchPipeline stub. Each method
 // consults a matching function field; when nil, returns empty results
@@ -276,11 +286,14 @@ func (nilDBDeps) LogHeartbeat(string, any)                                      
 func (nilDBDeps) RunPipeline(context.Context, []string, orchestrator.Config, chan<- orchestrator.Progress) error {
 	return nil
 }
-func (nilDBDeps) NewSearchPipeline(bool) SearchPipeline          { return nil }
-func (nilDBDeps) LLMProvider() llm.Provider                      { return nil }
-func (nilDBDeps) LLMModel() string                               { return "" }
-func (nilDBDeps) SearchCapabilities() router.Capabilities        { return router.Capabilities{} }
-func (nilDBDeps) CollectionMeta(string) CollectionInfo           { return CollectionInfo{} }
+func (nilDBDeps) NewSearchPipeline(bool) SearchPipeline   { return nil }
+func (nilDBDeps) LLMProvider() llm.Provider               { return nil }
+func (nilDBDeps) LLMModel() string                        { return "" }
+func (nilDBDeps) SearchCapabilities() router.Capabilities { return router.Capabilities{} }
+func (nilDBDeps) CollectionMeta(string) CollectionInfo    { return CollectionInfo{} }
+func (nilDBDeps) DoSync(context.Context, string, string, []string, string, []string) (map[string]any, map[string]any, error) {
+	return map[string]any{}, map[string]any{}, nil
+}
 
 func setupDepsTestDB(t *testing.T) *fakeDeps {
 	t.Helper()

--- a/Levara/pkg/mcp/tool_sync.go
+++ b/Levara/pkg/mcp/tool_sync.go
@@ -1,0 +1,86 @@
+package mcp
+
+// Sync tool: bidirectional data sync between Levara instances.
+// Migrated in F-4 wave 3q — the last remaining full-body tool in
+// internal/http/mcp.go. One DoSync Deps method absorbs all the sync
+// helpers (SyncPull, syncPush, syncPullCollections, syncPushCollections,
+// SyncManifestFromRemote) so pkg/mcp stays free of APIConfig and
+// *store.CollectionManager.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// ToolSync orchestrates a bidirectional sync with a remote Levara instance.
+//
+// Args:
+//   - remote_url (required): e.g. "http://10.23.0.53:8080/api/v1"
+//   - direction: "pull" (default) or "push"
+//   - since: ISO-8601 timestamp — only sync records updated after this
+//   - types: ["memories", "graph", "collections"] — default all
+//   - collections: collection names for the collections type
+//
+// Error branches: missing remote_url → IsError; nil DB → IsError;
+// manifest-fetch failure → IsError. Per-type errors are folded into
+// the result JSON under "<type>_error" keys, matching pre-refactor
+// behaviour.
+func ToolSync(ctx context.Context, deps Deps, args map[string]any) ToolResult {
+	remoteURL, _ := args["remote_url"].(string)
+	if remoteURL == "" {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: 'remote_url' required (e.g., http://10.23.0.53:8080/api/v1)"}},
+			IsError: true,
+		}
+	}
+
+	direction, _ := args["direction"].(string)
+	if direction == "" {
+		direction = "pull"
+	}
+	since, _ := args["since"].(string)
+
+	var types []string
+	if typesRaw, ok := args["types"].([]any); ok {
+		for _, t := range typesRaw {
+			if s, ok := t.(string); ok {
+				types = append(types, s)
+			}
+		}
+	}
+
+	var collectionNames []string
+	if collsRaw, ok := args["collections"].([]any); ok {
+		for _, c := range collsRaw {
+			if s, ok := c.(string); ok && s != "" {
+				collectionNames = append(collectionNames, s)
+			}
+		}
+	}
+
+	if deps.DB() == nil {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: "Error: database not configured"}},
+			IsError: true,
+		}
+	}
+
+	result, manifest, err := deps.DoSync(ctx, remoteURL, direction, types, since, collectionNames)
+	if err != nil {
+		return ToolResult{
+			Content: []Content{{Type: "text", Text: fmt.Sprintf("Error: %s", err.Error())}},
+			IsError: true,
+		}
+	}
+
+	result["remote_manifest"] = manifest
+	deps.LogHeartbeat("sync", map[string]any{
+		"direction": direction,
+		"remote":    remoteURL,
+		"types":     types,
+	})
+
+	out, _ := json.MarshalIndent(result, "", "  ")
+	return ToolResult{Content: []Content{{Type: "text", Text: string(out)}}}
+}

--- a/Levara/pkg/mcp/tool_sync_test.go
+++ b/Levara/pkg/mcp/tool_sync_test.go
@@ -1,0 +1,151 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// ── ToolSync ──
+
+func TestToolSync_MissingRemoteURL(t *testing.T) {
+	res := ToolSync(context.Background(), &fakeDeps{}, map[string]any{})
+	if !res.IsError {
+		t.Fatal("want IsError when remote_url missing")
+	}
+	if !strings.Contains(res.Content[0].Text, "'remote_url' required") {
+		t.Errorf("wrong error text: %q", res.Content[0].Text)
+	}
+}
+
+func TestToolSync_NilDB(t *testing.T) {
+	res := ToolSync(context.Background(), &fakeDeps{}, map[string]any{
+		"remote_url": "http://remote:8080/api/v1",
+	})
+	if !res.IsError {
+		t.Fatal("want IsError when DB is nil")
+	}
+	if !strings.Contains(res.Content[0].Text, "database not configured") {
+		t.Errorf("wrong error text: %q", res.Content[0].Text)
+	}
+}
+
+func TestToolSync_ManifestFetchError(t *testing.T) {
+	deps := setupCodifyDB(t) // any DB with tables is fine for this test
+	deps.doSyncFn = func(ctx context.Context, remoteURL, direction string, types []string, since string, collections []string) (map[string]any, map[string]any, error) {
+		return nil, nil, errors.New("connection refused")
+	}
+	res := ToolSync(context.Background(), deps, map[string]any{
+		"remote_url": "http://remote:8080/api/v1",
+	})
+	if !res.IsError {
+		t.Fatal("want IsError when manifest fetch fails")
+	}
+	if !strings.Contains(res.Content[0].Text, "connection refused") {
+		t.Errorf("wrong error text: %q", res.Content[0].Text)
+	}
+}
+
+func TestToolSync_PullDefault(t *testing.T) {
+	deps := setupCodifyDB(t)
+	var gotDirection string
+	deps.doSyncFn = func(ctx context.Context, remoteURL, direction string, types []string, since string, collections []string) (map[string]any, map[string]any, error) {
+		gotDirection = direction
+		return map[string]any{"memories": "ok"}, map[string]any{"embed_model": "nomic"}, nil
+	}
+
+	res := ToolSync(context.Background(), deps, map[string]any{
+		"remote_url": "http://remote:8080/api/v1",
+		// direction omitted → default "pull"
+	})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	if gotDirection != "pull" {
+		t.Errorf("default direction=%q, want pull", gotDirection)
+	}
+	// Response should be JSON with remote_manifest key.
+	var out map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &out); err != nil {
+		t.Fatalf("response not JSON: %s", res.Content[0].Text)
+	}
+	if _, ok := out["remote_manifest"]; !ok {
+		t.Error("remote_manifest not in response")
+	}
+}
+
+func TestToolSync_PushDirection(t *testing.T) {
+	deps := setupCodifyDB(t)
+	var gotDirection string
+	deps.doSyncFn = func(ctx context.Context, remoteURL, direction string, types []string, since string, collections []string) (map[string]any, map[string]any, error) {
+		gotDirection = direction
+		return map[string]any{}, map[string]any{}, nil
+	}
+
+	res := ToolSync(context.Background(), deps, map[string]any{
+		"remote_url": "http://remote:8080/api/v1",
+		"direction":  "push",
+	})
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %q", res.Content[0].Text)
+	}
+	if gotDirection != "push" {
+		t.Errorf("direction=%q, want push", gotDirection)
+	}
+}
+
+func TestToolSync_TypesForwarded(t *testing.T) {
+	deps := setupCodifyDB(t)
+	var gotTypes []string
+	deps.doSyncFn = func(ctx context.Context, remoteURL, direction string, types []string, since string, collections []string) (map[string]any, map[string]any, error) {
+		gotTypes = types
+		return map[string]any{}, map[string]any{}, nil
+	}
+
+	ToolSync(context.Background(), deps, map[string]any{
+		"remote_url": "http://remote:8080/api/v1",
+		"types":      []any{"memories", "graph"},
+	})
+	if len(gotTypes) != 2 || gotTypes[0] != "memories" || gotTypes[1] != "graph" {
+		t.Errorf("types=%v, want [memories graph]", gotTypes)
+	}
+}
+
+func TestToolSync_HeartbeatFired(t *testing.T) {
+	deps := setupCodifyDB(t)
+	deps.doSyncFn = func(ctx context.Context, remoteURL, direction string, types []string, since string, collections []string) (map[string]any, map[string]any, error) {
+		return map[string]any{}, map[string]any{}, nil
+	}
+	fired := false
+	deps.heartbeatFn = func(eventType string, payload any) {
+		if eventType == "sync" {
+			fired = true
+		}
+	}
+
+	ToolSync(context.Background(), deps, map[string]any{
+		"remote_url": "http://remote:8080/api/v1",
+	})
+	if !fired {
+		t.Error("heartbeat 'sync' not fired")
+	}
+}
+
+func TestToolSync_CollectionsForwarded(t *testing.T) {
+	deps := setupCodifyDB(t)
+	var gotCollections []string
+	deps.doSyncFn = func(ctx context.Context, remoteURL, direction string, types []string, since string, collections []string) (map[string]any, map[string]any, error) {
+		gotCollections = collections
+		return map[string]any{}, map[string]any{}, nil
+	}
+
+	ToolSync(context.Background(), deps, map[string]any{
+		"remote_url":  "http://remote:8080/api/v1",
+		"collections": []any{"coll1", "coll2"},
+	})
+	if len(gotCollections) != 2 {
+		t.Errorf("collections=%v, want [coll1 coll2]", gotCollections)
+	}
+}


### PR DESCRIPTION
## Summary
- **ToolSync** migrated to `pkg/mcp/tool_sync.go` — last remaining full-body tool
- **New Deps method**: `DoSync(ctx, remoteURL, direction, types, since, collections)` wraps all internal/http sync helpers in one clean interface boundary
- `*syncManifest` → `map[string]any` via JSON round-trip in the forwarder — no behaviour change, type-clean in pkg/mcp
- **Milestone**: every `mcpHandler.tool*` in `internal/http` is now a one-line shim

## Test plan
- [x] 8 tests: missing remote_url, nil DB, manifest fetch error, pull default, push direction, types forwarded, heartbeat fired, collections forwarded
- [x] 35/35 packages pass `go test -race ./...`

## F-4 complete
All 33 registered MCP tools now have bodies in `pkg/mcp`, testable without a live HTTP/LLM/embed stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)