### PR TITLE
test(http): post-F-4 search coverage — waves A/B/C/D + doc sync

### DIFF
--- a/Levara/internal/http/cypher_nl_search_test.go
+++ b/Levara/internal/http/cypher_nl_search_test.go
@@ -1,0 +1,209 @@
+// cypher_nl_search_test.go — Wave B coverage for Cypher-gated paths.
+//
+// Covers:
+//   - cypherSearch            (CYPHER search type)
+//   - naturalLanguageSearch   (NATURAL_LANGUAGE) fallback branches
+//   - extractCypher           (pure helper used by NL path)
+//
+// Both handlers need a running Neo4j for the success path; we do not pull
+// one in. Instead we exercise every early-exit branch — security gates,
+// missing config, and fallback-to-graphCompletion paths — which is where
+// the bugs tend to hide anyway (a misconfigured gate is worse than a slow
+// query).
+package http
+
+import (
+	"testing"
+)
+
+// ── cypherSearch ──
+
+// Security gate: ALLOW_CYPHER_QUERY must be exactly "true" or the handler
+// returns 403 before even looking at the rest of the config.
+func TestCypherSearch_DisabledByDefault(t *testing.T) {
+	t.Setenv("ALLOW_CYPHER_QUERY", "")
+	env := newSearchTestEnv(t)
+	env.start()
+
+	status, body := env.postSearch(map[string]any{
+		"query_text":   "MATCH (n) RETURN n",
+		"query_type":   "CYPHER",
+		"cypher_query": "MATCH (n) RETURN n LIMIT 1",
+	})
+	if status != 403 {
+		t.Fatalf("status = %d, want 403", status)
+	}
+	if detail, _ := body["detail"].(string); detail == "" {
+		t.Errorf("missing error detail; got %v", body)
+	}
+}
+
+// Flag set but Neo4j not configured → 503 with explicit detail.
+func TestCypherSearch_RequiresNeo4j(t *testing.T) {
+	t.Setenv("ALLOW_CYPHER_QUERY", "true")
+	env := newSearchTestEnv(t)
+	// Neo4jCfg left zero.
+	env.start()
+
+	status, body := env.postSearch(map[string]any{
+		"query_text":   "q",
+		"query_type":   "CYPHER",
+		"cypher_query": "MATCH (n) RETURN n LIMIT 1",
+	})
+	if status != 503 {
+		t.Fatalf("status = %d, want 503", status)
+	}
+	if detail, _ := body["detail"].(string); detail == "" {
+		t.Errorf("missing detail; got %v", body)
+	}
+}
+
+// Empty cypher_query → 400.
+func TestCypherSearch_RequiresQuery(t *testing.T) {
+	t.Setenv("ALLOW_CYPHER_QUERY", "true")
+	env := newSearchTestEnv(t)
+	env.cfg.Neo4jCfg = GraphVisualizationConfig{Neo4jURL: "bolt://unused.test:7687"}
+	env.start()
+
+	status, _ := env.postSearch(map[string]any{
+		"query_text": "q",
+		"query_type": "CYPHER",
+		// cypher_query omitted
+	})
+	if status != 400 {
+		t.Fatalf("status = %d, want 400", status)
+	}
+}
+
+// Write-operation keywords must be blocked before touching Neo4j. We check
+// every keyword the production code screens for so a future edit to the
+// list is caught.
+func TestCypherSearch_BlocksWrites(t *testing.T) {
+	t.Setenv("ALLOW_CYPHER_QUERY", "true")
+
+	// Spelled in the form the production check looks for (uppercased &
+	// including the trailing space for SET).
+	writeQueries := []struct {
+		name  string
+		query string
+	}{
+		{"CREATE", "CREATE (n:Person {name:'x'}) RETURN n"},
+		{"MERGE", "MERGE (n:Person {name:'x'}) RETURN n"},
+		{"DELETE", "MATCH (n) DELETE n"},
+		{"DETACH", "MATCH (n) DETACH DELETE n"},
+		{"SET", "MATCH (n) SET n.x = 1 RETURN n"},
+		{"REMOVE", "MATCH (n) REMOVE n.x RETURN n"},
+		// Lowercase keyword must still be blocked — the handler upper-cases
+		// the query before comparing.
+		{"lowercase create", "create (n) return n"},
+	}
+
+	for _, tc := range writeQueries {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newSearchTestEnv(t)
+			env.cfg.Neo4jCfg = GraphVisualizationConfig{Neo4jURL: "bolt://unused.test:7687"}
+			env.start()
+
+			status, body := env.postSearch(map[string]any{
+				"query_text":   "q",
+				"query_type":   "CYPHER",
+				"cypher_query": tc.query,
+			})
+			if status != 403 {
+				t.Fatalf("status = %d, want 403 (write blocked); body=%v", status, body)
+			}
+		})
+	}
+}
+
+// ── naturalLanguageSearch ──
+
+// No Neo4j configured → falls back to graphCompletionSearch. We verify by
+// checking search_type flips from NATURAL_LANGUAGE to GRAPH_COMPLETION.
+func TestNaturalLanguageSearch_NoNeo4jFallsBack(t *testing.T) {
+	env := newSearchTestEnv(t)
+	t.Setenv("LLM_ENDPOINT", "")
+	t.Setenv("LLM_MODEL", "")
+	env.start()
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "who is Alice",
+		"query_type": "NATURAL_LANGUAGE",
+	})
+	if body["search_type"] != "GRAPH_COMPLETION" {
+		t.Errorf("search_type = %v, want GRAPH_COMPLETION (fallback)", body["search_type"])
+	}
+}
+
+// Neo4j set but LLM env unset → also falls back (can't translate NL → Cypher
+// without an LLM).
+func TestNaturalLanguageSearch_NoLLMFallsBack(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.cfg.Neo4jCfg = GraphVisualizationConfig{Neo4jURL: "bolt://unused.test:7687"}
+	t.Setenv("LLM_ENDPOINT", "")
+	t.Setenv("LLM_MODEL", "")
+	env.start()
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "who is Alice",
+		"query_type": "NATURAL_LANGUAGE",
+	})
+	if body["search_type"] != "GRAPH_COMPLETION" {
+		t.Errorf("search_type = %v, want GRAPH_COMPLETION (no-LLM fallback)", body["search_type"])
+	}
+}
+
+// ── extractCypher (pure helper) ──
+
+func TestExtractCypher(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "markdown cypher block",
+			in:   "```cypher\nMATCH (n) RETURN n LIMIT 10\n```",
+			want: "MATCH (n) RETURN n LIMIT 10",
+		},
+		{
+			name: "markdown generic block",
+			in:   "```\nMATCH (n) RETURN n LIMIT 10\n```",
+			want: "MATCH (n) RETURN n LIMIT 10",
+		},
+		{
+			name: "plain match",
+			in:   "MATCH (n:Person) RETURN n.name LIMIT 5",
+			want: "MATCH (n:Person) RETURN n.name LIMIT 5",
+		},
+		{
+			name: "preamble then match",
+			in:   "Sure! Here is the query:\nMATCH (n) RETURN n LIMIT 5",
+			want: "MATCH (n) RETURN n LIMIT 5",
+		},
+		{
+			name: "no cypher at all",
+			in:   "I'm sorry, I can't help with that.",
+			want: "",
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "whitespace only",
+			in:   "   \n\t ",
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractCypher(tc.in)
+			if got != tc.want {
+				t.Errorf("extractCypher(%q)\n  got  %q\n  want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/Levara/internal/http/extended_search_test.go
+++ b/Levara/internal/http/extended_search_test.go
@@ -1,0 +1,472 @@
+// extended_search_test.go — Wave C coverage for the "extended" search
+// handlers on top of vector + graph:
+//
+//   contextExtensionSearch     (GRAPH_COMPLETION_CONTEXT_EXTENSION, 2-hop)
+//   cotSearch                  (GRAPH_COMPLETION_COT, chain-of-thought)
+//   communityLocalSearch       (COMMUNITY_LOCAL)
+//   communityGlobalSearch      (COMMUNITY_GLOBAL, map-reduce)
+//   parseJSONStringArray       (pure helper used by cotSearch)
+//
+// All four handlers have cheap, deterministic fallback paths that dominate
+// real-world traffic (any time embed/DB/LLM is missing). Those are the
+// branches we cover here — the full happy path for every handler requires
+// a live Neo4j and a capable LLM, both of which are out of scope for unit
+// tests.
+package http
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// ── contextExtensionSearch ──
+
+func TestContextExtensionSearch_EmptyConfig(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.cfg.EmbedEndpoint = ""
+	env.cfg.Collections = nil
+	env.start()
+
+	status, body := env.postSearch(map[string]any{
+		"query_text": "q",
+		"query_type": "GRAPH_COMPLETION_CONTEXT_EXTENSION",
+	})
+	if status != 200 {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if body["search_type"] != "GRAPH_COMPLETION_CONTEXT_EXTENSION" {
+		t.Errorf("search_type = %v", body["search_type"])
+	}
+}
+
+// Postgres path populates hop1 context via graphContextFromPostgres, but
+// the postgres helper does NOT return target names, so hop2 stays empty.
+// We verify that explicitly — the 2-hop feature only works against Neo4j.
+func TestContextExtensionSearch_PostgresHop1Only(t *testing.T) {
+	env := newSearchTestEnv(t)
+	t.Setenv("LLM_ENDPOINT", "")
+	t.Setenv("LLM_MODEL", "")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"name": "Alice"})
+	env.insertNode("n1", "Alice", "Person", "")
+	env.insertNode("n2", "Bob", "Person", "")
+	env.insertEdge("r1", "n1", "n2", "KNOWS")
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "alice",
+		"query_type": "GRAPH_COMPLETION_CONTEXT_EXTENSION",
+		"collection": "entities",
+	})
+
+	hop1, _ := body["context_hop1"].([]any)
+	hop2, _ := body["context_hop2"].([]any)
+	if len(hop1) != 1 {
+		t.Fatalf("hop1 = %v (len=%d), want 1", hop1, len(hop1))
+	}
+	if len(hop2) != 0 {
+		t.Errorf("hop2 = %v, want empty (postgres backend has no targets)", hop2)
+	}
+	if body["hops"] != float64(2) {
+		t.Errorf("hops = %v, want 2", body["hops"])
+	}
+}
+
+// With LLM provider wired, contextExtension must call it with a prompt
+// that labels the 1-hop vs 2-hop context sections.
+func TestContextExtensionSearch_CallsLLMWithLabelledContext(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{responses: []string{"Alice knows Bob."}}
+	env.cfg.LLMProvider = llm
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused-model")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"name": "Alice"})
+	env.insertNode("n1", "Alice", "Person", "")
+	env.insertNode("n2", "Bob", "Person", "")
+	env.insertEdge("r1", "n1", "n2", "KNOWS")
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "who does alice know",
+		"query_type": "GRAPH_COMPLETION_CONTEXT_EXTENSION",
+		"collection": "entities",
+	})
+	if body["answer"] != "Alice knows Bob." {
+		t.Errorf("answer = %v", body["answer"])
+	}
+	prompts := llm.promptsSnapshot()
+	if len(prompts) != 1 {
+		t.Fatalf("captured %d prompts, want 1", len(prompts))
+	}
+	if !strings.Contains(prompts[0], "Direct relationships (1-hop)") {
+		t.Errorf("prompt missing hop1 label:\n%s", prompts[0])
+	}
+	// No hop2 content via postgres, so the "Extended relationships (2-hop)"
+	// header must NOT appear when hop2 is empty.
+	if strings.Contains(prompts[0], "Extended relationships (2-hop)") {
+		t.Errorf("prompt has hop2 section with no hop2 data:\n%s", prompts[0])
+	}
+}
+
+// ── cotSearch ──
+
+// No LLM env → falls back to graphCompletionSearch (single-step).
+func TestCoTSearch_NoLLMFallsBack(t *testing.T) {
+	env := newSearchTestEnv(t)
+	t.Setenv("LLM_ENDPOINT", "")
+	t.Setenv("LLM_MODEL", "")
+	env.start()
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "q",
+		"query_type": "GRAPH_COMPLETION_COT",
+	})
+	if body["search_type"] != "GRAPH_COMPLETION" {
+		t.Errorf("search_type = %v, want GRAPH_COMPLETION (fallback)", body["search_type"])
+	}
+}
+
+// LLM env set but no collections → skeleton response with COT search_type.
+func TestCoTSearch_NoCollectionsSkeleton(t *testing.T) {
+	env := newSearchTestEnv(t)
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused")
+	env.cfg.LLMProvider = &recordingLLM{}
+	env.cfg.EmbedEndpoint = ""
+	env.cfg.Collections = nil
+	env.start()
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "q",
+		"query_type": "GRAPH_COMPLETION_COT",
+	})
+	if body["search_type"] != "GRAPH_COMPLETION_COT" {
+		t.Errorf("search_type = %v", body["search_type"])
+	}
+	if body["answer"] != "" {
+		t.Errorf("answer = %v, want empty", body["answer"])
+	}
+}
+
+// Happy path: LLM decomposes into sub-questions, sub-queries find entities
+// and graph context, synthesis prompt called. We script two LLM responses
+// — decomposition (JSON array) and synthesis — and verify the prompt
+// shape captured.
+func TestCoTSearch_DecomposesAndSynthesises(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{
+		responses: []string{
+			`["who is alice", "who does alice know"]`, // decompose
+			"Alice knows Bob.",                        // synthesise
+		},
+	}
+	env.cfg.LLMProvider = llm
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"name": "Alice"})
+	env.insertNode("n1", "Alice", "Person", "")
+	env.insertNode("n2", "Bob", "Person", "")
+	env.insertEdge("r1", "n1", "n2", "KNOWS")
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "tell me about alice",
+		"query_type": "GRAPH_COMPLETION_COT",
+		"collection": "entities",
+	})
+	if body["answer"] != "Alice knows Bob." {
+		t.Errorf("answer = %v, want scripted reply", body["answer"])
+	}
+	steps, _ := body["reasoning_steps"].([]any)
+	if len(steps) != 2 {
+		t.Fatalf("reasoning_steps len=%d, want 2", len(steps))
+	}
+	prompts := llm.promptsSnapshot()
+	if len(prompts) != 2 {
+		t.Fatalf("captured %d prompts, want 2 (decompose + synthesise)", len(prompts))
+	}
+	if !strings.Contains(prompts[0], "sub-questions") {
+		t.Errorf("first prompt should be the decomposition prompt, got:\n%s", prompts[0])
+	}
+	if !strings.Contains(prompts[1], "multi-step research") {
+		t.Errorf("second prompt should be the synthesis prompt, got:\n%s", prompts[1])
+	}
+}
+
+// Decomposition fails to produce a JSON array → handler uses the original
+// query as the sole sub-question. We detect this by checking the LLM saw
+// exactly one decompose call and one step surfaced in the response.
+func TestCoTSearch_BadDecompositionFallsBackToSingleStep(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{
+		responses: []string{
+			"not a json array", // bad decompose
+			"answer about alice",
+		},
+	}
+	env.cfg.LLMProvider = llm
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"name": "Alice"})
+	env.insertNode("n1", "Alice", "Person", "")
+	env.insertNode("n2", "Bob", "Person", "")
+	env.insertEdge("r1", "n1", "n2", "KNOWS")
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "tell me about alice",
+		"query_type": "GRAPH_COMPLETION_COT",
+		"collection": "entities",
+	})
+	steps, _ := body["reasoning_steps"].([]any)
+	if len(steps) != 1 {
+		t.Fatalf("reasoning_steps len=%d, want 1 (single-step fallback)", len(steps))
+	}
+	step0, _ := steps[0].(map[string]any)
+	if sub, _ := step0["sub_question"].(string); sub != "tell me about alice" {
+		t.Errorf("sub_question = %q, want original query", sub)
+	}
+}
+
+// ── parseJSONStringArray ──
+
+func TestParseJSONStringArray(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"plain array", `["a", "b", "c"]`, []string{"a", "b", "c"}},
+		{"markdown wrapped", "```json\n[\"a\", \"b\"]\n```", []string{"a", "b"}},
+		{"markdown generic", "```\n[\"a\"]\n```", []string{"a"}},
+		{"with preamble", `Here are the questions: ["a", "b"]`, []string{"a", "b"}},
+		{"empty array", `[]`, nil}, // Go's json decodes [] into a nil slice for our initial nil var
+		{"invalid", "not json", nil},
+		{"object not array", `{"a": 1}`, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseJSONStringArray(tc.in)
+			if tc.name == "empty array" {
+				// json.Unmarshal into a nil slice leaves it nil; accept [] too.
+				if len(got) != 0 {
+					t.Errorf("parseJSONStringArray(%q) = %v, want empty", tc.in, got)
+				}
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("parseJSONStringArray(%q)\n  got  %v\n  want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// ── communityLocalSearch ──
+
+func TestCommunityLocalSearch_EmptyConfig(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.cfg.EmbedEndpoint = ""
+	env.cfg.Collections = nil
+	env.start()
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "q",
+		"query_type": "COMMUNITY_LOCAL",
+	})
+	if body["search_type"] != "COMMUNITY_LOCAL" {
+		t.Errorf("search_type = %v", body["search_type"])
+	}
+}
+
+// Vector hit but no matching community → fall back to graphCompletion.
+func TestCommunityLocalSearch_NoCommunityFallback(t *testing.T) {
+	env := newSearchTestEnv(t)
+	t.Setenv("LLM_ENDPOINT", "")
+	t.Setenv("LLM_MODEL", "")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"name": "Alice"})
+	env.insertNode("n1", "Alice", "Person", "")
+	// No community inserted → LookupCommunities returns empty → fallback.
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "alice",
+		"query_type": "COMMUNITY_LOCAL",
+		"collection": "entities",
+	})
+	if body["search_type"] != "GRAPH_COMPLETION" {
+		t.Errorf("search_type = %v, want GRAPH_COMPLETION (fallback)", body["search_type"])
+	}
+}
+
+// Happy path: entity has a community, LLM wired → community-based answer.
+func TestCommunityLocalSearch_UsesCommunityContext(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{responses: []string{"The auth community covers users and roles."}}
+	env.cfg.LLMProvider = llm
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"name": "Alice"})
+	env.insertNode("n1", "Alice", "Person", "")
+	env.insertNode("n2", "Bob", "Person", "")
+	env.insertEdge("r1", "n1", "n2", "KNOWS")
+	env.insertCommunity("c-auth", 0, "Auth subsystem: users, roles, permissions", []string{"n1", "n2"})
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "who is alice",
+		"query_type": "COMMUNITY_LOCAL",
+		"collection": "entities",
+	})
+	if body["search_type"] != "COMMUNITY_LOCAL" {
+		t.Errorf("search_type = %v, want COMMUNITY_LOCAL", body["search_type"])
+	}
+	if body["answer"] != "The auth community covers users and roles." {
+		t.Errorf("answer = %v", body["answer"])
+	}
+	commsUsed, _ := body["communities_used"].([]any)
+	if len(commsUsed) != 1 {
+		t.Fatalf("communities_used len=%d, want 1", len(commsUsed))
+	}
+	prompts := llm.promptsSnapshot()
+	if len(prompts) != 1 {
+		t.Fatalf("captured %d prompts, want 1", len(prompts))
+	}
+	if !strings.Contains(prompts[0], "Community summary: Auth subsystem") {
+		t.Errorf("prompt missing community summary:\n%s", prompts[0])
+	}
+}
+
+// ── communityGlobalSearch ──
+
+func TestCommunityGlobalSearch_EmptyConfig(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.cfg.EmbedEndpoint = ""
+	env.cfg.Collections = nil
+	env.start()
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "q",
+		"query_type": "COMMUNITY_GLOBAL",
+	})
+	if body["search_type"] != "COMMUNITY_GLOBAL" {
+		t.Errorf("search_type = %v", body["search_type"])
+	}
+}
+
+// No LLM → falls back to plain chunksSearch (documented behaviour:
+// map-reduce is pointless without an LLM to map/reduce with).
+func TestCommunityGlobalSearch_NoLLMFallsBackToChunks(t *testing.T) {
+	env := newSearchTestEnv(t)
+	t.Setenv("LLM_ENDPOINT", "")
+	t.Setenv("LLM_MODEL", "")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"text": "hello"})
+
+	status, body := env.postSearch(map[string]any{
+		"query_text": "q",
+		"query_type": "COMMUNITY_GLOBAL",
+		"collection": "entities",
+	})
+	if status != 200 {
+		t.Fatalf("status = %d", status)
+	}
+	// chunksSearch returns a raw array, so the parsed map will be nil and the
+	// raw body comes back as a JSON array. postSearch decodes into map[string]
+	// any — a JSON array decodes to nil map. Confirm via absence of the
+	// search_type field.
+	if _, ok := body["search_type"]; ok {
+		t.Errorf("expected raw-array chunks response (no search_type), got %v", body)
+	}
+}
+
+// No _community_summaries collection → falls back to graphCompletion.
+func TestCommunityGlobalSearch_NoSummariesFallback(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{responses: []string{"fallback answer"}}
+	env.cfg.LLMProvider = llm
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused")
+	env.start()
+
+	// Only a regular collection, no _community_summaries.
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"name": "Alice"})
+	env.insertNode("n1", "Alice", "Person", "")
+	env.insertNode("n2", "Bob", "Person", "")
+	env.insertEdge("r1", "n1", "n2", "KNOWS")
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "alice",
+		"query_type": "COMMUNITY_GLOBAL",
+		"collection": "entities",
+	})
+	if body["search_type"] != "GRAPH_COMPLETION" {
+		t.Errorf("search_type = %v, want GRAPH_COMPLETION (fallback)", body["search_type"])
+	}
+}
+
+// Summary collection exists → map step runs concurrently, reduce step
+// synthesises. We script N map-phase responses + 1 synthesis response and
+// confirm all were called.
+func TestCommunityGlobalSearch_MapReduceSynthesises(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{
+		responses: []string{
+			// Order of map-phase responses is non-deterministic (concurrent).
+			// All of them return the same string so ordering doesn't matter;
+			// the synthesis response is the last in the script.
+			"Auth covers login.",
+			"Ingest covers pipelines.",
+			"Final synthesised answer.",
+		},
+	}
+	env.cfg.LLMProvider = llm
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused")
+	env.start()
+
+	// Seed _community_summaries collection. The request collection must NOT
+	// be set to only this one, since resolveCollections with req.Collection
+	// would restrict the search to a different collection. Leave it empty so
+	// ListByDomain / List returns all collections, which includes the
+	// _community_summaries one.
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("_community_summaries", "c1", vec, map[string]any{
+		"community_id": "c-auth", "text": "Auth: users, roles", "member_count": float64(5), "level": float64(0),
+	})
+	env.insertVector("_community_summaries", "c2", vec, map[string]any{
+		"community_id": "c-ingest", "text": "Ingest: pipelines", "member_count": float64(3), "level": float64(0),
+	})
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "what subsystems exist",
+		"query_type": "COMMUNITY_GLOBAL",
+	})
+	if body["search_type"] != "COMMUNITY_GLOBAL" {
+		t.Errorf("search_type = %v", body["search_type"])
+	}
+	if body["total_communities_searched"] != float64(2) {
+		t.Errorf("total_communities_searched = %v, want 2", body["total_communities_searched"])
+	}
+	if body["answer"] != "Final synthesised answer." {
+		t.Errorf("answer = %v, want synthesised reply", body["answer"])
+	}
+	prompts := llm.promptsSnapshot()
+	if len(prompts) != 3 {
+		t.Fatalf("captured %d prompts, want 3 (2 map + 1 reduce)", len(prompts))
+	}
+}

--- a/Levara/internal/http/graph_search_test.go
+++ b/Levara/internal/http/graph_search_test.go
@@ -1,0 +1,338 @@
+// graph_search_test.go — Wave A coverage for the two graph-based search paths:
+//
+//   graphCompletionSearch     (GRAPH_COMPLETION / GRAPH_SUMMARY_COMPLETION)
+//   tripletCompletionSearch   (TRIPLET_COMPLETION)
+//
+// Both handlers follow the same pattern: vector search → extract entity names
+// from chunk metadata → fetch graph context → optionally feed to LLM. The
+// tests below exercise every early-exit branch plus the full happy path using
+// an in-process CollectionManager, an in-memory SQLite graph, a httptest
+// embed-server, and a recordingLLM that captures the prompt.
+package http
+
+import (
+	"strings"
+	"testing"
+)
+
+// ── graphCompletionSearch ──
+
+// Empty config (no embed endpoint, no CollectionManager) must return a
+// well-formed skeleton instead of 500ing.
+func TestGraphCompletionSearch_EmptyConfig(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.cfg.EmbedEndpoint = ""
+	env.cfg.Collections = nil
+	env.start()
+
+	status, body := env.postSearch(map[string]any{
+		"query_text": "anything",
+		"query_type": "GRAPH_COMPLETION",
+	})
+	if status != 200 {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if body["answer"] != "" {
+		t.Errorf("answer = %v, want empty", body["answer"])
+	}
+	if body["search_type"] != "GRAPH_COMPLETION" {
+		t.Errorf("search_type = %v, want GRAPH_COMPLETION", body["search_type"])
+	}
+}
+
+// Vector-only path: no graph data and no LLM env → chunks returned, empty
+// answer, empty context. This is the common case when the graph stage fails
+// or when the caller has not yet indexed entities.
+func TestGraphCompletionSearch_VectorOnly_NoGraph_NoLLM(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.cfg.LLMProvider = nil
+	// Ensure stray env doesn't flip us into the LLM branch.
+	t.Setenv("LLM_ENDPOINT", "")
+	t.Setenv("LLM_MODEL", "")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"name": "Alice", "text": "Alice writes code"})
+
+	status, body := env.postSearch(map[string]any{
+		"query_text": "who writes code",
+		"query_type": "GRAPH_COMPLETION",
+		"collection": "entities",
+	})
+	if status != 200 {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if body["answer"] != "" {
+		t.Errorf("answer = %v, want empty (LLM env unset)", body["answer"])
+	}
+	chunks, ok := body["chunks"].([]any)
+	if !ok || len(chunks) != 1 {
+		t.Fatalf("chunks = %v (len=%d), want 1", body["chunks"], len(chunks))
+	}
+	if ctxArr, _ := body["context"].([]any); len(ctxArr) != 0 {
+		t.Errorf("context = %v, want empty (no graph rows)", ctxArr)
+	}
+}
+
+// With an entity name extracted from the chunk metadata and matching edges in
+// Postgres, graphContextFromPostgres must populate context[]. Still no LLM —
+// we only verify the retrieval half here.
+func TestGraphCompletionSearch_PostgresGraphContext(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.cfg.LLMProvider = nil
+	t.Setenv("LLM_ENDPOINT", "")
+	t.Setenv("LLM_MODEL", "")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"name": "Alice"})
+	env.insertNode("n1", "Alice", "Person", "")
+	env.insertNode("n2", "Bob", "Person", "")
+	env.insertEdge("rel1", "n1", "n2", "KNOWS")
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "alice",
+		"query_type": "GRAPH_COMPLETION",
+		"collection": "entities",
+	})
+
+	ctxArr, _ := body["context"].([]any)
+	if len(ctxArr) != 1 {
+		t.Fatalf("context = %v (len=%d), want 1 edge", ctxArr, len(ctxArr))
+	}
+	line, _ := ctxArr[0].(string)
+	if !strings.Contains(line, "Alice") || !strings.Contains(line, "Bob") || !strings.Contains(line, "KNOWS") {
+		t.Errorf("context[0] = %q, want mention of Alice/Bob/KNOWS", line)
+	}
+}
+
+// Happy path: vector hit + graph edge + LLMProvider wired. The recordingLLM
+// must see a prompt containing both the question and the graph triple.
+func TestGraphCompletionSearch_CallsLLMWithGraphContext(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{responses: []string{"Alice knows Bob."}}
+	env.cfg.LLMProvider = llm
+	// callLLMFromAPI still gates on these env vars before delegating to the
+	// provider. The actual values are never dialed when provider is non-nil.
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused-model")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"name": "Alice"})
+	env.insertNode("n1", "Alice", "Person", "")
+	env.insertNode("n2", "Bob", "Person", "")
+	env.insertEdge("rel1", "n1", "n2", "KNOWS")
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "who does alice know",
+		"query_type": "GRAPH_COMPLETION",
+		"collection": "entities",
+	})
+
+	if body["answer"] != "Alice knows Bob." {
+		t.Errorf("answer = %v, want scripted LLM reply", body["answer"])
+	}
+	prompts := llm.promptsSnapshot()
+	if len(prompts) != 1 {
+		t.Fatalf("captured %d prompts, want 1", len(prompts))
+	}
+	if !strings.Contains(prompts[0], "who does alice know") {
+		t.Errorf("prompt missing question: %q", prompts[0])
+	}
+	if !strings.Contains(prompts[0], "Alice") || !strings.Contains(prompts[0], "Bob") || !strings.Contains(prompts[0], "KNOWS") {
+		t.Errorf("prompt missing graph triple: %q", prompts[0])
+	}
+}
+
+// RBAC: a chunk with dataset_id="blocked" must be filtered out when the
+// caller's AllowedDatasetIDs does not include it. Since the request-path
+// field is unexported (RBAC is set from user_id locals, not the body), we
+// drive this through searchHandler → GetAllowedDatasetIDs by using a middle-
+// ware that injects user_id and by seeding the RBAC mapping in the DB.
+//
+// Simpler direct route: call filterByAllowedDatasets via the same public
+// entry point — we verify the handler respects a pre-populated allow-list by
+// tagging the chunk's metadata and checking the response.
+func TestGraphCompletionSearch_RBACFiltersChunks(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.cfg.LLMProvider = nil
+	t.Setenv("LLM_ENDPOINT", "")
+	t.Setenv("LLM_MODEL", "")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e-allowed", vec, map[string]any{
+		"name": "Alice", "dataset_id": "ds-allowed",
+	})
+	env.insertVector("entities", "e-blocked", vec, map[string]any{
+		"name": "Eve", "dataset_id": "ds-blocked",
+	})
+
+	// RBAC filter is applied from AllowedDatasetIDs set on the request by
+	// searchHandler via GetAllowedDatasetIDs. With no user_id header and no
+	// dataset_access rows, it returns nil ⇒ no filter. So for this test we
+	// seed one row to force filtering.
+	if _, err := env.db.Exec(`CREATE TABLE dataset_access (user_id TEXT, dataset_id TEXT)`); err != nil {
+		t.Fatalf("create dataset_access: %v", err)
+	}
+	if _, err := env.db.Exec(`INSERT INTO dataset_access(user_id, dataset_id) VALUES ('u1', 'ds-allowed')`); err != nil {
+		t.Fatalf("seed dataset_access: %v", err)
+	}
+
+	// Use a request without user_id → AllowedDatasetIDs stays nil → no filter.
+	// Both chunks should come back.
+	_, body := env.postSearch(map[string]any{
+		"query_text": "anything",
+		"query_type": "GRAPH_COMPLETION",
+		"collection": "entities",
+	})
+	chunks, _ := body["chunks"].([]any)
+	if len(chunks) != 2 {
+		t.Fatalf("without user_id: got %d chunks, want 2 (no RBAC filter)", len(chunks))
+	}
+}
+
+// ── tripletCompletionSearch ──
+
+// With no embed endpoint we take the same well-formed skeleton exit as the
+// graph path but under the TRIPLET_COMPLETION search_type.
+func TestTripletCompletionSearch_EmptyConfig(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.cfg.EmbedEndpoint = ""
+	env.cfg.Collections = nil
+	env.start()
+
+	status, body := env.postSearch(map[string]any{
+		"query_text": "anything",
+		"query_type": "TRIPLET_COMPLETION",
+	})
+	if status != 200 {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if body["search_type"] != "TRIPLET_COMPLETION" {
+		t.Errorf("search_type = %v, want TRIPLET_COMPLETION", body["search_type"])
+	}
+	if body["answer"] != "" {
+		t.Errorf("answer = %v, want empty", body["answer"])
+	}
+}
+
+// No collection contains the substring "triplet" → the handler must delegate
+// to graphCompletionSearch, and therefore return a GRAPH_COMPLETION payload
+// (with chunks + context, not triplets).
+func TestTripletCompletionSearch_FallbackToGraph(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.cfg.LLMProvider = nil
+	t.Setenv("LLM_ENDPOINT", "")
+	t.Setenv("LLM_MODEL", "")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"name": "Alice"})
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "alice",
+		"query_type": "TRIPLET_COMPLETION",
+		"collection": "entities",
+	})
+	if body["search_type"] != "GRAPH_COMPLETION" {
+		t.Errorf("search_type = %v, want GRAPH_COMPLETION (fallback)", body["search_type"])
+	}
+	if _, ok := body["triplets"]; ok {
+		t.Errorf("unexpected triplets field in fallback response")
+	}
+}
+
+// Happy path: a triplet collection is present, its metadata carries
+// source/rel/target, and the LLM receives a prompt with the formatted
+// triplet context.
+func TestTripletCompletionSearch_ParsesTripletsAndCallsLLM(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{responses: []string{"Bob authored Paper1."}}
+	env.cfg.LLMProvider = llm
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused-model")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("triplets_main", "t1", vec, map[string]any{
+		"source": "Bob", "rel": "AUTHORED", "target": "Paper1",
+	})
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "who authored paper1",
+		"query_type": "TRIPLET_COMPLETION",
+		"collection": "triplets_main",
+	})
+
+	if body["search_type"] != "TRIPLET_COMPLETION" {
+		t.Errorf("search_type = %v, want TRIPLET_COMPLETION", body["search_type"])
+	}
+	triplets, _ := body["triplets"].([]any)
+	if len(triplets) != 1 {
+		t.Fatalf("triplets = %v (len=%d), want 1", triplets, len(triplets))
+	}
+	if body["answer"] != "Bob authored Paper1." {
+		t.Errorf("answer = %v, want scripted LLM reply", body["answer"])
+	}
+	prompts := llm.promptsSnapshot()
+	if len(prompts) != 1 {
+		t.Fatalf("captured %d prompts, want 1", len(prompts))
+	}
+	want := "Bob -> AUTHORED -> Paper1"
+	if !strings.Contains(prompts[0], want) {
+		t.Errorf("prompt missing triplet %q in:\n%s", want, prompts[0])
+	}
+	if !strings.Contains(prompts[0], "who authored paper1") {
+		t.Errorf("prompt missing question: %q", prompts[0])
+	}
+}
+
+// A triplet row missing rel/source/target must not crash the handler or
+// produce phantom triplet lines in the LLM prompt. We assert both that the
+// handler returns 200 and that the prompt does not contain a malformed line.
+func TestTripletCompletionSearch_SkipsIncompleteTriplets(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{responses: []string{"ok"}}
+	env.cfg.LLMProvider = llm
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused-model")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("triplets_main", "t1", vec, map[string]any{
+		"source": "Bob",
+		// rel and target missing
+	})
+	env.insertVector("triplets_main", "t2", vec, map[string]any{
+		"source": "Alice", "rel": "KNOWS", "target": "Bob",
+	})
+
+	status, body := env.postSearch(map[string]any{
+		"query_text": "relationships",
+		"query_type": "TRIPLET_COMPLETION",
+		"collection": "triplets_main",
+	})
+	if status != 200 {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	// Both rows surface as triplets in the response (the filter only guards
+	// the LLM prompt formatting), but prompt must only reference the valid
+	// triple.
+	triplets, _ := body["triplets"].([]any)
+	if len(triplets) != 2 {
+		t.Fatalf("triplets len=%d, want 2 (raw results unfiltered)", len(triplets))
+	}
+	prompts := llm.promptsSnapshot()
+	if len(prompts) != 1 {
+		t.Fatalf("captured %d prompts, want 1", len(prompts))
+	}
+	if !strings.Contains(prompts[0], "Alice -> KNOWS -> Bob") {
+		t.Errorf("prompt missing valid triple, got: %s", prompts[0])
+	}
+	if strings.Contains(prompts[0], "Bob -> ") && !strings.Contains(prompts[0], "Bob -> KNOWS") {
+		t.Errorf("prompt contains malformed Bob-> line: %s", prompts[0])
+	}
+}
+

--- a/Levara/internal/http/rbac_search_test.go
+++ b/Levara/internal/http/rbac_search_test.go
@@ -1,0 +1,210 @@
+// rbac_search_test.go — Wave D: end-to-end RBAC for search.
+//
+// The production code path is:
+//
+//   searchHandler → c.Locals("user_id") → GetAllowedDatasetIDs(db, ctx, uid)
+//     → req.AllowedDatasetIDs → filterByAllowedDatasets(results, allowed)
+//
+// We wire a middleware that sets Locals("user_id") to a test user, seed
+// users/datasets/dataset_shares, and insert vectors tagged with dataset_id
+// in their metadata. The tests verify:
+//
+//   * User B cannot see user A's data (isolation).
+//   * Once A shares with B, B can see it (share grant).
+//   * Without user_id (anonymous) no filter applies (dev-mode compat).
+//   * Superusers bypass the filter.
+//
+// This complements the Wave A RBAC test, which only checked the "no
+// filter" branch — here we prove the filter itself works end-to-end.
+package http
+
+import (
+	"testing"
+)
+
+func TestRBAC_UserBCannotSeeUserAData(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.startWithUser("user-b")
+
+	env.insertUser("user-a", "a@example.com", false)
+	env.insertUser("user-b", "b@example.com", false)
+	env.insertDataset("ds-a", "user-a")
+	env.insertDataset("ds-b", "user-b")
+
+	vec := []float32{1, 0, 0, 0}
+	// Data in user A's dataset (not shared).
+	env.insertVector("entities", "a1", vec, map[string]any{
+		"name": "Alice", "dataset_id": "ds-a",
+	})
+	// Data in user B's own dataset.
+	env.insertVector("entities", "b1", vec, map[string]any{
+		"name": "Bob", "dataset_id": "ds-b",
+	})
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "q",
+		"query_type": "GRAPH_COMPLETION",
+		"collection": "entities",
+	})
+	chunks, _ := body["chunks"].([]any)
+	if len(chunks) != 1 {
+		t.Fatalf("chunks len=%d, want 1 (user-b only sees ds-b)", len(chunks))
+	}
+	chunk, _ := chunks[0].(map[string]any)
+	if id, _ := chunk["id"].(string); id != "b1" {
+		t.Errorf("visible chunk id=%q, want b1", id)
+	}
+}
+
+// After owner A shares ds-a with user B, user B's search must include
+// ds-a's chunks. Verifies dataset_shares is read into AllowedDatasetIDs.
+func TestRBAC_SharedDatasetVisibleToGrantee(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.startWithUser("user-b")
+
+	env.insertUser("user-a", "a@example.com", false)
+	env.insertUser("user-b", "b@example.com", false)
+	env.insertDataset("ds-a", "user-a")
+	env.shareDataset("ds-a", "user-b", "viewer")
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "a1", vec, map[string]any{
+		"name": "Alice", "dataset_id": "ds-a",
+	})
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "q",
+		"query_type": "GRAPH_COMPLETION",
+		"collection": "entities",
+	})
+	chunks, _ := body["chunks"].([]any)
+	if len(chunks) != 1 {
+		t.Fatalf("chunks len=%d, want 1 (ds-a now shared to user-b)", len(chunks))
+	}
+}
+
+// Anonymous request (no Locals("user_id")) → GetAllowedDatasetIDs returns
+// nil → filterByAllowedDatasets is a no-op. Both chunks come back.
+func TestRBAC_AnonymousBypass(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.start() // no user middleware
+
+	env.insertUser("user-a", "a@example.com", false)
+	env.insertDataset("ds-a", "user-a")
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "a1", vec, map[string]any{
+		"name": "Alice", "dataset_id": "ds-a",
+	})
+	env.insertVector("entities", "orphan", vec, map[string]any{
+		"name": "Orphan", // no dataset_id
+	})
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "q",
+		"query_type": "GRAPH_COMPLETION",
+		"collection": "entities",
+	})
+	chunks, _ := body["chunks"].([]any)
+	if len(chunks) != 2 {
+		t.Errorf("chunks len=%d, want 2 (no filter without user_id)", len(chunks))
+	}
+}
+
+// Superuser bypass: is_superuser=true → GetAllowedDatasetIDs returns nil
+// → no filter, even with user_id set. Validates the bypass clause in
+// rbac.go:229-233.
+func TestRBAC_SuperuserBypass(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.startWithUser("admin")
+
+	env.insertUser("admin", "admin@example.com", true)
+	env.insertUser("user-a", "a@example.com", false)
+	env.insertDataset("ds-a", "user-a")
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "a1", vec, map[string]any{
+		"name": "Alice", "dataset_id": "ds-a",
+	})
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "q",
+		"query_type": "GRAPH_COMPLETION",
+		"collection": "entities",
+	})
+	chunks, _ := body["chunks"].([]any)
+	if len(chunks) != 1 {
+		t.Errorf("chunks len=%d, want 1 (superuser sees everything)", len(chunks))
+	}
+}
+
+// Chunks with no dataset_id on their metadata must pass the filter even
+// when the user has a narrow allow-list. This matches production
+// filterByAllowedDatasets behaviour (empty dsID → always allowed) and
+// protects legacy data without dataset tags.
+func TestRBAC_OrphanChunksAllowed(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.startWithUser("user-b")
+
+	env.insertUser("user-a", "a@example.com", false)
+	env.insertUser("user-b", "b@example.com", false)
+	env.insertDataset("ds-a", "user-a")
+	env.insertDataset("ds-b", "user-b")
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "a1", vec, map[string]any{
+		"name": "Alice", "dataset_id": "ds-a",
+	})
+	env.insertVector("entities", "orphan", vec, map[string]any{
+		"name": "Orphan", // no dataset_id → always visible
+	})
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "q",
+		"query_type": "GRAPH_COMPLETION",
+		"collection": "entities",
+	})
+	chunks, _ := body["chunks"].([]any)
+	if len(chunks) != 1 {
+		t.Fatalf("chunks len=%d, want 1 (orphan only; ds-a filtered out)", len(chunks))
+	}
+	chunk, _ := chunks[0].(map[string]any)
+	if id, _ := chunk["id"].(string); id != "orphan" {
+		t.Errorf("visible chunk id=%q, want orphan", id)
+	}
+}
+
+// Same isolation check, but for the triplet path (different handler,
+// same filter code). Regression guard: a future refactor must not drop
+// the filter call from any handler that surfaces chunks.
+func TestRBAC_TripletHandlerHonoursFilter(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.startWithUser("user-b")
+
+	env.insertUser("user-a", "a@example.com", false)
+	env.insertUser("user-b", "b@example.com", false)
+	env.insertDataset("ds-a", "user-a")
+	env.insertDataset("ds-b", "user-b")
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("triplets_main", "t-a", vec, map[string]any{
+		"source": "Alice", "rel": "KNOWS", "target": "Bob", "dataset_id": "ds-a",
+	})
+	env.insertVector("triplets_main", "t-b", vec, map[string]any{
+		"source": "Charlie", "rel": "WORKS_AT", "target": "Acme", "dataset_id": "ds-b",
+	})
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "q",
+		"query_type": "TRIPLET_COMPLETION",
+		"collection": "triplets_main",
+	})
+	triplets, _ := body["triplets"].([]any)
+	if len(triplets) != 1 {
+		t.Fatalf("triplets len=%d, want 1 (user-b only sees ds-b)", len(triplets))
+	}
+	tri, _ := triplets[0].(map[string]any)
+	if id, _ := tri["id"].(string); id != "t-b" {
+		t.Errorf("visible triplet id=%q, want t-b", id)
+	}
+}

--- a/Levara/internal/http/search_test_helpers.go
+++ b/Levara/internal/http/search_test_helpers.go
@@ -25,6 +25,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -102,9 +103,10 @@ func newEmbedServer(t testing.TB, fixedVec []float32) *httptest.Server {
 	}))
 }
 
-// graphSchemaSQL creates the subset of tables graphContextFromPostgres and
-// the triplet/community paths read. Mirrors schema.go graph_nodes/edges but
-// adds dataset_id column used by RBAC filters.
+// graphSchemaSQL creates the subset of tables graphContextFromPostgres,
+// community*, and RBAC paths query against. Mirrors the relevant shape of
+// schema.go + the community/RBAC tables defined elsewhere. `dataset_id`
+// on graph_nodes is the RBAC post-filter key.
 const graphSchemaSQL = `
 CREATE TABLE graph_nodes (
 	id TEXT PRIMARY KEY,
@@ -126,6 +128,36 @@ CREATE TABLE graph_edges (
 	valid_until TEXT,
 	superseded_by TEXT NOT NULL DEFAULT '',
 	confidence REAL NOT NULL DEFAULT 1.0
+);
+CREATE TABLE graph_communities (
+	id TEXT PRIMARY KEY,
+	level INTEGER NOT NULL DEFAULT 0,
+	parent_id TEXT NOT NULL DEFAULT '',
+	member_count INTEGER NOT NULL DEFAULT 0,
+	summary TEXT NOT NULL DEFAULT ''
+);
+CREATE TABLE community_members (
+	id TEXT PRIMARY KEY,
+	community_id TEXT NOT NULL,
+	node_id TEXT NOT NULL,
+	level INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE users (
+	id TEXT PRIMARY KEY,
+	email TEXT,
+	is_superuser INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE datasets (
+	id TEXT PRIMARY KEY,
+	owner_id TEXT
+);
+CREATE TABLE dataset_shares (
+	id TEXT PRIMARY KEY,
+	dataset_id TEXT NOT NULL,
+	user_id TEXT NOT NULL,
+	role TEXT NOT NULL DEFAULT 'viewer',
+	granted_by TEXT,
+	created_at TEXT
 );
 `
 
@@ -209,6 +241,84 @@ func (e *searchTestEnv) start() {
 	app := fiber.New(fiber.Config{DisableStartupMessage: true})
 	app.Post("/search/text", searchHandler(e.cfg))
 	e.app = app
+}
+
+// startWithUser is the same as start() but injects a middleware that sets
+// Locals("user_id") = userID before the handler. Use for RBAC tests that
+// depend on GetAllowedDatasetIDs resolving to a concrete user.
+func (e *searchTestEnv) startWithUser(userID string) {
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("user_id", userID)
+		return c.Next()
+	})
+	app.Post("/search/text", searchHandler(e.cfg))
+	e.app = app
+}
+
+// insertUser seeds the users table. isSuperuser=true grants the dataset-
+// filter bypass inside GetAllowedDatasetIDs.
+func (e *searchTestEnv) insertUser(id, email string, isSuperuser bool) {
+	e.t.Helper()
+	su := 0
+	if isSuperuser {
+		su = 1
+	}
+	_, err := e.db.Exec(
+		`INSERT INTO users(id, email, is_superuser) VALUES (?, ?, ?)`,
+		id, email, su,
+	)
+	if err != nil {
+		e.t.Fatalf("insert user %q: %v", id, err)
+	}
+}
+
+// insertDataset seeds datasets.
+func (e *searchTestEnv) insertDataset(id, ownerID string) {
+	e.t.Helper()
+	_, err := e.db.Exec(
+		`INSERT INTO datasets(id, owner_id) VALUES (?, ?)`,
+		id, ownerID,
+	)
+	if err != nil {
+		e.t.Fatalf("insert dataset %q: %v", id, err)
+	}
+}
+
+// shareDataset grants userID read access to datasetID via dataset_shares.
+func (e *searchTestEnv) shareDataset(datasetID, userID, role string) {
+	e.t.Helper()
+	_, err := e.db.Exec(
+		`INSERT INTO dataset_shares(id, dataset_id, user_id, role, granted_by, created_at)
+		 VALUES (?, ?, ?, ?, '', '')`,
+		"share-"+datasetID+"-"+userID, datasetID, userID, role,
+	)
+	if err != nil {
+		e.t.Fatalf("share dataset %q→%q: %v", datasetID, userID, err)
+	}
+}
+
+// insertCommunity seeds graph_communities + community_members for a single
+// community at the given level.
+func (e *searchTestEnv) insertCommunity(commID string, level int, summary string, memberNodeIDs []string) {
+	e.t.Helper()
+	_, err := e.db.Exec(
+		`INSERT INTO graph_communities(id, level, parent_id, member_count, summary)
+		 VALUES (?, ?, '', ?, ?)`,
+		commID, level, len(memberNodeIDs), summary,
+	)
+	if err != nil {
+		e.t.Fatalf("insert community %q: %v", commID, err)
+	}
+	for i, nodeID := range memberNodeIDs {
+		_, err := e.db.Exec(
+			`INSERT INTO community_members(id, community_id, node_id, level) VALUES (?, ?, ?, ?)`,
+			commID+"-m"+strconv.Itoa(i), commID, nodeID, level,
+		)
+		if err != nil {
+			e.t.Fatalf("insert community member: %v", err)
+		}
+	}
 }
 
 func (e *searchTestEnv) cleanup() {

--- a/Levara/internal/http/search_test_helpers.go
+++ b/Levara/internal/http/search_test_helpers.go
@@ -1,0 +1,285 @@
+// search_test_helpers.go — shared fixtures for search-handler tests.
+//
+// Wave A of the internal/http test coverage push (fix_tasks.md FIX-2).
+// This file sets up a deterministic environment for every search path:
+//
+//   - CollectionManager rooted in t.TempDir so vector search is in-process
+//   - embed-server httptest replacement that returns a fixed vector per input
+//   - in-memory SQLite with the graph_nodes/graph_edges schema the PG-fallback
+//     paths query against
+//   - recordingLLM implementing llm.Provider so tests can assert prompt shape
+//     without touching a real LLM
+//
+// Tests customise the APIConfig on the returned env, then call env.start()
+// to freeze it into the mounted fiber.App — APIConfig is captured by value
+// inside the handler factories, so post-start mutations would be invisible.
+package http
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	_ "github.com/ncruces/go-sqlite3/driver"
+	"github.com/stek0v/cognevra/internal/store"
+	"github.com/stek0v/cognevra/pkg/llm"
+)
+
+// recordingLLM implements llm.Provider for tests. Each ChatCompletion call
+// pushes the user-message content to prompts and pops the next scripted
+// response. Exhausted scripts fall back to empty string (not an error) to
+// match production "LLM returned nothing" behaviour.
+type recordingLLM struct {
+	mu        sync.Mutex
+	prompts   []string
+	responses []string
+	err       error
+}
+
+func (r *recordingLLM) ChatCompletion(_ context.Context, req llm.CompletionRequest) (*llm.CompletionResponse, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var prompt string
+	if len(req.Messages) > 0 {
+		prompt = req.Messages[0].Content
+	}
+	r.prompts = append(r.prompts, prompt)
+
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	var content string
+	if len(r.responses) > 0 {
+		content = r.responses[0]
+		r.responses = r.responses[1:]
+	}
+	return &llm.CompletionResponse{Content: content}, nil
+}
+
+func (r *recordingLLM) Name() string { return "recording" }
+
+// promptsSnapshot returns a copy of captured prompts. Safe to call from
+// a test goroutine after the handler has completed.
+func (r *recordingLLM) promptsSnapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.prompts))
+	copy(out, r.prompts)
+	return out
+}
+
+// newEmbedServer returns an httptest server that returns fixedVec for every
+// input in an OpenAI-compatible embedding response.
+func newEmbedServer(t testing.TB, fixedVec []float32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Input []string `json:"input"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+
+		type item struct {
+			Index     int       `json:"index"`
+			Embedding []float32 `json:"embedding"`
+		}
+		data := make([]item, len(req.Input))
+		for i := range req.Input {
+			data[i] = item{Index: i, Embedding: fixedVec}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": data})
+	}))
+}
+
+// graphSchemaSQL creates the subset of tables graphContextFromPostgres and
+// the triplet/community paths read. Mirrors schema.go graph_nodes/edges but
+// adds dataset_id column used by RBAC filters.
+const graphSchemaSQL = `
+CREATE TABLE graph_nodes (
+	id TEXT PRIMARY KEY,
+	name TEXT NOT NULL DEFAULT '',
+	type TEXT NOT NULL DEFAULT '',
+	description TEXT NOT NULL DEFAULT '',
+	properties TEXT NOT NULL DEFAULT '{}',
+	dataset_id TEXT,
+	created_at TEXT,
+	updated_at TEXT
+);
+CREATE TABLE graph_edges (
+	id TEXT PRIMARY KEY,
+	source_id TEXT NOT NULL,
+	target_id TEXT NOT NULL,
+	relationship_name TEXT NOT NULL DEFAULT '',
+	properties TEXT NOT NULL DEFAULT '{}',
+	valid_from TEXT,
+	valid_until TEXT,
+	superseded_by TEXT NOT NULL DEFAULT '',
+	confidence REAL NOT NULL DEFAULT 1.0
+);
+`
+
+// searchTestEnv bundles a pre-wired environment for exercising searchHandler
+// and its per-type handlers. Fields are exported for tests to customise cfg
+// (e.g. set LLMProvider) before calling start().
+type searchTestEnv struct {
+	t     testing.TB
+	dir   string
+	cm    *store.CollectionManager
+	db    *sql.DB
+	embed *httptest.Server
+	cfg   APIConfig
+	app   *fiber.App
+}
+
+// newSearchTestEnv constructs the fixture. Caller must customise env.cfg
+// then call env.start() before issuing requests. Cleanup is registered
+// via t.Cleanup so tests don't need to defer.
+func newSearchTestEnv(t testing.TB) *searchTestEnv {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "levara-search-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const dim = 4
+	cm, err := store.NewCollectionManager(dim, dir)
+	if err != nil {
+		os.RemoveAll(dir)
+		t.Fatal(err)
+	}
+
+	dbPath := filepath.Join(dir, "graph.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		cm.Close()
+		os.RemoveAll(dir)
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(graphSchemaSQL); err != nil {
+		db.Close()
+		cm.Close()
+		os.RemoveAll(dir)
+		t.Fatalf("create graph schema: %v", err)
+	}
+
+	// Handler code uses $N placeholders — switch global dialect to SQLite
+	// for the test. Restored in cleanup.
+	SetDBProvider(DBSQLite)
+
+	// Fixed unit-length vector so HNSW scoring is deterministic for the
+	// dim-4 test collection. Any non-zero vector works; all inserts and
+	// queries use this same vector so similarity is 1.0.
+	vec := []float32{1, 0, 0, 0}
+	embedSrv := newEmbedServer(t, vec)
+
+	cfg := APIConfig{
+		EmbedEndpoint: embedSrv.URL,
+		EmbedModel:    "test-model",
+		Collections:   cm,
+		DB:            db,
+	}
+
+	env := &searchTestEnv{
+		t:     t,
+		dir:   dir,
+		cm:    cm,
+		db:    db,
+		embed: embedSrv,
+		cfg:   cfg,
+	}
+
+	t.Cleanup(env.cleanup)
+	return env
+}
+
+// start mounts searchHandler on a fresh fiber app with the current cfg
+// snapshot. Must be called exactly once per env after customisation.
+func (e *searchTestEnv) start() {
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Post("/search/text", searchHandler(e.cfg))
+	e.app = app
+}
+
+func (e *searchTestEnv) cleanup() {
+	if e.app != nil {
+		_ = e.app.Shutdown()
+	}
+	if e.embed != nil {
+		e.embed.Close()
+	}
+	if e.cm != nil {
+		_ = e.cm.Close()
+	}
+	if e.db != nil {
+		_ = e.db.Close()
+	}
+	os.RemoveAll(e.dir)
+	SetDBProvider(DBPostgres)
+}
+
+// insertVector seeds one record into collection (creates it if missing).
+func (e *searchTestEnv) insertVector(collection, id string, vec []float32, meta map[string]any) {
+	e.t.Helper()
+	if err := e.cm.CreateWithDim(collection, len(vec), "test-model", "cosine"); err != nil {
+		e.t.Fatalf("create collection %q: %v", collection, err)
+	}
+	metaBytes, err := json.Marshal(meta)
+	if err != nil {
+		e.t.Fatalf("marshal meta: %v", err)
+	}
+	if err := e.cm.Insert(collection, id, vec, json.RawMessage(metaBytes)); err != nil {
+		e.t.Fatalf("insert vector: %v", err)
+	}
+}
+
+// insertNode seeds graph_nodes. datasetID is optional (pass "" to skip).
+func (e *searchTestEnv) insertNode(id, name, nodeType, datasetID string) {
+	e.t.Helper()
+	_, err := e.db.Exec(
+		`INSERT INTO graph_nodes(id, name, type, properties, dataset_id) VALUES (?, ?, ?, '{}', ?)`,
+		id, name, nodeType, datasetID,
+	)
+	if err != nil {
+		e.t.Fatalf("insert node %q: %v", id, err)
+	}
+}
+
+// insertEdge seeds graph_edges.
+func (e *searchTestEnv) insertEdge(id, srcID, tgtID, rel string) {
+	e.t.Helper()
+	_, err := e.db.Exec(
+		`INSERT INTO graph_edges(id, source_id, target_id, relationship_name) VALUES (?, ?, ?, ?)`,
+		id, srcID, tgtID, rel,
+	)
+	if err != nil {
+		e.t.Fatalf("insert edge %q: %v", id, err)
+	}
+}
+
+// postSearch issues POST /search/text and returns status + decoded body.
+func (e *searchTestEnv) postSearch(body map[string]any) (int, map[string]any) {
+	e.t.Helper()
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/search/text", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := e.app.Test(req, -1)
+	if err != nil {
+		e.t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	var out map[string]any
+	_ = json.Unmarshal(raw, &out)
+	return resp.StatusCode, out
+}

--- a/docs/roadmap-feature-parity.md
+++ b/docs/roadmap-feature-parity.md
@@ -1,499 +1,66 @@
 # Cognevra Go — Roadmap до Feature Parity с Cognee Python
 
-> Текущий статус: 55% feature parity. Core pipeline работает (ingest → cognify → vector search).
-> Главные gaps: graph search types (7 fallback), RBAC isolation, multi-provider LLM.
+> **Статус на 2026-04-17:** все P0 и почти все P1 реализованы. Оставшиеся пункты
+> — P2/P3 (расширения, не feature gap) и **закрытие тестового покрытия** в
+> `internal/http` (самая большая оставшаяся дыра).
+>
+> Документ раньше описывал 55% parity и 7 search-types в fallback —
+> это устарело. Актуальное состояние ниже.
 
 ---
 
-## P0 — CRITICAL (блокируют production deployment)
-
----
-
-### P0.1: Реальные Graph Search Types
-
-**Текущая проблема:**
-7 из 14 search types в `searchHandler` (api.go) используют `chunksSearch()` как fallback вместо реального graph traversal. Пользователь запрашивает `GRAPH_COMPLETION` — получает простой vector search без graph reasoning.
-
-**Что реализовать:**
-
-#### P0.1a: GRAPH_COMPLETION
-- **Описание:** Vector search → найти top-K похожих нод в Neo4j → пройти по рёбрам (1-2 hop) → собрать контекст → отправить LLM с контекстом → вернуть answer
-- **Файлы:** `internal/http/api.go` (searchHandler switch), новый `internal/http/graph_search.go`
-- **Алгоритм:**
-  1. Embed query → vector search в коллекции `PipelineEntity_name`
-  2. Для каждого найденного entity → Neo4j: `MATCH (n)-[r]-(m) WHERE n.id IN $ids RETURN n, r, m`
-  3. Собрать context string: "Entity: X, related to Y via Z"
-  4. LLM prompt: "Given this graph context: {context}\n\nAnswer: {query}"
-  5. Вернуть `{answer, context_nodes, context_edges}`
-- **DoD:**
-  - POST /search/text с query_type=GRAPH_COMPLETION возвращает LLM-generated answer
-  - Answer содержит информацию из graph (не только из chunks)
-  - Если Neo4j недоступен — fallback на RAG_COMPLETION (не chunksSearch)
-  - Response time < 10s (зависит от LLM)
-
-#### P0.1b: TRIPLET_COMPLETION
-- **Описание:** Поиск по triplet embeddings (subject→predicate→object) → LLM completion
-- **Алгоритм:**
-  1. Embed query → search в коллекции `Triplet_text` или `Memify_triplet`
-  2. Собрать top-K triplets как контекст
-  3. LLM prompt с triplet context
-- **DoD:**
-  - Работает если memify был выполнен (triplet embeddings существуют)
-  - Возвращает answer с triplet-based reasoning
-  - Если triplet коллекции нет — fallback на GRAPH_COMPLETION
-
-#### P0.1c: GRAPH_SUMMARY_COMPLETION
-- **Описание:** Использует pre-computed TextSummary ноды (из memify) + graph context
-- **Алгоритм:**
-  1. Поиск в Neo4j: `MATCH (s:TextSummary) WHERE s.text CONTAINS $keyword`
-  2. Для каждого summary → найти связанные entities
-  3. LLM prompt с summary + entity context
-- **DoD:**
-  - Работает после memify (TextSummary ноды существуют)
-  - Быстрее GRAPH_COMPLETION (summaries уже pre-computed)
-
-#### P0.1d: CYPHER passthrough
-- **Описание:** Прямая передача Cypher query в Neo4j
-- **Алгоритм:**
-  1. Получить `cypher_query` из request body
-  2. Проверить флаг `ALLOW_CYPHER_QUERY` (env var)
-  3. `writer.Query(ctx, cypherQuery)` → вернуть результат
-- **DoD:**
-  - Возвращает raw Neo4j результат
-  - Защита: отключаемо через env var
-  - 400 если ALLOW_CYPHER_QUERY=false
-
-#### P0.1e: NATURAL_LANGUAGE
-- **Описание:** NL query → LLM генерирует Cypher → выполняет → возвращает результат
-- **Алгоритм:**
-  1. LLM prompt: "Convert this question to Cypher: {query}\nGraph schema: {schema}"
-  2. Parse Cypher из LLM response
-  3. Execute via Neo4j
-  4. Format results
-- **DoD:**
-  - "Who are the characters in chapter 3?" → Cypher → results
-  - Если LLM не генерирует валидный Cypher — fallback на GRAPH_COMPLETION
-
-**Тестирование P0.1:**
-```
-test_graph_completion_returns_answer — GRAPH_COMPLETION с данными в Neo4j → answer не пустой
-test_graph_completion_uses_graph — answer содержит entity names из графа
-test_graph_completion_no_neo4j_fallback — без Neo4j → fallback на RAG, не chunksSearch
-test_triplet_completion_with_memify — после memify → triplet search работает
-test_cypher_passthrough — raw Cypher → получить ноды
-test_cypher_disabled — ALLOW_CYPHER_QUERY=false → 400
-test_natural_language_to_cypher — NL query → Cypher → results
-test_graph_search_performance — GRAPH_COMPLETION < 15s (including LLM)
-```
-
-**ROI:** HIGH — это 50% жалоб от пользователей. Graph search — ключевая фича Cognee.
-**Effort:** 5 дней
-**Impact:** 7 search types из fallback → real. Coverage: 55% → 75%
-
----
-
-### P0.2: RBAC с изоляцией данных
-
-**Текущая проблема:**
-`dataset_shares` и `acl` таблицы существуют, но vector search и graph queries НЕ фильтруют по user_id/dataset_id. Юзер A может найти данные юзера B через vector search.
-
-**Что реализовать:**
-
-1. **Vector search filtering** — при search в collections, фильтровать результаты по `owner_id` из metadata
-2. **Graph query filtering** — при Neo4j queries, добавлять `WHERE n.owner_id = $userId OR n.dataset_id IN $allowedDatasets`
-3. **Dataset-level ACL check** — перед каждым search проверять `SELECT FROM acl WHERE user_id = $1 AND dataset_id = $2 AND permission = 'read'`
-4. **Empty results (не ошибка)** — если нет доступа, возвращать `[]`, не 403 (security by design)
-
-**Файлы:**
-- `internal/http/api.go` — searchHandler: добавить ACL check перед каждым search
-- `internal/http/rbac.go` — новая функция `checkReadPermission(ctx, db, userID, datasetID) bool`
-- `pipeline/search.go` — SearchPipeline: принимать `allowedDatasetIDs []string` для filtering
-
-**DoD:**
-- Юзер A создаёт dataset + cognify → юзер B НЕ находит данные через search
-- Юзер A шарит dataset юзеру B → юзер B НАХОДИТ данные
-- Без auth header → search возвращает только public/own данные
-- Работает для всех search types (CHUNKS, HYBRID, RAG, GRAPH)
-
-**Тестирование:**
-```
-test_rbac_search_isolation — юзер B не видит данные юзера A через /search/text
-test_rbac_shared_search — после share → юзер B видит
-test_rbac_graph_isolation — graph query фильтрует по owner
-test_rbac_empty_not_error — нет доступа → [], не 403
-test_rbac_no_auth_public — без auth → только public данные
-test_rbac_performance — ACL check добавляет < 5ms к search latency
-```
-
-**ROI:** CRITICAL — без этого multi-tenant deployment невозможен. Security vulnerability.
-**Effort:** 3 дня
-**Impact:** Безопасность multi-tenant. Coverage: → 80%
-
----
-
-### P0.3: Cypher passthrough + ALLOW_CYPHER_QUERY flag
-
-**Включено в P0.1d выше.**
-
-**ROI:** HIGH — power users (data scientists, devs) хотят raw Cypher. 1 день работы.
-**Effort:** 1 день
-
----
-
-## P1 — HIGH (качество и UX)
-
----
-
-### P1.1: Document Classification
-
-**Текущая проблема:**
-Все документы обрабатываются одинаково (chunking → LLM extraction). PDF с таблицами, код на Python, и email — одинаковый pipeline. Cognee classifies documents first и выбирает оптимальную стратегию.
-
-**Что реализовать:**
-- Новый пакет `pkg/classify/classify.go`
-- Определение типа: text_document, tabular_data, code_file, email, presentation, spreadsheet
-- Для каждого типа — разные chunking params (min/max size, overlap)
-- Для code — AST-aware chunking (по функциям, не по параграфам)
-
-**DoD:**
-- PDF → "text_document" → paragraph chunking
-- CSV → "tabular_data" → row-based chunking
-- .py → "code_file" → function-level chunking
-- Классификация добавляет < 10ms per document
-
-**Тестирование:**
-```
-test_classify_pdf_as_text — PDF → text_document
-test_classify_csv_as_tabular — CSV → tabular_data
-test_classify_python_as_code — .py → code_file
-test_classify_performance — < 10ms per file
-test_classify_unknown_fallback — unknown → text_document
-```
-
-**ROI:** MEDIUM — улучшает качество extraction на 20-30% для non-text documents
-**Effort:** 2 дня
-
----
-
-### P1.2: Дополнительные Chunking Strategies
-
-**Текущая проблема:**
-Только 1 стратегия — `ChunkByParagraphMerged`. Cognee имеет 3: paragraph, sentence, row-based.
-
-**Что реализовать:**
-- `pkg/chunker/sentence.go` — уже существует, нужно подключить к pipeline
-- `pkg/chunker/row.go` — новый: для CSV/tabular данных, chunk = N rows
-- Выбор стратегии через settings или auto (после classification)
-
-**DoD:**
-- Settings позволяют выбрать chunking strategy: "paragraph", "sentence", "row", "auto"
-- Auto: text → paragraph, CSV → row, short texts → sentence
-- Все стратегии генерируют UUID5 chunk IDs (детерминистично)
-
-**Тестирование:**
-```
-test_chunk_paragraph_default — paragraph chunking работает (уже есть)
-test_chunk_sentence — sentence chunking разбивает по предложениям
-test_chunk_row_csv — CSV chunking по строкам
-test_chunk_auto_selects — auto выбирает стратегию по типу документа
-test_chunk_deterministic_ids — один и тот же текст → одинаковые chunk IDs
-```
-
-**ROI:** MEDIUM — sentence chunking важен для коротких текстов, row для таблиц
-**Effort:** 1 день
-
----
-
-### P1.3: Temporal Awareness (полная)
-
-**Текущая проблема:**
-`pkg/temporal/temporal.go` извлекает даты из текста, но не интегрирован с graph extraction. Cognee строит time-aware граф с event→entity→timestamp связями.
-
-**Что реализовать:**
-1. **Event extraction** — при cognify извлекать events (что произошло, когда, с кем)
-2. **Temporal edges** — в Neo4j создавать `(Entity)-[:HAPPENED_AT]->(TimePoint)` рёбра
-3. **Temporal search** — `MATCH (e)-[:HAPPENED_AT]->(t) WHERE t.date >= $from AND t.date <= $to`
-4. **Temporal enrichment** — memify стадия: связать events с entities по времени
-
-**DoD:**
-- Cognify текста "Einstein published relativity in 1905" → нода Einstein + нода 1905 + ребро HAPPENED_AT
-- TEMPORAL search "events in 1905" → находит Einstein
-- Time range queries работают
-
-**Тестирование:**
-```
-test_temporal_extraction_creates_nodes — cognify с датами → temporal nodes в Neo4j
-test_temporal_search_range — search по диапазону дат → результаты
-test_temporal_entity_linking — event связан с entities
-test_temporal_performance — temporal search < 100ms
-```
-
-**ROI:** HIGH — temporal queries — уникальная фича Cognee, часто запрашиваемая
-**Effort:** 3 дня
-
----
-
-### P1.4: LLM Multi-Provider Abstraction
-
-**Текущая проблема:**
-Cognevra Go hardcoded на OpenAI-compatible HTTP endpoint. Cognee поддерживает 8+ providers через LiteLLM.
-
-**Что реализовать:**
-- Новый `pkg/llm/provider.go` — интерфейс LLMProvider:
-  ```go
-  type LLMProvider interface {
-      ChatCompletion(ctx, messages []Message, opts Options) (string, error)
-      StructuredOutput(ctx, messages, responseSchema) (json.RawMessage, error)
-  }
-  ```
-- Реализации: OpenAI, Ollama, Anthropic Claude (3 самых важных)
-- Фабрика: `NewProvider(providerName, apiKey, endpoint)` → конкретный provider
-- Retry + timeout + rate limiting встроены
-
-**DoD:**
-- Settings: `llm_provider: "openai" | "ollama" | "anthropic"`
-- Каждый provider проходит одинаковые тесты
-- Переключение provider без перезапуска сервера (через PUT /settings)
-- Anthropic: поддержка Claude 3.5/4
-
-**Тестирование:**
-```
-test_openai_provider_completion — OpenAI → ответ
-test_ollama_provider_completion — Ollama → ответ
-test_anthropic_provider_completion — Claude → ответ (если API key)
-test_provider_switching — PUT /settings provider=ollama → следующий cognify использует Ollama
-test_provider_timeout — timeout 30s → ошибка, не вечное ожидание
-test_provider_retry — 1 retry при 429/500
-test_provider_rate_limit — не более N req/sec
-```
-
-**ROI:** HIGH — Anthropic Claude даёт лучшее качество extraction чем Ollama. Production юзеры хотят OpenAI/Claude.
-**Effort:** 3 дня
-
----
-
-### P1.5: Structured Output (Go Instructor)
-
-**Текущая проблема:**
-Entity extraction парсит JSON из LLM response вручную (regex/string matching). Cognee использует Instructor — type-safe structured output через JSON Schema.
-
-**Что реализовать:**
-- Новый `pkg/llm/structured.go`:
-  - Генерировать JSON Schema из Go struct tags
-  - Отправлять schema в `response_format` (OpenAI) или `tool_use` (Anthropic)
-  - Парсить response в Go struct
-  - Retry при невалидном JSON
-
-**DoD:**
-- Entity extraction через structured output: `KnowledgeGraph{Nodes, Edges}`
-- Retry до 3 раз при parse failure
-- Поддержка OpenAI JSON mode и tool_use mode
-- Fallback на regex parsing если structured output не поддержан
-
-**Тестирование:**
-```
-test_structured_entity_extraction — JSON schema → LLM → parsed KnowledgeGraph
-test_structured_retry_on_invalid — невалидный JSON → retry → success
-test_structured_fallback_regex — provider без JSON mode → regex parsing
-test_structured_performance — overhead < 100ms vs raw parsing
-```
-
-**ROI:** HIGH — quality improvement: structured output даёт 30-40% меньше parse errors
-**Effort:** 2 дня
-
----
-
-## P2 — MEDIUM (feature parity)
-
----
-
-### P2.1: Session-Based Cognify
-
-**Описание:** Cognify с учётом контекста предыдущих сессий. "Remember what I told you yesterday."
-
-**Что реализовать:**
-- При cognify загружать предыдущие interactions из `interactions` table
-- Добавлять context из прошлых queries в LLM prompt
-- Связывать новые entities с entities из прошлых сессий
-
-**DoD:**
-- POST /cognify с session_id → LLM получает context из прошлых queries
-- Новые entities линкуются с существующими по name match
-
-**Тестирование:**
-```
-test_session_cognify_uses_history — с session_id → context из interactions
-test_session_cognify_entity_linking — новые entities связаны с предыдущими
-```
-
-**ROI:** MEDIUM — conversational AI use case
-**Effort:** 2 дня
-
----
-
-### P2.2: Web Scraping Task
-
-**Описание:** Полноценный web scraping (dynamic JS sites) через headless browser.
-
-**Что реализовать:**
-- `pkg/scraper/scraper.go` — интеграция с chromedp (Go headless Chrome)
-- Поддержка: JavaScript-rendered pages, SPA, pagination
-- Timeout + rate limiting
-
-**DoD:**
-- POST /add с URL SPA-сайта → извлечён текст после JS rendering
-- Работает с dynamic content (React/Vue/Angular sites)
-
-**ROI:** MEDIUM — web scraping нужен для ~15% use cases
-**Effort:** 3 дня
-
----
-
-### P2.3: Code-Aware Extraction
-
-**Описание:** AST-based extraction для code files (.py, .js, .go).
-
-**Что реализовать:**
-- Parse AST → extract functions, classes, imports
-- Chunk по function/class boundaries (не по параграфам)
-- Создавать entities: Function, Class, Module, Import
-
-**DoD:**
-- Cognify .py файла → entities: functions, classes с описаниями
-- Graph показывает: Module→contains→Function→imports→Module
-
-**ROI:** MEDIUM — developer tools use case
-**Effort:** 2 дня
-
----
-
-### P2.4: Go CLI Tool
-
-**Описание:** CLI для Cognevra (аналог `cognee-cli`).
-
-**Что реализовать:**
-- `cmd/cli/main.go`:
-  - `cognevra add <file/url/text>`
-  - `cognevra cognify [--dataset=name]`
-  - `cognevra search <query> [--type=CHUNKS]`
-  - `cognevra datasets [list|create|delete]`
-  - `cognevra health`
-
-**DoD:**
-- Все команды работают через HTTP API
-- `cognevra add file.pdf && cognevra cognify && cognevra search "what is this about?"` — полный цикл
-
-**ROI:** MEDIUM — developer UX
-**Effort:** 1 день
-
----
-
-### P2.5: Подключить LLM Cache (уже есть pkg/llmcache)
-
-**Текущая проблема:**
-`pkg/llmcache/` уже реализован (LRU + disk JSONL), но НЕ подключён к orchestrator pipeline.
-
-**Что реализовать:**
-- В `pkg/orchestrator/pipeline.go` перед каждым LLM call → check cache
-- После LLM call → store in cache
-- Key: hash(model + prompt + system_prompt + temperature)
-
-**DoD:**
-- Повторный cognify того же текста → 0 LLM calls (cache hit)
-- Cache hit rate > 90% при re-cognify
-- Cache persists между restart (JSONL file)
-
-**Тестирование:**
-```
-test_llm_cache_hit — cognify → re-cognify → 0 LLM calls
-test_llm_cache_persistence — restart → cache loaded from disk
-test_llm_cache_invalidation — TTL expired → re-call LLM
-```
-
-**ROI:** HIGH — экономит 90% LLM calls при re-cognify. 1 день работы, огромный impact.
-**Effort:** 1 день
-
----
-
-### P2.6: Rate Limiting
-
-**Что реализовать:**
-- `pkg/llm/ratelimit.go` — token bucket или sliding window
-- Настраиваемо: `LLM_RATE_LIMIT_REQUESTS=60`, `LLM_RATE_LIMIT_INTERVAL=60`
-
-**DoD:**
-- При превышении лимита — 429 или queue (не fail)
-- Логирование rate limit events
-
-**ROI:** MEDIUM — защита от overload LLM provider
-**Effort:** 1 день
-
----
-
-## P3 — LOW (nice-to-have)
-
----
-
-### P3.1: Kuzu Graph Backend
-- **Описание:** Альтернатива Neo4j — embedded graph DB (без внешнего сервиса)
-- **Effort:** 5 дней (новый adapter)
-- **ROI:** LOW — Neo4j покрывает 90% use cases
-
-### P3.2: PGVector Backend
-- **Описание:** Vector search через PostgreSQL (pgvector extension)
-- **Effort:** 2 дня
-- **ROI:** LOW — native HNSW быстрее
-
-### P3.3: Audio Transcription
-- **Описание:** Whisper API интеграция для audio файлов
-- **Effort:** 2 дня
-- **ROI:** LOW — нишевый use case
-
-### P3.4: Observability (Sentry + Langfuse)
-- **Описание:** Error tracking + LLM tracing
-- **Effort:** 1 день каждый
-- **ROI:** MEDIUM для production
-
-### P3.5: S3 Cloud Storage
-- **Описание:** Чтение/запись файлов из S3
-- **Effort:** 2 дня
-- **ROI:** MEDIUM для cloud deployments
-
----
-
-## Сводная таблица
-
-| ID | Задача | Effort | ROI | Impact на coverage |
-|----|--------|--------|-----|-------------------|
-| **P0.1** | Graph Search Types (5 типов) | 5д | HIGH | +20% (55→75%) |
-| **P0.2** | RBAC с изоляцией | 3д | CRITICAL | +5% (security) |
-| **P0.3** | Cypher passthrough | 1д | HIGH | +2% |
-| **P1.1** | Document Classification | 2д | MEDIUM | +3% |
-| **P1.2** | Chunking Strategies | 1д | MEDIUM | +2% |
-| **P1.3** | Temporal Awareness | 3д | HIGH | +5% |
-| **P1.4** | LLM Multi-Provider | 3д | HIGH | +5% |
-| **P1.5** | Structured Output | 2д | HIGH | +3% |
-| **P2.1** | Session Cognify | 2д | MEDIUM | +2% |
-| **P2.2** | Web Scraping | 3д | MEDIUM | +2% |
-| **P2.3** | Code Extraction | 2д | MEDIUM | +2% |
-| **P2.4** | Go CLI | 1д | MEDIUM | +1% |
-| **P2.5** | LLM Cache (подключить) | 1д | HIGH | +1% (perf) |
-| **P2.6** | Rate Limiting | 1д | MEDIUM | +1% |
-| **P3.1-P3.5** | Backends, audio, observability, S3 | 12д | LOW | +5% |
-| | **ИТОГО** | **42д** | | **55% → ~100%** |
-
----
-
-## Фазы реализации
-
-### Фаза 1: Production MVP (9 дней → 82% coverage)
-P0.1 + P0.2 + P0.3 + P2.5
-
-### Фаза 2: Quality (11 дней → 93% coverage)
-P1.1 + P1.2 + P1.3 + P1.4 + P1.5
-
-### Фаза 3: Feature Complete (10 дней → 98% coverage)
-P2.1 + P2.2 + P2.3 + P2.4 + P2.6
-
-### Фаза 4: Enterprise (12 дней → 100% coverage)
-P3.1-P3.5
+## Что уже сделано (P0 + P1)
+
+| Пункт | Статус | Где | Тесты |
+|---|---|---|---|
+| P0.1 GRAPH_COMPLETION | ✅ | `internal/http/graph_search.go:22` | `graph_search_test.go` (Wave A) |
+| P0.1 TRIPLET_COMPLETION | ✅ | `graph_search.go:695` | `graph_search_test.go` (Wave A) |
+| P0.1 GRAPH_SUMMARY_COMPLETION | ✅ | роутится на graphCompletion | — |
+| P0.1 CYPHER passthrough | ✅ | `graph_search.go:773` с `ALLOW_CYPHER_QUERY` gate | нужна (Wave B) |
+| P0.1 NATURAL_LANGUAGE | ✅ | `graph_search.go:817` | нужна (Wave B) |
+| P0.1 CONTEXT_EXTENSION (2-hop) | ✅ | `graph_search.go:124` | нужна (Wave C) |
+| P0.1 COT (chain-of-thought) | ✅ | `graph_search.go:329` | нужна (Wave C) |
+| P0.1 COMMUNITY_LOCAL/GLOBAL | ✅ | `graph_search.go:1087` + pkg/community | нужна (Wave C) |
+| P0.1 CODING_RULES | ✅ | `graph_search.go:457` | нужна |
+| P0.2 RBAC изоляция | ✅ | `rbac.go` + `filterByAllowedDatasets` в каждом handler | частично (Wave A) + e2e (Wave D) |
+| P0.3 Cypher flag | ✅ (P0.1d) | `ALLOW_CYPHER_QUERY` env | Wave B |
+| P1.1 Document Classification | ✅ | `pkg/classify/` + wired в `pkg/orchestrator/pipeline.go:155,271` | `classify_test.go` |
+| P1.2 Chunking strategies | ✅ | `pkg/chunker/{paragraph,sentence,row,code,section,sliding}.go` | `*_test.go` есть |
+| P1.3 Temporal awareness | ✅ | `pkg/temporal/` + `TEMPORAL` search type + `HAPPENED_AT` edges | `temporal_test.go` |
+| P1.4 LLM multi-provider | ✅ | `pkg/llm/provider.go` + Anthropic/Ollama/OpenAI | `structured_dispatch_test.go` |
+| P1.5 Structured output | ✅ | `pkg/llm/structured.go` + JSON Schema mode | `structured_dispatch_test.go` |
+| P2.5 LLM cache wired | ✅ | `pipeline.go:905` через `llmcache.Key` | `llmcache/cache_test.go` |
+| P2.6 Rate limiting | ✅ | `pkg/llm/ratelimit.go` | `ratelimit_test.go` |
+| F-4 MCP split | ✅ | 33 tools в `pkg/mcp/` за `Deps` (PRs #7–#30) | 18 test files, 220+ tests |
+
+## Закрытие тестового покрытия в `internal/http` (текущая работа)
+
+`internal/http` = 12k+ LOC, исторически имел 1 test file (`handler_contract_test.go`).
+Сейчас идёт post-F-4 coverage push по 4 волнам:
+
+| Wave | Покрытие | Статус |
+|---|---|---|
+| A | `graphCompletionSearch` + `tripletCompletionSearch` + общий fixture | ✅ 9 тестов, branch `claude/test-wave-a-graph-search` |
+| B | `cypherSearch` (security gates) + `naturalLanguageSearch` (fallback paths) | pending |
+| C | `contextExtensionSearch` + `cotSearch` + `communityLocal/GlobalSearch` | pending |
+| D | RBAC end-to-end (user A cognify → user B isolation) | pending |
+
+## Оставшиеся P2/P3 (не feature-parity, а расширения)
+
+| ID | Задача | Effort | Статус |
+|---|---|---|---|
+| P2.1 | Session-based cognify | 2д | не начато |
+| P2.2 | Web scraping (headless Chrome) | 3д | не начато |
+| P2.3 | Code-aware extraction (AST) | 2д | частично — `pkg/chunker/code.go` есть, entities-by-AST нет |
+| P2.4 | Go CLI tool | 1д | `cmd/cli/` каркас есть |
+| P3.1 | Kuzu graph backend | 5д | ROI low |
+| P3.2 | PGVector backend | 2д | ROI low |
+| P3.3 | Audio transcription | 2д | `pkg/audio/` ранняя стадия |
+| P3.4 | Observability (Sentry/Langfuse) | 2д | `pkg/observe/` есть, интеграция — нет |
+| P3.5 | S3 storage | 2д | `pkg/storage/` частично |
+
+## Ссылки
+
+- [test_reports/fix_tasks.md](../test_reports/fix_tasks.md) — приоритеты по тестовому покрытию (актуализирован 2026-04-17).
+- `pkg/mcp/` — канонический пример модуля с deps-injection и полным test coverage.
+- `internal/http/search_test_helpers.go` — общий fixture для всех search-handler тестов (Wave A-D).

--- a/test_reports/fix_tasks.md
+++ b/test_reports/fix_tasks.md
@@ -1,0 +1,78 @@
+# Levara: план фиксов и тестирования
+
+Модульный review от 2026-04-15, актуализирован 2026-04-17 после F-4 MCP split
+и Wave A покрытия `internal/http`. Приоритеты сортируются по **влияние × риск
+× объём непокрытого кода**.
+
+## Что уже закрыто
+
+- **FIX-1 (db.mu)** — done. Group-commit WAL + async fsync, `internal/store`
+  показывает 8.6× scaling на 8 писателях (см. CLAUDE.md «Cognevra Write Path»).
+- **FIX-2 частично** — MCP вынесен в `pkg/mcp/` (F-4, PRs #7–#30), 18 test
+  files, 220+ тестов. `internal/http/api.go` больше не содержит MCP-handler'ы.
+  Осталось покрыть search-handler'ы (идёт post-F-4 wave A-D).
+- **FIX-3 (orchestrator)** — done. `pkg/orchestrator/pipeline_test.go`,
+  `parseentities_test.go`, `pipeline_deepseek_test.go` (18 тестов).
+- **FIX-4 (extract)** — done. `pkg/extract/extract_test.go` +
+  `code_test.go` (23 теста).
+- **FIX-5 (llm)** — done. `pkg/llm/mock/`, `ratelimit_test.go`,
+  `structured_dispatch_test.go` + mock provider через `pkg/llm/mock`.
+- **FIX-8 (community)** — done. `pkg/community/` уже имеет покрытие на
+  Louvain + incremental.
+
+## Что ещё открыто
+
+### P0 — internal/http search coverage (идёт сейчас)
+
+Post-F-4 coverage push. `internal/http` оставался самым большим untested
+пакетом после выноса MCP. Делим на 4 волны:
+
+- **Wave A — graphCompletionSearch + tripletCompletionSearch** ✅
+  9 тестов, `internal/http/graph_search_test.go`, общий fixture в
+  `search_test_helpers.go`. Branch `claude/test-wave-a-graph-search`.
+- **Wave B — cypherSearch + naturalLanguageSearch** (pending)
+  Фокус: security gates (`ALLOW_CYPHER_QUERY`, write-op blocking) +
+  fallback paths когда LLM не возвращает валидный Cypher.
+- **Wave C — contextExtensionSearch + cotSearch + communityLocal/GlobalSearch** (pending)
+  2-hop traversal, chain-of-thought prompt shape, community retrieval.
+- **Wave D — RBAC end-to-end** (pending)
+  User A cognify → user B search → 0 results. Без моков по максимуму.
+
+### P1 — внешние сервисы / side-paths
+
+- **FIX-6 (cluster sync).** `internal/cluster` — 810 LOC, тесты есть на
+  DirectNode, но property/chaos-тесты на Mac↔Pi sync отсутствуют.
+  Тесты: mock peer + property-test на конвергенцию; chaos — разрыв на
+  N ms в середине sync.
+- **FIX-7 (graph architecture ADR).** `graph` / `graphdb` / `graphstore`
+  — три пакета без чёткого разделения ответственности. Нужен короткий
+  ADR: что где живёт. Предложение: `graphstore` → в `graph` как
+  interface, `graphdb` — Neo4j adapter.
+- **FIX-9 (llmproxy contract tests).** 321 LOC, тестов нет. Нужны
+  golden-запросы из openai-python SDK → expected responses.
+
+### P2 — средние
+
+- **FIX-10** — `pkg/storage` S3 backend через MinIO container.
+- **FIX-11** — `pkg/observe` базовые тесты метрик/трассировки.
+- **FIX-12** — `pkg/ontology` golden-тесты RDF/OWL на 2-3 публичных онтологиях.
+- **FIX-13** — `internal/grpc` contract-тесты, симметричные HTTP.
+- **FIX-14** — слияние `git` + `fetch` → `ingest`, `classify` → `extract`
+  (архитектурное, не тестовое).
+
+### P3 — наблюдать
+
+- **OBS-1** — `pkg/audio` ранняя стадия, не трогать до явного use-case.
+- **OBS-2** — `pkg/temporal` — фича работает, тесты есть.
+- **OBS-3** — `pkg/rerank`, `pkg/llmcache`, `pkg/embed` — зрелые, покрыты.
+
+## Политика при первом падении
+
+1. Остановить прогон.
+2. Записать `test_reports/failures/<pkg>_<test>_<date>.md` со stack trace.
+3. Классифицировать:
+   - `flake` → добавить retry и продолжить;
+   - `env` (missing binary, port busy) → починить инфру;
+   - `regression` → `git bisect`, зафиксировать в `hall="discovery"` через Levara MCP;
+   - `legit-bug` → создать задачу FIX-N, **не чинить автоматически**.
+4. Перед фиксом — `recall_memory(query="<module>", hall="discovery")`.


### PR DESCRIPTION
## Summary

Post-F-4 coverage push for `internal/http`, the largest untested package after the MCP split. 4 waves, 37 test functions, 35/35 packages pass `go test -race`.

- **Wave A** — `graphCompletionSearch` + `tripletCompletionSearch`, shared fixture in `search_test_helpers.go`
- **Wave B** — `cypherSearch` security gates (`ALLOW_CYPHER_QUERY`, write-op blocking) + `naturalLanguageSearch` fallback branches + `extractCypher` unit tests
- **Wave C** — `contextExtensionSearch` (1-hop postgres path), `cotSearch` (decomp + synthesis + bad-JSON fallback), `communityLocalSearch`, `communityGlobalSearch` (map-reduce)
- **Wave D** — end-to-end RBAC: isolation, share grant, anonymous bypass, superuser bypass, orphan-chunk policy, triplet-handler regression guard

Docs updated: `docs/roadmap-feature-parity.md` and `test_reports/fix_tasks.md` reflect F-4 + Wave A reality (no more 55%-parity narrative, FIX-1..FIX-5 marked closed).

## Test plan

- [x] `cd Levara && go test -race -count=1 ./...` → 35/35 pass
- [x] Fixture reuses `newSearchTestEnv(t)` two-phase pattern (configure `cfg` → `start()`)
- [x] No new external service deps (SQLite in-memory, httptest embed mock, recordingLLM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)