### PR TITLE
docs(fix-14): close as won't-do

### DIFF
--- a/Levara/docs/testing-roadmap.md
+++ b/Levara/docs/testing-roadmap.md
@@ -24,7 +24,7 @@ Live-документ. Каждая задача фиксирует статус
 | F-2 | ADR: три слоя графа (`graph` / `graphdb` / `graphstore`) | ✅ done | this batch |
 | F-3 | Решить судьбу `pkg/graphstore` (unused abstraction) | ⬜ deferred → см. ADR-001 | — |
 | F-4 | Вынос MCP из `internal/http` в `pkg/mcp` | ⬜ deferred (4375 LOC) — requires plan | — |
-| F-5 | Слияние мелких pkg (`git`/`fetch` → `ingest`, `classify` → `extract`) | ⬜ pending | — |
+| F-5 | Слияние мелких pkg (`git`/`fetch` → `ingest`, `classify` → `extract`) | ❌ won't do (2026-04-17) | см. `test_reports/fix_tasks.md` FIX-14 |
 | **F-6** | 🔴 **HNSW data race** (FIXED): Search теперь держит `h.RLock` весь traversal. Регрессия: `TestHNSW_ConcurrentSearchAdd_NoRace` гоняет 2 writers × 8 readers × 300ms под `-race`. `TestRecallAt10` разблокирован. | ✅ done | this batch |
 
 ## Wave 2 — TEST

--- a/test_reports/fix_tasks.md
+++ b/test_reports/fix_tasks.md
@@ -84,8 +84,32 @@ Post-F-4 coverage push. `internal/http` оставался самым больш
   (temperature — часть ключа), BM25 index+search (ранжирование +
   InvalidArgument guards), SearchTriplets scoring, ExtractText
   plain-text. Симметрично HTTP wave-coverage, без embed-server/graphdb.
-- **FIX-14** — слияние `git` + `fetch` → `ingest`, `classify` → `extract`
-  (архитектурное, не тестовое — вне scope этого testing-push'а).
+- ~~**FIX-14 (merge mini-packages).**~~ **Won't do** (решение
+  2026-04-17). Задумывалось: `git` + `fetch` → `ingest`,
+  `classify` → `extract`. После аудита (5 пакетов, 7 production-сайтов,
+  ~1000 LOC тестов) — отказ. Причины:
+  1. **Dependency bloat.** `fetch` тянет `goquery` (HTML DOM). Merge в
+     `ingest` → все 4 caller'а (`cmd/server`, `grpc`, `http`, `mcp
+     tool_data`) транзитивно линкуют goquery, хотя MCP-тул считает только
+     SHA+диск. `extract` тянет `tabula` + `pkg/audio` (Whisper);
+     `classify` — чистый stdlib. Merge → `pkg/orchestrator` (единственный
+     caller classify, использует его только для выбора chunker'а) начнёт
+     линковать document-parser. Это регресс.
+  2. **SRP чище как есть.** `classify` — pure dispatcher
+     `(filename, content) → {Type, Chunker, Min/Max}`. `extract` —
+     трансформация байтов в текст. Разные сигнатуры, разные концерны.
+     `git.ParseLog` — local git reader; имя `ingest.ParseGitLog()`
+     читалось бы как "запись git-истории". `fetch` — URL/HTML text
+     extraction с единственным use-case (HTTP `/add` детектит URL в
+     body), обобщать нечего.
+  3. **Нет измеримого выигрыша, есть риск.** Переименование тронет 3
+     test-suite'а и 7 production-сайтов. Все пакеты уже покрыты тестами.
+     FIX-14 — единственный в списке пункт без конкретной дыры
+     (coverage/concurrency/security). Aesthetic refactor без sign-off
+     закрывается как won't-do.
+
+  Если в будущем dependency graphs сойдутся (например, `goquery` уйдёт
+  из `fetch`), вопрос можно пересмотреть.
 
 ### P3 — наблюдать
 


### PR DESCRIPTION
## Summary

Closes **FIX-14** (merge `git` + `fetch` → `ingest`, `classify` → `extract`) as **won't-do** after full audit. No code moves.

After auditing the 5 candidate packages (7 production call sites, ~1000 LOC of tests), the merge would:

1. **Leak heavy dependencies.** `fetch` pulls `goquery` (HTML DOM); merging into `ingest` forces it onto every ingest caller (`cmd/server`, `grpc`, `http`, `mcp/tool_data`) — the MCP tool just hashes bytes and writes to disk. `extract` pulls `tabula` + `pkg/audio` (Whisper); `classify` is pure stdlib — merging forces `pkg/orchestrator` (which uses `classify` only to pick a chunker) to transitively link a document parser.
2. **Blur SRP.** `classify` is a pure dispatcher `(filename, content) → {Type, Chunker, Min/MaxChars}`. `extract` turns bytes into text. Different signatures, different concerns. `git.ParseLog` is a local git-log reader; calling it from an `ingest` sink reads wrong. `fetch` has a single caller (HTTP `/add` URL detection) with nothing to generalize.
3. **Risk without benefit.** 3 test suites + 7 call sites would move for an aesthetic win. FIX-14 was the only open item not tied to a concrete hole (coverage / concurrency / security).

If dependency graphs later converge (e.g. `goquery` leaves `fetch`), we can revisit.

## Changes

- [`test_reports/fix_tasks.md`](test_reports/fix_tasks.md) — FIX-14 moved to **won't do** with the full reasoning above.
- [`Levara/docs/testing-roadmap.md`](Levara/docs/testing-roadmap.md) — F-5 row flipped to ❌ with pointer back to fix_tasks.md.

No production-code changes; no tests to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)