### PR TITLE
feat(http+extract): P2.1 session-aware search/cognify + P2.3 Go AST

### DIFF
--- a/Levara/internal/http/api.go
+++ b/Levara/internal/http/api.go
@@ -827,15 +827,8 @@ func cognifyHandler(cfg APIConfig) fiber.Handler {
 			PersistPipelineStatus(cfg.DB, pipeCfg.DatasetID, collection,
 				runStatus.Status, runStatus.Chunks, runStatus.Entities, runStatus.Edges, runStatus.ElapsedMs)
 
-			// P2.1: Save interaction to session history after pipeline completes
-			if sessionID != "" && cfg.DB != nil {
-				entityCount := runStatus.Entities
-				cfg.DB.ExecContext(context.Background(),
-					Q(`INSERT INTO interactions (id, session_id, user_id, query, response, search_type, created_at)
-					 VALUES ($1, $2, $3, $4, $5, $6, NOW())`),
-					uuid.New().String(), sessionID, userID, strings.Join(texts, " "),
-					fmt.Sprintf("%d entities extracted", entityCount), "cognify")
-			}
+			recordInteraction(cfg, sessionID, userID, strings.Join(texts, " "),
+				fmt.Sprintf("%d entities extracted", runStatus.Entities), "cognify")
 		}()
 
 		return c.JSON(fiber.Map{

--- a/Levara/internal/http/graph_search.go
+++ b/Levara/internal/http/graph_search.go
@@ -107,8 +107,11 @@ func graphCompletionSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest)
 		}
 
 		prompt := fmt.Sprintf("Answer the question based on the following knowledge graph and search context.\n\n%s\n\nQuestion: %s\n\nAnswer:", contextStr, req.QueryText)
+		prompt = prependSessionContext(cfg, req.SessionID, prompt)
 		answer = callLLMFromAPI(llmEndpoint, llmModel, prompt, cfg.LLMProvider)
 	}
+
+	recordInteraction(cfg, req.SessionID, "", req.QueryText, answer, "GRAPH_COMPLETION")
 
 	return c.JSON(fiber.Map{
 		"answer":      answer,
@@ -237,8 +240,11 @@ func contextExtensionSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest
 			"Answer the question using the extended knowledge graph context below. "+
 				"The context includes both direct (1-hop) and extended (2-hop) relationships.\n\n"+
 				"%s\n\nQuestion: %s\n\nAnswer:", contextStr, req.QueryText)
+		prompt = prependSessionContext(cfg, req.SessionID, prompt)
 		answer = callLLMFromAPI(llmEndpoint, llmModel, prompt, cfg.LLMProvider)
 	}
+
+	recordInteraction(cfg, req.SessionID, "", req.QueryText, answer, "GRAPH_COMPLETION_CONTEXT_EXTENSION")
 
 	return c.JSON(fiber.Map{
 		"answer":       answer,
@@ -390,6 +396,7 @@ func cotSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) error {
 
 		synthesizePrompt := fmt.Sprintf(
 			"Given this multi-step research:\n\n%s\nAnswer the original question: %s", stepSummary, req.QueryText)
+		synthesizePrompt = prependSessionContext(cfg, req.SessionID, synthesizePrompt)
 		answer = callLLMFromAPI(llmEndpoint, llmModel, synthesizePrompt, cfg.LLMProvider)
 	}
 
@@ -402,6 +409,8 @@ func cotSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) error {
 			"context_found": s.ContextFound,
 		}
 	}
+
+	recordInteraction(cfg, req.SessionID, "", req.QueryText, answer, "GRAPH_COMPLETION_COT")
 
 	return c.JSON(fiber.Map{
 		"answer":          answer,
@@ -759,8 +768,11 @@ func tripletCompletionSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchReques
 	if llmEndpoint != "" && llmModel != "" && len(tripletTexts) > 0 {
 		contextStr := "Knowledge graph triplets (Subject -> Predicate -> Object):\n" + strings.Join(tripletTexts, "\n")
 		prompt := fmt.Sprintf("Answer the question based on the following knowledge graph triplets.\n\n%s\n\nQuestion: %s\n\nAnswer:", contextStr, req.QueryText)
+		prompt = prependSessionContext(cfg, req.SessionID, prompt)
 		answer = callLLMFromAPI(llmEndpoint, llmModel, prompt, cfg.LLMProvider)
 	}
+
+	recordInteraction(cfg, req.SessionID, "", req.QueryText, answer, "TRIPLET_COMPLETION")
 
 	return c.JSON(fiber.Map{
 		"answer":      answer,
@@ -1151,8 +1163,11 @@ func communityLocalSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) 
 		prompt := fmt.Sprintf(
 			"Answer based on these knowledge graph communities:\n\n%s\n\nQuestion: %s\n\nAnswer:",
 			strings.Join(communityContexts, "\n---\n"), req.QueryText)
+		prompt = prependSessionContext(cfg, req.SessionID, prompt)
 		answer = callLLMFromAPI(llmEndpoint, llmModel, prompt, cfg.LLMProvider)
 	}
+
+	recordInteraction(cfg, req.SessionID, "", req.QueryText, answer, "COMMUNITY_LOCAL")
 
 	return c.JSON(fiber.Map{
 		"answer":           answer,
@@ -1288,8 +1303,11 @@ func communityGlobalSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest)
 				"Synthesize a comprehensive answer combining all relevant perspectives. "+
 				"Resolve any contradictions. Be thorough but concise.",
 			req.QueryText, strings.Join(partialTexts, "\n\n---\n\n"))
+		synthesizePrompt = prependSessionContext(cfg, req.SessionID, synthesizePrompt)
 		answer = callLLMFromAPI(llmEndpoint, llmModel, synthesizePrompt, cfg.LLMProvider)
 	}
+
+	recordInteraction(cfg, req.SessionID, "", req.QueryText, answer, "COMMUNITY_GLOBAL")
 
 	return c.JSON(fiber.Map{
 		"answer":                   answer,

--- a/Levara/internal/http/sessions.go
+++ b/Levara/internal/http/sessions.go
@@ -51,6 +51,34 @@ func GetSessionContext(db *sql.DB, ctx context.Context, sessionID string, limit 
 	return "Previous conversation context:\n" + strings.Join(parts, "\n---\n")
 }
 
+// prependSessionContext returns prompt with prior interactions prepended when
+// a session_id is supplied; otherwise returns prompt unchanged. Failures in
+// context loading fall through silently — the base prompt is always returned.
+func prependSessionContext(cfg APIConfig, sessionID, prompt string) string {
+	if sessionID == "" || cfg.DB == nil {
+		return prompt
+	}
+	sctx := GetSessionContext(cfg.DB, context.Background(), sessionID, 5)
+	if sctx == "" {
+		return prompt
+	}
+	return sctx + "\n\n" + prompt
+}
+
+// recordInteraction persists a query/answer turn so subsequent requests on the
+// same session_id see it via prependSessionContext. No-op when session_id is
+// empty or DB unavailable; errors are swallowed (observability layer is the
+// right place to surface them if needed).
+func recordInteraction(cfg APIConfig, sessionID, userID, query, answer, searchType string) {
+	if sessionID == "" || cfg.DB == nil || answer == "" {
+		return
+	}
+	cfg.DB.ExecContext(context.Background(),
+		Q(`INSERT INTO interactions (id, session_id, user_id, query, response, search_type, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)`),
+		uuid.New().String(), sessionID, userID, query, answer, searchType, time.Now().UTC())
+}
+
 func RegisterSessionAPI(app fiber.Router, cfg APIConfig) {
 	app.Post("/interactions", saveInteractionHandler(cfg))
 	app.Get("/interactions", listInteractionsHandler(cfg))

--- a/Levara/pkg/extract/code.go
+++ b/Levara/pkg/extract/code.go
@@ -1,8 +1,11 @@
 // code.go — Source code analysis: extract functions, classes, imports, and call relationships.
-// Supports Go and Python via regex-based parsing (no external AST tools).
+// Go uses go/ast (stdlib); Python uses regex (no external deps).
 package extract
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"regexp"
 	"strings"
 )
@@ -57,73 +60,91 @@ func detectLanguage(filename string) string {
 	return "unknown"
 }
 
-// ── Go Analysis ──
-
-var (
-	goFuncRe   = regexp.MustCompile(`(?m)^func\s+(?:\((\w+)\s+\*?(\w+)\)\s+)?(\w+)\s*\(`)
-	goImportRe = regexp.MustCompile(`(?m)^\s*"([^"]+)"`)
-	goCallRe   = regexp.MustCompile(`\b(\w+)\.([\w]+)\s*\(`)
-	goStructRe = regexp.MustCompile(`(?m)^type\s+(\w+)\s+struct\s*\{`)
-	goIfaceRe  = regexp.MustCompile(`(?m)^type\s+(\w+)\s+interface\s*\{`)
-)
+// ── Go Analysis (AST-based) ──
 
 func analyzeGo(source, filename string) CodeAnalysis {
 	a := CodeAnalysis{Language: "go"}
-	lines := strings.Split(source, "\n")
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filename, source, parser.AllErrors)
+	if err != nil && f == nil {
+		return a
+	}
 
-	// Extract functions and methods
-	for i, line := range lines {
-		if m := goFuncRe.FindStringSubmatch(line); m != nil {
-			receiver := m[2]
-			funcName := m[3]
-			e := CodeEntity{Name: funcName, Type: "function", File: filename, Line: i + 1}
-			if receiver != "" {
-				e.Type = "method"
-				e.Parent = receiver
+	for _, decl := range f.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			line := fset.Position(d.Pos()).Line
+			e := CodeEntity{Name: d.Name.Name, Type: "function", File: filename, Line: line}
+			if d.Recv != nil && len(d.Recv.List) > 0 {
+				if rt := receiverTypeName(d.Recv.List[0].Type); rt != "" {
+					e.Type = "method"
+					e.Parent = rt
+				}
 			}
 			a.Entities = append(a.Entities, e)
-		}
-	}
-
-	// Extract structs and interfaces
-	for i, line := range lines {
-		if m := goStructRe.FindStringSubmatch(line); m != nil {
-			a.Entities = append(a.Entities, CodeEntity{Name: m[1], Type: "class", File: filename, Line: i + 1})
-		}
-		if m := goIfaceRe.FindStringSubmatch(line); m != nil {
-			a.Entities = append(a.Entities, CodeEntity{Name: m[1], Type: "interface", File: filename, Line: i + 1})
-		}
-	}
-
-	// Extract imports
-	inImport := false
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "import (" {
-			inImport = true
-			continue
-		}
-		if inImport && trimmed == ")" {
-			inImport = false
-			continue
-		}
-		if inImport {
-			if m := goImportRe.FindStringSubmatch(line); m != nil {
-				pkg := m[1]
-				parts := strings.Split(pkg, "/")
-				name := parts[len(parts)-1]
-				a.Entities = append(a.Entities, CodeEntity{Name: name, Type: "import", File: filename})
-				a.Relations = append(a.Relations, CodeRelation{Source: filename, Target: pkg, Relationship: "IMPORTS"})
+		case *ast.GenDecl:
+			for _, spec := range d.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				line := fset.Position(ts.Pos()).Line
+				switch ts.Type.(type) {
+				case *ast.StructType:
+					a.Entities = append(a.Entities, CodeEntity{Name: ts.Name.Name, Type: "class", File: filename, Line: line})
+				case *ast.InterfaceType:
+					a.Entities = append(a.Entities, CodeEntity{Name: ts.Name.Name, Type: "interface", File: filename, Line: line})
+				}
 			}
 		}
 	}
 
-	// Extract function calls (method calls: obj.Method())
-	for _, m := range goCallRe.FindAllStringSubmatch(source, -1) {
-		a.Relations = append(a.Relations, CodeRelation{Source: filename, Target: m[1] + "." + m[2], Relationship: "CALLS"})
+	for _, imp := range f.Imports {
+		path := strings.Trim(imp.Path.Value, `"`)
+		parts := strings.Split(path, "/")
+		name := parts[len(parts)-1]
+		a.Entities = append(a.Entities, CodeEntity{Name: name, Type: "import", File: filename})
+		a.Relations = append(a.Relations, CodeRelation{Source: filename, Target: path, Relationship: "IMPORTS"})
 	}
 
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		x, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		a.Relations = append(a.Relations, CodeRelation{
+			Source:       filename,
+			Target:       x.Name + "." + sel.Sel.Name,
+			Relationship: "CALLS",
+		})
+		return true
+	})
+
 	return a
+}
+
+// receiverTypeName extracts the bare type name from a method receiver,
+// unwrapping pointers and generic type parameters.
+func receiverTypeName(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.StarExpr:
+		return receiverTypeName(t.X)
+	case *ast.Ident:
+		return t.Name
+	case *ast.IndexExpr:
+		return receiverTypeName(t.X)
+	case *ast.IndexListExpr:
+		return receiverTypeName(t.X)
+	}
+	return ""
 }
 
 // ── Python Analysis ──


### PR DESCRIPTION
## Summary
- **P2.1 — session continuity.** New helpers in `internal/http/sessions.go`: `prependSessionContext` (load last-5 interactions into LLM prompt) and `recordInteraction` (persist query/answer turn). Wired into 6 answer-synthesis sites in `graph_search.go` (graphCompletion, contextExtension, cot-final, triplet, communityLocal, communityGlobal). `cognifyHandler` simplified to use `recordInteraction`.
- **P2.3 — Go AST analyzer.** `pkg/extract/code.go::analyzeGo` rewritten on `go/parser` + `go/ast` (stdlib, no new deps). `receiverTypeName` handles pointer/value/generic receivers (`*T`, `T`, `T[U]`, `T[U, V]`). Python path unchanged.
- **P2.2** (headless scraping) intentionally deferred — no concrete JS-heavy source yet.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./pkg/extract/ ./internal/http/` — pass
- [x] `go test ./...` — 35/35 packages pass (incl. pre-existing race-enabled suites)
- [ ] Manual smoke: `/cognify` with `session_id=X`, then `/search?query_type=GRAPH_COMPLETION` with same `session_id` — verify LLM prompt sees prior turn via `GET /interactions/X`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)