### PR TITLE
Neo4j: schema bootstrap, Cypher policy hardening, doctor schema checks and tests

### DIFF
--- a/Levara/cmd/server/main.go
+++ b/Levara/cmd/server/main.go
@@ -62,11 +62,11 @@ import (
 
 	"path/filepath"
 
+	"github.com/gofiber/swagger"
 	"github.com/hashicorp/raft"
-	_ "github.com/jackc/pgx/v5/stdlib"  // pgx via database/sql (binary protocol, prepared stmts)
+	_ "github.com/jackc/pgx/v5/stdlib"       // pgx via database/sql (binary protocol, prepared stmts)
 	_ "github.com/ncruces/go-sqlite3/driver" // pure-Go SQLite driver (no CGO, ARM64 ready)
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/gofiber/swagger"
 	"github.com/stek0v/levara/internal/cluster"
 	vectorGrpc "github.com/stek0v/levara/internal/grpc"
 	"github.com/stek0v/levara/internal/metrics"
@@ -74,6 +74,7 @@ import (
 
 	_ "github.com/stek0v/levara/docs" // swaggo-generated OpenAPI spec (T13)
 	"github.com/stek0v/levara/pkg/embed"
+	"github.com/stek0v/levara/pkg/graphdb"
 	"github.com/stek0v/levara/pkg/ingest"
 	"github.com/stek0v/levara/pkg/llmcache"
 	"github.com/stek0v/levara/pkg/observe"
@@ -250,7 +251,6 @@ func main() {
 		return c.JSON(fiber.Map{"status": "ready", "health": "healthy", "version": "levara-go"})
 	})
 
-
 	// ---------------------------------------------------------------
 	// Cluster replication endpoints
 	// ---------------------------------------------------------------
@@ -272,8 +272,23 @@ func main() {
 		return c.JSON(fiber.Map{"status": "ready", "health": "healthy", "version": "levara-go"})
 	})
 
-
 	api := app.Group("/api/v1")
+
+	// Neo4j schema bootstrap is one-time at startup. Per-request handlers
+	// should not execute DDL for latency and side-effect reasons.
+	if *neo4jURL != "" && shouldBootstrapNeo4jSchema(os.Getenv("NEO4J_BOOTSTRAP_SCHEMA")) {
+		neoCtx, neoCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		w, neoErr := graphdb.NewWriterWithSchema(neoCtx, *neo4jURL, *neo4jUser, *neo4jPassword, *neo4jDatabase)
+		if neoErr != nil {
+			log.Printf("[startup] neo4j schema bootstrap skipped: %v", neoErr)
+		} else {
+			_ = w.Close(neoCtx)
+			log.Printf("[startup] neo4j schema bootstrap complete")
+		}
+		neoCancel()
+	} else if *neo4jURL != "" {
+		log.Printf("[startup] neo4j schema bootstrap disabled (NEO4J_BOOTSTRAP_SCHEMA=%q)", os.Getenv("NEO4J_BOOTSTRAP_SCHEMA"))
+	}
 
 	// Graph visualization config (used by both public and protected routes)
 	vizCfg := vectorHttp.GraphVisualizationConfig{
@@ -360,10 +375,22 @@ func main() {
 	} else if dbHost := os.Getenv("DB_HOST"); dbHost != "" {
 		// PostgreSQL mode (default)
 		vectorHttp.SetDBProvider(vectorHttp.DBPostgres)
-		dbUser := os.Getenv("DB_USERNAME"); if dbUser == "" { dbUser = "cognee" }
-		dbPass := os.Getenv("DB_PASSWORD"); if dbPass == "" { dbPass = "cognee" }
-		dbName := os.Getenv("DB_NAME"); if dbName == "" { dbName = "cognee_db" }
-		dbPort := os.Getenv("DB_PORT"); if dbPort == "" { dbPort = "5432" }
+		dbUser := os.Getenv("DB_USERNAME")
+		if dbUser == "" {
+			dbUser = "cognee"
+		}
+		dbPass := os.Getenv("DB_PASSWORD")
+		if dbPass == "" {
+			dbPass = "cognee"
+		}
+		dbName := os.Getenv("DB_NAME")
+		if dbName == "" {
+			dbName = "cognee_db"
+		}
+		dbPort := os.Getenv("DB_PORT")
+		if dbPort == "" {
+			dbPort = "5432"
+		}
 		pgDSN = fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", dbUser, dbPass, dbHost, dbPort, dbName)
 
 		var dbErr error
@@ -392,7 +419,10 @@ func main() {
 		log.Printf("Graph visualization: SQL fallback enabled")
 	}
 	embedEndpoint := os.Getenv("EMBEDDING_ENDPOINT")
-	embedModel := os.Getenv("EMBEDDING_MODEL"); if embedModel == "" { embedModel = "text-embedding-3-small" }
+	embedModel := os.Getenv("EMBEDDING_MODEL")
+	if embedModel == "" {
+		embedModel = "text-embedding-3-small"
+	}
 
 	// Auth endpoints (public — no JWT required)
 	jwtSecret := os.Getenv("JWT_SECRET")
@@ -513,17 +543,17 @@ func main() {
 
 	// MCP (Model Context Protocol) server — JSON-RPC 2.0 for AI agent integration
 	vectorHttp.RegisterMCPAPI(app, vectorHttp.APIConfig{
-		EmbedEndpoint:  embedEndpoint,
-		EmbedModel:     embedModel,
-		EmbedClient:    sharedEmbed,
-		Collections:    colManager,
-		DB:             pgDB,
-		BM25Indexes:    grpcSvc.BM25Indexes(),
-		LLMCache:       llmCache,
-		RerankEndpoint: rerankCfg.Endpoint,
-		RerankModel:    rerankCfg.Model,
+		EmbedEndpoint:   embedEndpoint,
+		EmbedModel:      embedModel,
+		EmbedClient:     sharedEmbed,
+		Collections:     colManager,
+		DB:              pgDB,
+		BM25Indexes:     grpcSvc.BM25Indexes(),
+		LLMCache:        llmCache,
+		RerankEndpoint:  rerankCfg.Endpoint,
+		RerankModel:     rerankCfg.Model,
 		RerankTimeoutMs: rerankCfg.TimeoutMs,
-		Runs:           runs,
+		Runs:            runs,
 	})
 
 	// Cache stats endpoint
@@ -535,18 +565,18 @@ func main() {
 	// Detailed /health/details with per-dependency probes lives in
 	// bootstrap.go.
 	registerHealthDetails(app, healthDeps{
-		port:           *port,
-		grpcPort:       *grpcPort,
-		dim:            *dim,
-		pgDB:           pgDB,
-		neo4jURL:       *neo4jURL,
-		neo4jUser:      *neo4jUser,
-		neo4jPassword:  *neo4jPassword,
-		neo4jDatabase:  *neo4jDatabase,
-		embedEndpoint:  embedEndpoint,
-		embedModel:     embedModel,
-		llmProvider:    llmProvider,
-		colManager:     colManager,
+		port:          *port,
+		grpcPort:      *grpcPort,
+		dim:           *dim,
+		pgDB:          pgDB,
+		neo4jURL:      *neo4jURL,
+		neo4jUser:     *neo4jUser,
+		neo4jPassword: *neo4jPassword,
+		neo4jDatabase: *neo4jDatabase,
+		embedEndpoint: embedEndpoint,
+		embedModel:    embedModel,
+		llmProvider:   llmProvider,
+		colManager:    colManager,
 	})
 
 	// gRPC server (v1 + v2) starts in a goroutine. nil when disabled.

--- a/Levara/cmd/server/neo4j_bootstrap.go
+++ b/Levara/cmd/server/neo4j_bootstrap.go
@@ -1,0 +1,20 @@
+package main
+
+import "strings"
+
+// shouldBootstrapNeo4jSchema decides whether startup should attempt Neo4j
+// schema bootstrap. Empty value defaults to enabled for backward compatibility.
+//
+// Disable values: "0", "false", "no", "off" (case-insensitive).
+func shouldBootstrapNeo4jSchema(raw string) bool {
+	v := strings.TrimSpace(strings.ToLower(raw))
+	if v == "" {
+		return true
+	}
+	switch v {
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}

--- a/Levara/cmd/server/neo4j_bootstrap_test.go
+++ b/Levara/cmd/server/neo4j_bootstrap_test.go
@@ -1,0 +1,31 @@
+package main
+
+import "testing"
+
+func TestShouldBootstrapNeo4jSchema(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{name: "empty defaults enabled", in: "", want: true},
+		{name: "whitespace defaults enabled", in: "   ", want: true},
+		{name: "false", in: "false", want: false},
+		{name: "FALSE", in: "FALSE", want: false},
+		{name: "zero", in: "0", want: false},
+		{name: "no", in: "no", want: false},
+		{name: "off", in: "off", want: false},
+		{name: "true", in: "true", want: true},
+		{name: "one", in: "1", want: true},
+		{name: "unexpected treated enabled", in: "maybe", want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldBootstrapNeo4jSchema(tc.in)
+			if got != tc.want {
+				t.Fatalf("shouldBootstrapNeo4jSchema(%q)=%v want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/Levara/internal/http/cypher_nl_search_test.go
+++ b/Levara/internal/http/cypher_nl_search_test.go
@@ -96,6 +96,7 @@ func TestCypherSearch_BlocksWrites(t *testing.T) {
 		// Lowercase keyword must still be blocked — the handler upper-cases
 		// the query before comparing.
 		{"lowercase create", "create (n) return n"},
+		{"foreach write", "MATCH (n) FOREACH (_ IN [1] | SET n.x = 1) RETURN n"},
 	}
 
 	for _, tc := range writeQueries {
@@ -113,6 +114,41 @@ func TestCypherSearch_BlocksWrites(t *testing.T) {
 				t.Fatalf("status = %d, want 403 (write blocked); body=%v", status, body)
 			}
 		})
+	}
+}
+
+func TestCypherSearch_BlocksNonReadPrefixes(t *testing.T) {
+	t.Setenv("ALLOW_CYPHER_QUERY", "true")
+	env := newSearchTestEnv(t)
+	env.cfg.Neo4jCfg = GraphVisualizationConfig{Neo4jURL: "bolt://unused.test:7687"}
+	env.start()
+
+	status, body := env.postSearch(map[string]any{
+		"query_text":   "q",
+		"query_type":   "CYPHER",
+		"cypher_query": "RETURN 1 AS one",
+	})
+	if status != 403 {
+		t.Fatalf("status = %d, want 403 (non-read-prefix should be blocked); body=%v", status, body)
+	}
+}
+
+func TestCypherSearch_WriteCanBeEnabled(t *testing.T) {
+	t.Setenv("ALLOW_CYPHER_QUERY", "true")
+	t.Setenv("ALLOW_CYPHER_WRITE", "true")
+	env := newSearchTestEnv(t)
+	env.cfg.Neo4jCfg = GraphVisualizationConfig{Neo4jURL: "bolt://unused.test:7687"}
+	env.start()
+
+	status, _ := env.postSearch(map[string]any{
+		"query_text":   "q",
+		"query_type":   "CYPHER",
+		"cypher_query": "CREATE (n:Person {name:'x'}) RETURN n",
+	})
+	// The request is no longer denied by policy, so the next expected
+	// failure is connection-level (Neo4j isn't running in this test).
+	if status != 500 {
+		t.Fatalf("status = %d, want 500 (policy allowed, then connect fails)", status)
 	}
 }
 
@@ -203,6 +239,34 @@ func TestExtractCypher(t *testing.T) {
 			got := extractCypher(tc.in)
 			if got != tc.want {
 				t.Errorf("extractCypher(%q)\n  got  %q\n  want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsCypherAllowed(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		allowWrite bool
+		want       bool
+	}{
+		{name: "read match", query: "MATCH (n) RETURN n", allowWrite: false, want: true},
+		{name: "read call", query: "CALL db.labels() YIELD label RETURN label", allowWrite: false, want: true},
+		{name: "read unwind", query: "UNWIND [1,2] AS x RETURN x", allowWrite: false, want: true},
+		{name: "bare return denied", query: "RETURN 1", allowWrite: false, want: false},
+		{name: "write denied by default", query: "CREATE (n) RETURN n", allowWrite: false, want: false},
+		{name: "write allowed with flag", query: "CREATE (n) RETURN n", allowWrite: true, want: true},
+		{name: "drop always denied", query: "DROP DATABASE neo4j", allowWrite: true, want: false},
+		{name: "constraint always denied", query: "CREATE CONSTRAINT x IF NOT EXISTS FOR (n:Node) REQUIRE n.id IS UNIQUE", allowWrite: true, want: false},
+		{name: "empty denied", query: "   ", allowWrite: false, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isCypherAllowed(tc.query, tc.allowWrite)
+			if got != tc.want {
+				t.Fatalf("isCypherAllowed(%q, allowWrite=%v) = %v, want %v", tc.query, tc.allowWrite, got, tc.want)
 			}
 		})
 	}

--- a/Levara/internal/http/graph_search.go
+++ b/Levara/internal/http/graph_search.go
@@ -12,9 +12,9 @@ import (
 	"sync"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/stek0v/levara/pipeline"
 	"github.com/stek0v/levara/pkg/community"
 	"github.com/stek0v/levara/pkg/graphdb"
-	"github.com/stek0v/levara/pipeline"
 )
 
 // graphCompletionSearch performs vector search → extract entities → graph context → LLM answer.
@@ -644,20 +644,20 @@ func codeGraphContextFromPostgres(ctx context.Context, cfg APIConfig, names []st
 func formatCodeRules(rows []map[string]any) []string {
 	// Map relationship types to human-readable verbs.
 	verbMap := map[string]string{
-		"CALLS":        "calls",
-		"IMPORTS":      "imports",
-		"INHERITS":     "inherits from",
-		"EXTENDS":      "extends",
-		"IMPLEMENTS":   "implements",
-		"CONTAINS":     "contains",
-		"HAS_PART":     "contains",
-		"DEPENDS_ON":   "depends on",
-		"RELATES_TO":   "is related to",
-		"USES":         "uses",
-		"RETURNS":      "returns",
-		"ACCEPTS":      "accepts",
-		"DEFINES":      "defines",
-		"OVERRIDES":    "overrides",
+		"CALLS":      "calls",
+		"IMPORTS":    "imports",
+		"INHERITS":   "inherits from",
+		"EXTENDS":    "extends",
+		"IMPLEMENTS": "implements",
+		"CONTAINS":   "contains",
+		"HAS_PART":   "contains",
+		"DEPENDS_ON": "depends on",
+		"RELATES_TO": "is related to",
+		"USES":       "uses",
+		"RETURNS":    "returns",
+		"ACCEPTS":    "accepts",
+		"DEFINES":    "defines",
+		"OVERRIDES":  "overrides",
 	}
 
 	var rules []string
@@ -796,12 +796,10 @@ func cypherSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) error {
 		return c.Status(400).JSON(fiber.Map{"detail": "cypher_query required for CYPHER search type"})
 	}
 
-	// Block write operations
-	upper := strings.ToUpper(cypherQuery)
-	for _, keyword := range []string{"CREATE", "MERGE", "DELETE", "DETACH", "SET ", "REMOVE"} {
-		if strings.Contains(upper, keyword) {
-			return c.Status(403).JSON(fiber.Map{"detail": "Write operations not allowed in Cypher search"})
-		}
+	if !isCypherAllowed(cypherQuery, os.Getenv("ALLOW_CYPHER_WRITE") == "true") {
+		return c.Status(403).JSON(fiber.Map{
+			"detail": "Cypher policy violation: only read-only MATCH/RETURN/CALL/WITH/OPTIONAL MATCH/UNWIND queries are allowed unless ALLOW_CYPHER_WRITE=true",
+		})
 	}
 
 	ctx := context.Background()
@@ -822,6 +820,71 @@ func cypherSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) error {
 		"query":       cypherQuery,
 		"search_type": "CYPHER",
 	})
+}
+
+// isCypherAllowed validates whether a Cypher query is allowed by policy.
+//
+// Default policy (allowWrite=false):
+//   - Query must start with a read clause: MATCH / OPTIONAL MATCH / WITH / CALL / UNWIND
+//   - Query must not include write/admin keywords.
+//   - This is intentionally conservative: uncertain queries are denied.
+//
+// Write policy (allowWrite=true):
+//   - Still blocks administrative/destructive schema/database operations.
+func isCypherAllowed(query string, allowWrite bool) bool {
+	trimmed := strings.TrimSpace(query)
+	if trimmed == "" {
+		return false
+	}
+	upper := strings.ToUpper(trimmed)
+
+	if containsAnyCypherKeyword(upper, []string{
+		"DROP ",
+		" DATABASE ",
+		" CONSTRAINT ",
+		" INDEX ",
+		" DBMS ",
+		" TERMINATE ",
+		" LOAD CSV",
+	}) {
+		return false
+	}
+
+	if !allowWrite {
+		if !hasAllowedReadPrefix(upper) {
+			return false
+		}
+		if containsAnyCypherKeyword(upper, []string{
+			"CREATE ",
+			"MERGE ",
+			"DELETE ",
+			"DETACH ",
+			"SET ",
+			"REMOVE ",
+			"FOREACH ",
+		}) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasAllowedReadPrefix(upperQuery string) bool {
+	for _, prefix := range []string{"MATCH ", "OPTIONAL MATCH ", "WITH ", "CALL ", "UNWIND "} {
+		if strings.HasPrefix(upperQuery, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAnyCypherKeyword(upperQuery string, keywords []string) bool {
+	for _, kw := range keywords {
+		if strings.Contains(upperQuery, kw) {
+			return true
+		}
+	}
+	return false
 }
 
 // naturalLanguageSearch converts a natural language question to Cypher via LLM, then executes it.
@@ -877,13 +940,10 @@ Cypher query:`, strings.Join(labels, ", "), strings.Join(relTypes, ", "), req.Qu
 		return graphCompletionSearch(c, cfg, req)
 	}
 
-	// Safety check: block write operations
-	upper := strings.ToUpper(cypher)
-	for _, keyword := range []string{"CREATE", "MERGE", "DELETE", "DETACH", "SET ", "REMOVE"} {
-		if strings.Contains(upper, keyword) {
-			log.Printf("[nl-search] LLM generated write query, falling back: %s", cypher)
-			return graphCompletionSearch(c, cfg, req)
-		}
+	// Safety check: force read-only policy for NL-generated Cypher.
+	if !isCypherAllowed(cypher, false) {
+		log.Printf("[nl-search] LLM generated disallowed query, falling back: %s", cypher)
+		return graphCompletionSearch(c, cfg, req)
 	}
 
 	// Step 3: Execute
@@ -1187,7 +1247,7 @@ func communityGlobalSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest)
 	if cfg.EmbedEndpoint == "" || cfg.Collections == nil {
 		return c.JSON(fiber.Map{"answer": "", "search_type": "COMMUNITY_GLOBAL"})
 	}
-	if (llmEndpoint == "" && cfg.LLMProvider == nil) {
+	if llmEndpoint == "" && cfg.LLMProvider == nil {
 		// No LLM → fallback to CHUNKS
 		return chunksSearch(c, cfg, req)
 	}
@@ -1309,9 +1369,9 @@ func communityGlobalSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest)
 	recordInteraction(cfg, req.SessionID, "", req.QueryText, answer, "COMMUNITY_GLOBAL")
 
 	return c.JSON(fiber.Map{
-		"answer":                   answer,
-		"communities_used":         partials,
+		"answer":                     answer,
+		"communities_used":           partials,
 		"total_communities_searched": len(hits),
-		"search_type":              "COMMUNITY_GLOBAL",
+		"search_type":                "COMMUNITY_GLOBAL",
 	})
 }

--- a/Levara/internal/http/mcp_doctor.go
+++ b/Levara/internal/http/mcp_doctor.go
@@ -11,8 +11,11 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"time"
+
+	"github.com/stek0v/levara/pkg/graphdb"
 )
 
 // ── Doctor check types ──
@@ -53,6 +56,7 @@ func (h *mcpHandler) toolDoctor(ctx context.Context, args map[string]any) mcpToo
 	// 4. Neo4j (optional)
 	if h.cfg.Neo4jCfg.Neo4jURL != "" {
 		checks = append(checks, h.checkNeo4j(ctx))
+		checks = append(checks, h.checkNeo4jSchema(ctx))
 	}
 
 	// 5. Embedding coverage
@@ -222,6 +226,141 @@ func (h *mcpHandler) checkNeo4j(ctx context.Context) doctorCheck {
 		Status:      "warn",
 		Message:     fmt.Sprintf("Unreachable: %s", url),
 		Remediation: "Check Neo4j service or remove NEO4J_URL if not needed",
+	}
+}
+
+func (h *mcpHandler) checkNeo4jSchema(ctx context.Context) doctorCheck {
+	writer, err := graphdb.NewWriter(ctx, h.cfg.Neo4jCfg.Neo4jURL, h.cfg.Neo4jCfg.Neo4jUser,
+		h.cfg.Neo4jCfg.Neo4jPassword, h.cfg.Neo4jCfg.Neo4jDatabase)
+	if err != nil {
+		return doctorCheck{
+			Name:        "neo4j_schema",
+			Status:      "warn",
+			Message:     fmt.Sprintf("Unable to verify schema (connect error): %v", err),
+			Remediation: "Ensure Neo4j is reachable to run schema checks and auto-create required indexes/constraints",
+		}
+	}
+	defer writer.Close(ctx)
+
+	constraintRows, err := writer.Query(ctx, "SHOW CONSTRAINTS YIELD type, labelsOrTypes, properties RETURN type, labelsOrTypes, properties", nil)
+	if err != nil {
+		return doctorCheck{
+			Name:        "neo4j_schema",
+			Status:      "warn",
+			Message:     fmt.Sprintf("Constraint introspection failed: %v", err),
+			Remediation: "Verify Neo4j version/permissions; SHOW CONSTRAINTS must be accessible",
+		}
+	}
+	indexRows, err := writer.Query(ctx, "SHOW INDEXES YIELD labelsOrTypes, properties RETURN labelsOrTypes, properties", nil)
+	if err != nil {
+		return doctorCheck{
+			Name:        "neo4j_schema",
+			Status:      "warn",
+			Message:     fmt.Sprintf("Index introspection failed: %v", err),
+			Remediation: "Verify Neo4j version/permissions; SHOW INDEXES must be accessible",
+		}
+	}
+
+	obs := neo4jObservedSchema{
+		constraints: normalizeNeo4jConstraintRows(constraintRows),
+		indexes:     normalizeNeo4jIndexRows(indexRows),
+	}
+	status, message, remediation := evaluateNeo4jSchema(obs)
+	return doctorCheck{
+		Name:        "neo4j_schema",
+		Status:      status,
+		Message:     message,
+		Remediation: remediation,
+	}
+}
+
+type neo4jObservedSchema struct {
+	constraints map[string]bool
+	indexes     map[string]bool
+}
+
+func requiredNeo4jConstraintKeys() []string {
+	return []string{"__Node__:id:UNIQUE"}
+}
+
+func requiredNeo4jIndexKeys() []string {
+	return []string{
+		"__Node__:name",
+		"__Node__:dataset_id",
+		"__Node__:type",
+	}
+}
+
+func evaluateNeo4jSchema(obs neo4jObservedSchema) (status, message, remediation string) {
+	missing := missingNeo4jSchemaKeys(obs)
+	if len(missing) == 0 {
+		return "ok", "Required Neo4j constraints/indexes are present", ""
+	}
+	sort.Strings(missing)
+	return "warn",
+		fmt.Sprintf("Missing %d schema objects: %s", len(missing), strings.Join(missing, ", ")),
+		"Run startup schema bootstrap (Writer.EnsureSchema) or manually create the missing Neo4j indexes/constraints"
+}
+
+func missingNeo4jSchemaKeys(obs neo4jObservedSchema) []string {
+	var missing []string
+	for _, key := range requiredNeo4jConstraintKeys() {
+		if !obs.constraints[key] {
+			missing = append(missing, "constraint:"+key)
+		}
+	}
+	for _, key := range requiredNeo4jIndexKeys() {
+		if !obs.indexes[key] {
+			missing = append(missing, "index:"+key)
+		}
+	}
+	return missing
+}
+
+func normalizeNeo4jConstraintRows(rows []map[string]any) map[string]bool {
+	out := map[string]bool{}
+	for _, row := range rows {
+		typ, _ := row["type"].(string)
+		props := rowStringSlice(row["properties"])
+		labels := rowStringSlice(row["labelsOrTypes"])
+		for _, label := range labels {
+			for _, prop := range props {
+				key := fmt.Sprintf("%s:%s:%s", label, prop, strings.ToUpper(strings.TrimSpace(typ)))
+				out[key] = true
+			}
+		}
+	}
+	return out
+}
+
+func normalizeNeo4jIndexRows(rows []map[string]any) map[string]bool {
+	out := map[string]bool{}
+	for _, row := range rows {
+		props := rowStringSlice(row["properties"])
+		labels := rowStringSlice(row["labelsOrTypes"])
+		for _, label := range labels {
+			for _, prop := range props {
+				out[fmt.Sprintf("%s:%s", label, prop)] = true
+			}
+		}
+	}
+	return out
+}
+
+func rowStringSlice(v any) []string {
+	switch x := v.(type) {
+	case []any:
+		out := make([]string, 0, len(x))
+		for _, it := range x {
+			if s, ok := it.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	case []string:
+		return x
+	default:
+		return nil
 	}
 }
 

--- a/Levara/internal/http/mcp_doctor_schema_test.go
+++ b/Levara/internal/http/mcp_doctor_schema_test.go
@@ -1,0 +1,69 @@
+package http
+
+import "testing"
+
+func TestEvaluateNeo4jSchema_OK(t *testing.T) {
+	obs := neo4jObservedSchema{
+		constraints: map[string]bool{
+			"__Node__:id:UNIQUE": true,
+		},
+		indexes: map[string]bool{
+			"__Node__:name":       true,
+			"__Node__:dataset_id": true,
+			"__Node__:type":       true,
+		},
+	}
+	status, msg, remediation := evaluateNeo4jSchema(obs)
+	if status != "ok" {
+		t.Fatalf("status=%s want ok", status)
+	}
+	if msg == "" {
+		t.Fatalf("expected non-empty message")
+	}
+	if remediation != "" {
+		t.Fatalf("expected empty remediation for ok, got %q", remediation)
+	}
+}
+
+func TestEvaluateNeo4jSchema_Missing(t *testing.T) {
+	obs := neo4jObservedSchema{
+		constraints: map[string]bool{},
+		indexes: map[string]bool{
+			"__Node__:name": true,
+		},
+	}
+	status, msg, remediation := evaluateNeo4jSchema(obs)
+	if status != "warn" {
+		t.Fatalf("status=%s want warn", status)
+	}
+	if msg == "" || remediation == "" {
+		t.Fatalf("expected message+remediation for warn; msg=%q remediation=%q", msg, remediation)
+	}
+}
+
+func TestNormalizeNeo4jConstraintRows(t *testing.T) {
+	rows := []map[string]any{
+		{
+			"type":          "UNIQUE",
+			"labelsOrTypes": []any{"__Node__"},
+			"properties":    []any{"id"},
+		},
+	}
+	got := normalizeNeo4jConstraintRows(rows)
+	if !got["__Node__:id:UNIQUE"] {
+		t.Fatalf("expected __Node__:id:UNIQUE to be present; got=%v", got)
+	}
+}
+
+func TestNormalizeNeo4jIndexRows(t *testing.T) {
+	rows := []map[string]any{
+		{
+			"labelsOrTypes": []any{"__Node__"},
+			"properties":    []any{"name", "dataset_id"},
+		},
+	}
+	got := normalizeNeo4jIndexRows(rows)
+	if !got["__Node__:name"] || !got["__Node__:dataset_id"] {
+		t.Fatalf("expected name+dataset_id indexes; got=%v", got)
+	}
+}

--- a/Levara/pkg/graphdb/neo4j.go
+++ b/Levara/pkg/graphdb/neo4j.go
@@ -15,9 +15,9 @@ const baseLabel = "__Node__"
 
 // NodeRecord represents a node to write to Neo4j.
 type NodeRecord struct {
-	ID         string            // UUID string
-	Label      string            // Dynamic label (class name, e.g. "Entity")
-	Properties map[string]any    // All serialized properties
+	ID         string         // UUID string
+	Label      string         // Dynamic label (class name, e.g. "Entity")
+	Properties map[string]any // All serialized properties
 }
 
 // EdgeRecord represents an edge to write to Neo4j.
@@ -65,14 +65,20 @@ func NewWriter(ctx context.Context, url, username, password, database string) (*
 		return nil, fmt.Errorf("neo4j connectivity: %w", err)
 	}
 
-	w := &Writer{driver: driver, database: database}
+	return &Writer{driver: driver, database: database}, nil
+}
 
-	// Ensure unique constraint
-	if err := w.ensureConstraint(ctx); err != nil {
-		driver.Close(ctx)
+// NewWriterWithSchema creates a writer and ensures required schema objects.
+// Use this for one-time bootstrap paths, not per-request query handlers.
+func NewWriterWithSchema(ctx context.Context, url, username, password, database string) (*Writer, error) {
+	w, err := NewWriter(ctx, url, username, password, database)
+	if err != nil {
 		return nil, err
 	}
-
+	if err := w.EnsureSchema(ctx); err != nil {
+		w.Close(ctx)
+		return nil, err
+	}
 	return w, nil
 }
 
@@ -81,15 +87,26 @@ func (w *Writer) Close(ctx context.Context) error {
 	return w.driver.Close(ctx)
 }
 
-func (w *Writer) ensureConstraint(ctx context.Context) error {
+// EnsureSchema creates required constraints/indexes if they do not exist.
+func (w *Writer) EnsureSchema(ctx context.Context) error {
 	session := w.driver.NewSession(ctx, neo4j.SessionConfig{DatabaseName: w.database})
 	defer session.Close(ctx)
 
-	_, err := session.Run(ctx,
-		fmt.Sprintf("CREATE CONSTRAINT IF NOT EXISTS FOR (n:`%s`) REQUIRE n.id IS UNIQUE", baseLabel),
-		nil,
-	)
-	return err
+	for _, stmt := range requiredNeo4jSchemaStatements(baseLabel) {
+		if _, err := session.Run(ctx, stmt, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func requiredNeo4jSchemaStatements(label string) []string {
+	return []string{
+		fmt.Sprintf("CREATE CONSTRAINT IF NOT EXISTS FOR (n:`%s`) REQUIRE n.id IS UNIQUE", label),
+		fmt.Sprintf("CREATE INDEX IF NOT EXISTS FOR (n:`%s`) ON (n.name)", label),
+		fmt.Sprintf("CREATE INDEX IF NOT EXISTS FOR (n:`%s`) ON (n.dataset_id)", label),
+		fmt.Sprintf("CREATE INDEX IF NOT EXISTS FOR (n:`%s`) ON (n.type)", label),
+	}
 }
 
 // BatchWrite writes nodes and edges to Neo4j in batch using UNWIND.

--- a/Levara/pkg/graphdb/neo4j_test.go
+++ b/Levara/pkg/graphdb/neo4j_test.go
@@ -2,6 +2,7 @@ package graphdb
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -56,10 +57,10 @@ func TestFlattenEdgeProperties(t *testing.T) {
 		"source_node_id": "n1",
 		"target_node_id": "n2",
 		"weights": map[string]any{
-			"semantic":  0.8,
-			"temporal":  0.3,
+			"semantic": 0.8,
+			"temporal": 0.3,
 		},
-		"edge_text": "uses",
+		"edge_text":  "uses",
 		"extra_data": map[string]any{"foo": "bar"},
 		"tag_list":   []any{"a", "b"},
 	}
@@ -108,5 +109,30 @@ func TestFlattenEdgePropertiesNil(t *testing.T) {
 	out := flattenEdgeProperties(nil)
 	if out == nil || len(out) != 0 {
 		t.Errorf("nil props should return empty map, got %v", out)
+	}
+}
+
+func TestRequiredNeo4jSchemaStatements(t *testing.T) {
+	stmts := requiredNeo4jSchemaStatements(baseLabel)
+	if len(stmts) != 4 {
+		t.Fatalf("expected 4 schema statements, got %d", len(stmts))
+	}
+	wantContains := []string{
+		"CREATE CONSTRAINT IF NOT EXISTS",
+		"ON (n.name)",
+		"ON (n.dataset_id)",
+		"ON (n.type)",
+	}
+	for _, want := range wantContains {
+		found := false
+		for _, stmt := range stmts {
+			if strings.Contains(stmt, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("schema statements missing fragment %q; got %v", want, stmts)
+		}
 	}
 }

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -111,6 +111,8 @@ docker run -d --name neo4j \
 ### Cypher Queries
 ```bash
 ALLOW_CYPHER_QUERY=true  # разрешить raw Cypher через API
+# Optional startup toggle (default: enabled):
+NEO4J_BOOTSTRAP_SCHEMA=false  # не выполнять startup CREATE INDEX/CONSTRAINT
 ```
 Защита: CREATE/MERGE/DELETE/SET/REMOVE/DROP блокируются.
 

--- a/docs/neo4j-coverage-plan.md
+++ b/docs/neo4j-coverage-plan.md
@@ -1,0 +1,96 @@
+# Levara × Neo4j Coverage Plan (Tasks + DoD)
+
+Дата: 2026-04-28  
+Цель: расширить покрытие neo4j-функционала в Levara без деградации безопасности и стабильности.
+
+## Принципы выполнения
+
+- Безопасность по умолчанию: read-only policy остаётся дефолтом.
+- Все изменения с автотестами (unit + handler/integration где применимо).
+- Каждый этап завершать измеримым DoD.
+
+---
+
+## Этап 1 — Cypher policy hardening + controlled write mode
+
+### Задачи
+1. Вынести проверку Cypher в отдельный валидатор.
+2. Ужесточить read-only профиль:
+   - разрешённые префиксы: `MATCH`, `OPTIONAL MATCH`, `WITH`, `CALL`, `UNWIND`;
+   - запрет write-операций: `CREATE`, `MERGE`, `DELETE`, `DETACH`, `SET`, `REMOVE`, `FOREACH`.
+3. Добавить управляемый write-режим через env-флаг `ALLOW_CYPHER_WRITE=true`.
+4. Даже в write-режиме блокировать admin/destructive операции:
+   - `DROP`, `DATABASE`, `CONSTRAINT`, `INDEX`, `DBMS`, `TERMINATE`, `LOAD CSV`.
+
+### DoD
+- [ ] `CYPHER` запросы с write-клаузами в дефолтном режиме возвращают 403.
+- [ ] `CYPHER` запросы с write-клаузами при `ALLOW_CYPHER_WRITE=true` проходят policy-check.
+- [ ] Admin/destructive запросы блокируются всегда.
+- [ ] Покрытие тестами:
+  - unit-тесты policy-валидатора,
+  - handler-тесты для 403/500 веток без поднятого Neo4j.
+
+---
+
+## Этап 2 — Index/Constraint manager для Neo4j
+
+### Задачи
+1. Ввести декларативный список индексов/constraint'ов (name/type/dataset_id/temporal поля).
+2. Добавить `EnsureSchema(ctx)` в graphdb-слой.
+3. Встроить schema-check в doctor (warn/fail + remediation hint).
+
+### DoD
+- [ ] При старте система создаёт/проверяет обязательные индексы.
+- [ ] Doctor показывает отсутствующие индексы и рекомендации.
+- [ ] Тесты на генерацию/применение schema statements.
+
+---
+
+## Этап 3 — Transaction API для graphdb
+
+### Задачи
+1. Добавить `RunReadTx` / `RunWriteTx` обёртки.
+2. Перенести multi-step graph write в explicit transaction.
+3. Добавить retry на transient ошибки (bounded retry).
+
+### DoD
+- [ ] Multi-step write атомарен.
+- [ ] При transient ошибке наблюдается успешный bounded retry.
+- [ ] Покрытие unit-тестами и happy-path integration-тестом.
+
+---
+
+## Этап 4 — Path/Traversal API
+
+### Задачи
+1. Добавить endpoint/tool для shortest-path и k-hop traversal.
+2. Параметры: `source`, `target`, `max_hops`, `rel_allowlist`.
+3. Возвращать explainable путь (узлы + рёбра + сводка).
+
+### DoD
+- [ ] API выдаёт корректный путь на тестовом графе.
+- [ ] Невозможный путь возвращает корректный empty result.
+- [ ] Есть тесты для ограничений по `max_hops` и фильтрации типов рёбер.
+
+---
+
+## Этап 5 — Temporal graph parity в Neo4j path
+
+### Задачи
+1. Добавить `as_of` и временные фильтры в Neo4j-поиск/контекст.
+2. Привести семантику к MCP `query_entity` (valid window).
+3. Индексы по temporal полям.
+
+### DoD
+- [ ] Для одинаковых тест-кейсов PostgreSQL и Neo4j пути дают согласованную temporal-выборку.
+- [ ] Есть тесты на active-now и snapshot-as_of.
+
+---
+
+## Статус текущей итерации
+
+- [x] Этап 1: реализован (policy hardening + controlled write mode + тесты).
+- [~] Этап 2: частично реализован (bootstrap индексов/constraint'ов + doctor schema-check; остаются интеграционные проверки).
+- [ ] Этап 3: запланирован.
+- [ ] Этап 4: запланирован.
+- [ ] Этап 5: запланирован.


### PR DESCRIPTION
### Motivation

- Provide a safe, declarative way to ensure Neo4j indexes/constraints on startup while allowing operators to disable bootstrap for legacy flows.
- Harden Cypher query handling so raw queries are read-only by default and only allow writes behind an explicit flag, preventing accidental destructive operations.
- Surface Neo4j schema coverage in the MCP "doctor" diagnostics to warn operators when required indexes/constraints are missing.

### Description

- Added a one-time startup schema bootstrap flow gated by `NEO4J_BOOTSTRAP_SCHEMA` and a helper `shouldBootstrapNeo4jSchema` in `neo4j_bootstrap.go`, and invoked `graphdb.NewWriterWithSchema` from `cmd/server/main.go` when appropriate.
- Moved Neo4j schema creation into the graph layer with `graphdb.NewWriterWithSchema`, `Writer.EnsureSchema`, and `requiredNeo4jSchemaStatements` in `pkg/graphdb/neo4j.go`, and stopped making schema changes as part of the regular `NewWriter` path.
- Replaced simple substring write-blocking with a policy validator `isCypherAllowed` (and helpers `hasAllowedReadPrefix`/`containsAnyCypherKeyword`) in `internal/http/graph_search.go`, and integrated it into both the raw `cypherSearch` and NL→Cypher `naturalLanguageSearch` flows; write queries can be enabled with `ALLOW_CYPHER_WRITE=true` while admin/destructive keywords remain blocked.
- Added Neo4j schema introspection and evaluation to the MCP doctor (`checkNeo4jSchema`, normalizers, and schema evaluation helpers) in `internal/http/mcp_doctor.go` so the doctor reports missing constraints/indexes with remediation hints.
- Added/updated unit tests for the new behavior: `neo4j_bootstrap_test.go`, enhancements to `cypher_nl_search_test.go` including `TestIsCypherAllowed`, `mcp_doctor_schema_test.go`, and `pkg/graphdb/neo4j_test.go` additions; also small formatting/cleanup changes and docs additions (`docs/integrations.md`, `docs/neo4j-coverage-plan.md`).

### Testing

- Ran the unit test suite (`go test ./...`) covering new and affected packages, including `TestShouldBootstrapNeo4jSchema`, Cypher handler tests (`TestCypherSearch_*`, `TestIsCypherAllowed`), Neo4j schema evaluation tests (`TestEvaluateNeo4jSchema_*`, `TestNormalizeNeo4j*`), and `TestRequiredNeo4jSchemaStatements` and observed success.
- Handler tests exercise both policy-deny (403) and policy-allow-then-connection-fail (500) branches to ensure the policy gating works without requiring a live Neo4j instance.
- Documentation updated to describe the new `NEO4J_BOOTSTRAP_SCHEMA` toggle and the Neo4j coverage plan used to guide these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f04b5701b8832db10c2f6c4aac63bf)