### PR TITLE
Search: add confidence/abstention, verification, evidence IDs and debug response envelope

### DIFF
--- a/Levara/internal/http/api_search.go
+++ b/Levara/internal/http/api_search.go
@@ -50,6 +50,10 @@ type CogneeSearchRequest struct {
 	SessionID         string   `json:"session_id"`    // Conversational memory: load prior interactions
 	Tags              []string `json:"tags"`           // Optional: filter results by metadata tags
 	Rerank            bool     `json:"rerank"`         // Optional: rerank results via cross-encoder
+	IncludeDebug      bool     `json:"include_debug"`  // Optional: envelope list responses with debug metadata
+	StrictGrounded    bool     `json:"strict_grounded"` // Optional: abstain if no evidence_ids
+	VerifyResults     bool     `json:"verify_results"` // Optional: verify metadata JSON and filter malformed rows
+	MinScore          float64  `json:"min_score"`      // Optional: drop hits below this score
 	AllowedDatasetIDs []string `json:"-"`              // RBAC: nil = no filtering (dev mode)
 }
 
@@ -323,11 +327,12 @@ func searchHandler(cfg APIConfig) fiber.Handler {
 			queryType = d.SearchType
 		}
 
-		metrics.SearchRequestsByType.WithLabelValues(queryType, source).Inc()
+			metrics.SearchRequestsByType.WithLabelValues(queryType, source).Inc()
+			c.Locals("routing_source", source)
 
-		// Store routing metadata for response enrichment
-		if routingDecision != nil {
-			c.Locals("routing_decision", routingDecision)
+			// Store routing metadata for response enrichment
+			if routingDecision != nil {
+				c.Locals("routing_decision", routingDecision)
 		}
 
 		// T5: strategy dispatch through the registry. Unknown query_type
@@ -362,7 +367,7 @@ func capabilitiesFromConfig(cfg APIConfig) router.Capabilities {
 
 func chunksSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) error {
 	if cfg.EmbedEndpoint == "" || cfg.Collections == nil {
-		return c.JSON([]any{})
+		return respondSearchItems(c, req, "CHUNKS", []any{})
 	}
 
 	// Create reranker if requested and endpoint configured
@@ -450,12 +455,12 @@ func chunksSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) error {
 		allResults = allResults[:req.TopK]
 	}
 
-	return c.JSON(allResults)
+	return respondSearchItems(c, req, "CHUNKS", allResults)
 }
 
 func bm25Search(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) error {
 	if cfg.BM25Indexes == nil {
-		return c.JSON([]any{})
+		return respondSearchItems(c, req, "CHUNKS_LEXICAL", []any{})
 	}
 
 	var allResults []fiber.Map
@@ -480,12 +485,12 @@ func bm25Search(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) error {
 	if len(allResults) > req.TopK {
 		allResults = allResults[:req.TopK]
 	}
-	return c.JSON(allResults)
+	return respondSearchItems(c, req, "CHUNKS_LEXICAL", allResults)
 }
 
 func hybridSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) error {
 	if cfg.EmbedEndpoint == "" || cfg.Collections == nil {
-		return c.JSON([]any{})
+		return respondSearchItems(c, req, "HYBRID", []any{})
 	}
 
 	var rerankClient *rerank.Client
@@ -549,7 +554,7 @@ func hybridSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) error {
 	if len(allResults) > req.TopK {
 		allResults = allResults[:req.TopK]
 	}
-	return c.JSON(allResults)
+	return respondSearchItems(c, req, "HYBRID", allResults)
 }
 
 func temporalSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) error {
@@ -619,11 +624,11 @@ func temporalSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) error 
 		})
 	}
 
-	return c.JSON(fiber.Map{
+	return c.JSON(attachSearchDebugMetadata(c, fiber.Map{
 		"results":         combined,
 		"extracted_dates": extractedDates,
 		"search_type":     "TEMPORAL",
-	})
+	}))
 }
 
 // temporalSearchNeo4j queries Neo4j for entities linked to TemporalEvent nodes in a date range.
@@ -738,7 +743,13 @@ func temporalSearchPostgres(ctx context.Context, cfg APIConfig, from, to time.Ti
 // Returns both raw chunks and an LLM-generated answer.
 func ragCompletionSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) error {
 	if cfg.EmbedEndpoint == "" || cfg.Collections == nil {
-		return c.JSON(fiber.Map{"chunks": []any{}, "answer": ""})
+		return c.JSON(attachSearchDebugMetadata(c, fiber.Map{
+			"chunks":         []any{},
+			"answer":         "",
+			"confidence":     0.0,
+			"abstained":      true,
+			"abstain_reason": "embedding backend unavailable",
+		}))
 	}
 
 	// Step 1: vector search (same as chunksSearch)
@@ -767,13 +778,30 @@ func ragCompletionSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) e
 	}
 	// RBAC post-filter
 	chunks = filterByAllowedDatasets(chunks, req.AllowedDatasetIDs)
+	chunks, verification := verifyScoredResults(chunks, req.MinScore, req.VerifyResults)
+
+	threshold := ragAbstainThresholdFor("RAG_COMPLETION")
+	breakdown := buildConfidenceBreakdown(c, chunks, threshold)
+	confidence := breakdown.Combined
+	evidenceIDs := extractEvidenceChunkIDs(chunks, 10)
+	lowConfidence := threshold > 0 && (len(chunks) == 0 || confidence < threshold)
+	noEvidence := req.StrictGrounded && len(evidenceIDs) == 0
+	abstained := lowConfidence || noEvidence
+	abstainReason := ""
+	if noEvidence {
+		abstainReason = "strict_grounded_no_evidence"
+	} else if lowConfidence {
+		abstainReason = "low_confidence"
+	}
 
 	// Step 2: LLM completion using retrieved chunks as context
 	llmEndpoint := os.Getenv("LLM_ENDPOINT")
 	llmModel := os.Getenv("LLM_MODEL")
 	answer := ""
 
-	if llmEndpoint != "" && llmModel != "" && len(chunks) > 0 {
+	if abstained {
+		answer = defaultAbstainMessage
+	} else if llmEndpoint != "" && llmModel != "" && len(chunks) > 0 {
 		// Build context from chunk metadata — extract "text" field, skip entities without text
 		var contextParts []string
 		for _, chunk := range chunks {
@@ -840,16 +868,24 @@ func ragCompletionSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) e
 		}
 	}
 
-	return c.JSON(fiber.Map{
-		"chunks": chunks,
-		"answer": answer,
-	})
+	return c.JSON(attachSearchDebugMetadata(c, fiber.Map{
+		"chunks":               chunks,
+		"evidence_ids":         evidenceIDs,
+		"answer":               answer,
+		"confidence":           confidence,
+		"confidence_breakdown": breakdown,
+		"abstained":            abstained,
+		"abstain_reason":       abstainReason,
+		"threshold":            threshold,
+		"search_type":          "RAG_COMPLETION",
+		"verification":         verification,
+	}))
 }
 
 // summariesSearch searches only in summary collections (TextSummary nodes from memify).
 func summariesSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) error {
 	if cfg.EmbedEndpoint == "" || cfg.Collections == nil {
-		return c.JSON([]any{})
+		return respondSearchItems(c, req, "SUMMARIES", []any{})
 	}
 
 	embedClient := cfg.EmbedClient
@@ -926,7 +962,7 @@ func summariesSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) error
 		allResults = allResults[:req.TopK]
 	}
 
-	return c.JSON(allResults)
+	return respondSearchItems(c, req, "SUMMARIES", allResults)
 }
 
 // callLLMFromAPI is a standalone LLM call helper for search handlers.

--- a/Levara/internal/http/confidence.go
+++ b/Levara/internal/http/confidence.go
@@ -1,0 +1,139 @@
+package http
+
+import (
+	"math"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stek0v/levara/pkg/router"
+)
+
+const (
+	defaultAbstainThreshold = 0.0
+	defaultAbstainMessage   = "Недостаточно подтвержденного контекста для надежного ответа. Уточните запрос или добавьте больше данных."
+)
+
+type confidenceBreakdown struct {
+	Retrieval float64 `json:"retrieval"`
+	Routing   float64 `json:"routing"`
+	Combined  float64 `json:"combined"`
+	Threshold float64 `json:"threshold"`
+}
+
+// ragAbstainThreshold returns the confidence threshold below which the API abstains.
+// LEVARA_RAG_ABSTAIN_THRESHOLD can override the default in [0,1].
+func ragAbstainThreshold() float64 {
+	v, _ := parseThreshold(os.Getenv("LEVARA_RAG_ABSTAIN_THRESHOLD"))
+	return v
+}
+
+// ragAbstainThresholdFor returns per-search-type threshold when configured, and
+// falls back to global LEVARA_RAG_ABSTAIN_THRESHOLD otherwise.
+//
+// Example keys:
+//   LEVARA_RAG_ABSTAIN_THRESHOLD_RAG_COMPLETION
+//   LEVARA_RAG_ABSTAIN_THRESHOLD_GRAPH_COMPLETION
+func ragAbstainThresholdFor(searchType string) float64 {
+	st := strings.ToUpper(strings.TrimSpace(searchType))
+	if st != "" {
+		key := "LEVARA_RAG_ABSTAIN_THRESHOLD_" + st
+		if v, ok := parseThreshold(os.Getenv(key)); ok {
+			return v
+		}
+	}
+	return ragAbstainThreshold()
+}
+
+func parseThreshold(raw string) (float64, bool) {
+	if raw == "" {
+		return defaultAbstainThreshold, false
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil || v < 0 || v > 1 {
+		return defaultAbstainThreshold, false
+	}
+	return v, true
+}
+
+// normalizeScore maps both similarity-like and distance-like scores to [0,1].
+func normalizeScore(v float64) float64 {
+	switch {
+	case v < 0:
+		return 0
+	case v <= 1:
+		return v
+	default:
+		// Distance-like scores (larger is worse) compressed into [0,1).
+		return 1.0 / (1.0 + v)
+	}
+}
+
+func confidenceFromChunks(chunks []fiber.Map) float64 {
+	if len(chunks) == 0 {
+		return 0
+	}
+	top := 0.0
+	second := 0.0
+	for i, c := range chunks {
+		s, ok := c["score"].(float64)
+		if !ok {
+			continue
+		}
+		n := normalizeScore(s)
+		if i == 0 || n > top {
+			second = top
+			top = n
+		} else if n > second {
+			second = n
+		}
+	}
+	gap := top - second
+	if gap < 0 {
+		gap = 0
+	}
+	coverage := math.Min(float64(len(chunks))/10.0, 1.0)
+	// Weighted blend: score quality + confidence gap + retrieval coverage.
+	conf := top*0.6 + gap*0.25 + coverage*0.15
+	if conf < 0 {
+		return 0
+	}
+	if conf > 1 {
+		return 1
+	}
+	return conf
+}
+
+func confidenceFromRouting(c *fiber.Ctx) float64 {
+	if c == nil {
+		return 0.5
+	}
+	rd, ok := c.Locals("routing_decision").(*router.Decision)
+	if !ok || rd == nil {
+		return 0.5
+	}
+	return float64(rd.Confidence)
+}
+
+func combinedRAGConfidence(c *fiber.Ctx, chunks []fiber.Map) float64 {
+	return buildConfidenceBreakdown(c, chunks, 0).Combined
+}
+
+func buildConfidenceBreakdown(c *fiber.Ctx, chunks []fiber.Map, threshold float64) confidenceBreakdown {
+	retr := confidenceFromChunks(chunks)
+	route := confidenceFromRouting(c)
+	conf := retr*0.7 + route*0.3
+	if conf < 0 {
+		conf = 0
+	}
+	if conf > 1 {
+		conf = 1
+	}
+	return confidenceBreakdown{
+		Retrieval: retr,
+		Routing:   route,
+		Combined:  conf,
+		Threshold: threshold,
+	}
+}

--- a/Levara/internal/http/confidence_test.go
+++ b/Levara/internal/http/confidence_test.go
@@ -1,0 +1,80 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func TestRAGAbstainThreshold_DefaultAndEnv(t *testing.T) {
+	t.Setenv("LEVARA_RAG_ABSTAIN_THRESHOLD", "")
+	if got := ragAbstainThreshold(); got != defaultAbstainThreshold {
+		t.Fatalf("default threshold: got %.2f want %.2f", got, defaultAbstainThreshold)
+	}
+
+	t.Setenv("LEVARA_RAG_ABSTAIN_THRESHOLD", "0.62")
+	if got := ragAbstainThreshold(); got != 0.62 {
+		t.Fatalf("env threshold: got %.2f want 0.62", got)
+	}
+
+	t.Setenv("LEVARA_RAG_ABSTAIN_THRESHOLD", "oops")
+	if got := ragAbstainThreshold(); got != defaultAbstainThreshold {
+		t.Fatalf("invalid env fallback: got %.2f want %.2f", got, defaultAbstainThreshold)
+	}
+}
+
+func TestRAGAbstainThresholdFor_PerSearchTypeOverride(t *testing.T) {
+	t.Setenv("LEVARA_RAG_ABSTAIN_THRESHOLD", "0.25")
+	t.Setenv("LEVARA_RAG_ABSTAIN_THRESHOLD_RAG_COMPLETION", "0.70")
+	t.Setenv("LEVARA_RAG_ABSTAIN_THRESHOLD_GRAPH_COMPLETION", "")
+
+	if got := ragAbstainThresholdFor("RAG_COMPLETION"); got != 0.70 {
+		t.Fatalf("rag-specific threshold: got %.2f want 0.70", got)
+	}
+	if got := ragAbstainThresholdFor("GRAPH_COMPLETION"); got != 0.25 {
+		t.Fatalf("graph fallback threshold: got %.2f want 0.25", got)
+	}
+}
+
+func TestConfidenceFromChunks(t *testing.T) {
+	empty := confidenceFromChunks(nil)
+	if empty != 0 {
+		t.Fatalf("empty confidence: got %.2f want 0", empty)
+	}
+
+	strong := confidenceFromChunks([]fiber.Map{
+		{"score": 0.93},
+		{"score": 0.81},
+		{"score": 0.77},
+	})
+	weak := confidenceFromChunks([]fiber.Map{
+		{"score": 0.25},
+		{"score": 0.24},
+	})
+	if strong <= weak {
+		t.Fatalf("expected strong > weak confidence: strong=%.3f weak=%.3f", strong, weak)
+	}
+}
+
+func TestNormalizeScore_DistanceLike(t *testing.T) {
+	if got := normalizeScore(2.0); got <= 0 || got >= 1 {
+		t.Fatalf("distance-like score normalization out of range: %.3f", got)
+	}
+}
+
+func TestCombinedRAGConfidence_Clamped(t *testing.T) {
+	conf := combinedRAGConfidence(nil, []fiber.Map{{"score": 0.9}})
+	if conf < 0 || conf > 1 {
+		t.Fatalf("combined confidence not clamped: %.3f", conf)
+	}
+}
+
+func TestBuildConfidenceBreakdown(t *testing.T) {
+	b := buildConfidenceBreakdown(nil, []fiber.Map{{"score": 0.9}}, 0.4)
+	if b.Combined < 0 || b.Combined > 1 {
+		t.Fatalf("combined out of range: %.3f", b.Combined)
+	}
+	if b.Threshold != 0.4 {
+		t.Fatalf("threshold mismatch: %.2f", b.Threshold)
+	}
+}

--- a/Levara/internal/http/evidence.go
+++ b/Levara/internal/http/evidence.go
@@ -1,0 +1,25 @@
+package http
+
+import "github.com/gofiber/fiber/v2"
+
+// extractEvidenceChunkIDs extracts up to limit chunk IDs for response grounding metadata.
+func extractEvidenceChunkIDs(chunks []fiber.Map, limit int) []string {
+	if limit <= 0 {
+		limit = 10
+	}
+	out := make([]string, 0, limit)
+	seen := make(map[string]bool, limit)
+	for _, c := range chunks {
+		id, _ := c["id"].(string)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out
+}
+

--- a/Levara/internal/http/evidence_test.go
+++ b/Levara/internal/http/evidence_test.go
@@ -1,0 +1,24 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func TestExtractEvidenceChunkIDs_DedupAndLimit(t *testing.T) {
+	chunks := []fiber.Map{
+		{"id": "a"},
+		{"id": "b"},
+		{"id": "a"},
+		{"id": "c"},
+	}
+	got := extractEvidenceChunkIDs(chunks, 2)
+	if len(got) != 2 {
+		t.Fatalf("len=%d, want 2", len(got))
+	}
+	if got[0] != "a" || got[1] != "b" {
+		t.Fatalf("got=%v, want [a b]", got)
+	}
+}
+

--- a/Levara/internal/http/extended_search_test.go
+++ b/Levara/internal/http/extended_search_test.go
@@ -38,6 +38,15 @@ func TestContextExtensionSearch_EmptyConfig(t *testing.T) {
 	if body["search_type"] != "GRAPH_COMPLETION_CONTEXT_EXTENSION" {
 		t.Errorf("search_type = %v", body["search_type"])
 	}
+	if body["abstained"] != true {
+		t.Errorf("abstained = %v, want true", body["abstained"])
+	}
+	if body["confidence"] != float64(0) {
+		t.Errorf("confidence = %v, want 0", body["confidence"])
+	}
+	if dbg, ok := body["debug"].(map[string]any); !ok || dbg["source"] != "explicit" {
+		t.Errorf("debug = %v, want source=explicit", body["debug"])
+	}
 }
 
 // Postgres path populates hop1 context via graphContextFromPostgres, but
@@ -98,6 +107,9 @@ func TestContextExtensionSearch_CallsLLMWithLabelledContext(t *testing.T) {
 	if body["answer"] != "Alice knows Bob." {
 		t.Errorf("answer = %v", body["answer"])
 	}
+	if ids, ok := body["evidence_ids"].([]any); !ok || len(ids) == 0 {
+		t.Fatalf("evidence_ids missing/empty: %#v", body["evidence_ids"])
+	}
 	prompts := llm.promptsSnapshot()
 	if len(prompts) != 1 {
 		t.Fatalf("captured %d prompts, want 1", len(prompts))
@@ -109,6 +121,45 @@ func TestContextExtensionSearch_CallsLLMWithLabelledContext(t *testing.T) {
 	// header must NOT appear when hop2 is empty.
 	if strings.Contains(prompts[0], "Extended relationships (2-hop)") {
 		t.Errorf("prompt has hop2 section with no hop2 data:\n%s", prompts[0])
+	}
+}
+
+func TestContextExtensionSearch_AbstainsAtHighThreshold(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{responses: []string{"should not be used"}}
+	env.cfg.LLMProvider = llm
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused-model")
+	t.Setenv("LEVARA_RAG_ABSTAIN_THRESHOLD", "0.95")
+	t.Setenv("LEVARA_RAG_ABSTAIN_THRESHOLD_GRAPH_COMPLETION_CONTEXT_EXTENSION", "0.95")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"name": "Alice"})
+	env.insertNode("n1", "Alice", "Person", "")
+	env.insertNode("n2", "Bob", "Person", "")
+	env.insertEdge("r1", "n1", "n2", "KNOWS")
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "what is related to alice",
+		"query_type": "GRAPH_COMPLETION_CONTEXT_EXTENSION",
+		"collection": "entities",
+	})
+
+	if body["abstained"] != true {
+		t.Fatalf("abstained = %v, want true", body["abstained"])
+	}
+	if body["threshold"] != 0.95 {
+		t.Fatalf("threshold = %v, want 0.95", body["threshold"])
+	}
+	if _, ok := body["confidence_breakdown"].(map[string]any); !ok {
+		t.Fatalf("confidence_breakdown missing or wrong type: %#v", body["confidence_breakdown"])
+	}
+	if body["answer"] != defaultAbstainMessage {
+		t.Fatalf("answer = %v, want abstain message", body["answer"])
+	}
+	if got := len(llm.promptsSnapshot()); got != 0 {
+		t.Fatalf("llm prompts = %d, want 0 on abstain", got)
 	}
 }
 

--- a/Levara/internal/http/graph_search.go
+++ b/Levara/internal/http/graph_search.go
@@ -20,7 +20,14 @@ import (
 // graphCompletionSearch performs vector search → extract entities → graph context → LLM answer.
 func graphCompletionSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) error {
 	if cfg.EmbedEndpoint == "" || cfg.Collections == nil {
-		return c.JSON(fiber.Map{"answer": "", "context": []any{}, "search_type": "GRAPH_COMPLETION"})
+		return c.JSON(attachSearchDebugMetadata(c, fiber.Map{
+			"answer":         "",
+			"context":        []any{},
+			"search_type":    "GRAPH_COMPLETION",
+			"confidence":     0.0,
+			"abstained":      true,
+			"abstain_reason": "embedding backend unavailable",
+		}))
 	}
 
 	ctx := context.Background()
@@ -57,6 +64,7 @@ func graphCompletionSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest)
 	}
 	// RBAC post-filter
 	vectorChunks = filterByAllowedDatasets(vectorChunks, req.AllowedDatasetIDs)
+	vectorChunks, verification := verifyScoredResults(vectorChunks, req.MinScore, req.VerifyResults)
 
 	if len(vectorChunks) > req.TopK {
 		vectorChunks = vectorChunks[:req.TopK]
@@ -76,12 +84,28 @@ func graphCompletionSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest)
 		graphContext = graphContextFromPostgres(ctx, cfg, entityNames, req.AllowedDatasetIDs)
 	}
 
+	threshold := ragAbstainThresholdFor("GRAPH_COMPLETION")
+	breakdown := buildConfidenceBreakdown(c, vectorChunks, threshold)
+	confidence := breakdown.Combined
+	evidenceIDs := extractEvidenceChunkIDs(vectorChunks, 10)
+	lowConfidence := threshold > 0 && ((len(graphContext) == 0 && len(vectorChunks) == 0) || confidence < threshold)
+	noEvidence := req.StrictGrounded && len(evidenceIDs) == 0
+	abstained := lowConfidence || noEvidence
+	abstainReason := ""
+	if noEvidence {
+		abstainReason = "strict_grounded_no_evidence"
+	} else if lowConfidence {
+		abstainReason = "low_confidence"
+	}
+
 	// Step 3: LLM completion
 	llmEndpoint := os.Getenv("LLM_ENDPOINT")
 	llmModel := os.Getenv("LLM_MODEL")
 	answer := ""
 
-	if llmEndpoint != "" && llmModel != "" && (len(graphContext) > 0 || len(vectorChunks) > 0) {
+	if abstained {
+		answer = defaultAbstainMessage
+	} else if llmEndpoint != "" && llmModel != "" && (len(graphContext) > 0 || len(vectorChunks) > 0) {
 		var contextStr string
 		if len(graphContext) > 0 {
 			contextStr = "Knowledge graph context:\n" + strings.Join(graphContext, "\n")
@@ -112,12 +136,19 @@ func graphCompletionSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest)
 
 	recordInteraction(cfg, req.SessionID, "", req.QueryText, answer, "GRAPH_COMPLETION")
 
-	return c.JSON(fiber.Map{
-		"answer":      answer,
-		"context":     graphContext,
-		"chunks":      vectorChunks,
-		"search_type": "GRAPH_COMPLETION",
-	})
+	return c.JSON(attachSearchDebugMetadata(c, fiber.Map{
+		"answer":               answer,
+		"context":              graphContext,
+		"chunks":               vectorChunks,
+		"evidence_ids":         evidenceIDs,
+		"search_type":          "GRAPH_COMPLETION",
+		"confidence":           confidence,
+		"confidence_breakdown": breakdown,
+		"abstained":            abstained,
+		"abstain_reason":       abstainReason,
+		"threshold":            threshold,
+		"verification":         verification,
+	}))
 }
 
 // contextExtensionSearch performs 2-hop graph traversal for richer context.
@@ -125,7 +156,14 @@ func graphCompletionSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest)
 // entity→neighbours→THEIR neighbours, gathering a wider knowledge context.
 func contextExtensionSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest) error {
 	if cfg.EmbedEndpoint == "" || cfg.Collections == nil {
-		return c.JSON(fiber.Map{"answer": "", "context": []any{}, "search_type": "GRAPH_COMPLETION_CONTEXT_EXTENSION"})
+		return c.JSON(attachSearchDebugMetadata(c, fiber.Map{
+			"answer":         "",
+			"context":        []any{},
+			"search_type":    "GRAPH_COMPLETION_CONTEXT_EXTENSION",
+			"confidence":     0.0,
+			"abstained":      true,
+			"abstain_reason": "embedding backend unavailable",
+		}))
 	}
 
 	ctx := context.Background()
@@ -158,6 +196,7 @@ func contextExtensionSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest
 		}
 	}
 	vectorChunks = filterByAllowedDatasets(vectorChunks, req.AllowedDatasetIDs)
+	vectorChunks, verification := verifyScoredResults(vectorChunks, req.MinScore, req.VerifyResults)
 	if len(vectorChunks) > req.TopK {
 		vectorChunks = vectorChunks[:req.TopK]
 	}
@@ -204,12 +243,28 @@ func contextExtensionSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest
 	// Merge all context
 	allContext := append(hop1Context, hop2Context...)
 
+	threshold := ragAbstainThresholdFor("GRAPH_COMPLETION_CONTEXT_EXTENSION")
+	breakdown := buildConfidenceBreakdown(c, vectorChunks, threshold)
+	confidence := breakdown.Combined
+	evidenceIDs := extractEvidenceChunkIDs(vectorChunks, 10)
+	lowConfidence := threshold > 0 && ((len(allContext) == 0 && len(vectorChunks) == 0) || confidence < threshold)
+	noEvidence := req.StrictGrounded && len(evidenceIDs) == 0
+	abstained := lowConfidence || noEvidence
+	abstainReason := ""
+	if noEvidence {
+		abstainReason = "strict_grounded_no_evidence"
+	} else if lowConfidence {
+		abstainReason = "low_confidence"
+	}
+
 	// Step 4: LLM completion with extended context
 	llmEndpoint := os.Getenv("LLM_ENDPOINT")
 	llmModel := os.Getenv("LLM_MODEL")
 	answer := ""
 
-	if llmEndpoint != "" && llmModel != "" && (len(allContext) > 0 || len(vectorChunks) > 0) {
+	if abstained {
+		answer = defaultAbstainMessage
+	} else if llmEndpoint != "" && llmModel != "" && (len(allContext) > 0 || len(vectorChunks) > 0) {
 		var contextStr string
 		if len(hop1Context) > 0 {
 			contextStr = "Direct relationships (1-hop):\n" + strings.Join(hop1Context, "\n")
@@ -245,14 +300,21 @@ func contextExtensionSearch(c *fiber.Ctx, cfg APIConfig, req CogneeSearchRequest
 
 	recordInteraction(cfg, req.SessionID, "", req.QueryText, answer, "GRAPH_COMPLETION_CONTEXT_EXTENSION")
 
-	return c.JSON(fiber.Map{
-		"answer":       answer,
-		"context_hop1": hop1Context,
-		"context_hop2": hop2Context,
-		"chunks":       vectorChunks,
-		"hops":         2,
-		"search_type":  "GRAPH_COMPLETION_CONTEXT_EXTENSION",
-	})
+	return c.JSON(attachSearchDebugMetadata(c, fiber.Map{
+		"answer":               answer,
+		"context_hop1":         hop1Context,
+		"context_hop2":         hop2Context,
+		"chunks":               vectorChunks,
+		"evidence_ids":         evidenceIDs,
+		"hops":                 2,
+		"search_type":          "GRAPH_COMPLETION_CONTEXT_EXTENSION",
+		"confidence":           confidence,
+		"confidence_breakdown": breakdown,
+		"abstained":            abstained,
+		"abstain_reason":       abstainReason,
+		"threshold":            threshold,
+		"verification":         verification,
+	}))
 }
 
 // graphContextWithTargetsNeo4j returns context strings AND target entity names (for 2nd hop).

--- a/Levara/internal/http/graph_search_test.go
+++ b/Levara/internal/http/graph_search_test.go
@@ -38,6 +38,15 @@ func TestGraphCompletionSearch_EmptyConfig(t *testing.T) {
 	if body["search_type"] != "GRAPH_COMPLETION" {
 		t.Errorf("search_type = %v, want GRAPH_COMPLETION", body["search_type"])
 	}
+	if body["abstained"] != true {
+		t.Errorf("abstained = %v, want true", body["abstained"])
+	}
+	if body["confidence"] != float64(0) {
+		t.Errorf("confidence = %v, want 0", body["confidence"])
+	}
+	if dbg, ok := body["debug"].(map[string]any); !ok || dbg["source"] != "explicit" {
+		t.Errorf("debug = %v, want source=explicit", body["debug"])
+	}
 }
 
 // Vector-only path: no graph data and no LLM env → chunks returned, empty
@@ -133,6 +142,12 @@ func TestGraphCompletionSearch_CallsLLMWithGraphContext(t *testing.T) {
 	if body["answer"] != "Alice knows Bob." {
 		t.Errorf("answer = %v, want scripted LLM reply", body["answer"])
 	}
+	if _, ok := body["confidence_breakdown"].(map[string]any); !ok {
+		t.Fatalf("confidence_breakdown missing or wrong type: %#v", body["confidence_breakdown"])
+	}
+	if ids, ok := body["evidence_ids"].([]any); !ok || len(ids) == 0 {
+		t.Fatalf("evidence_ids missing/empty: %#v", body["evidence_ids"])
+	}
 	prompts := llm.promptsSnapshot()
 	if len(prompts) != 1 {
 		t.Fatalf("captured %d prompts, want 1", len(prompts))
@@ -142,6 +157,44 @@ func TestGraphCompletionSearch_CallsLLMWithGraphContext(t *testing.T) {
 	}
 	if !strings.Contains(prompts[0], "Alice") || !strings.Contains(prompts[0], "Bob") || !strings.Contains(prompts[0], "KNOWS") {
 		t.Errorf("prompt missing graph triple: %q", prompts[0])
+	}
+}
+
+// High abstention threshold with weak retrieval should skip LLM call and return
+// the standard abstain message.
+func TestGraphCompletionSearch_AbstainsAtHighThreshold(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{responses: []string{"should not be used"}}
+	env.cfg.LLMProvider = llm
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused-model")
+	t.Setenv("LEVARA_RAG_ABSTAIN_THRESHOLD", "0.95")
+	t.Setenv("LEVARA_RAG_ABSTAIN_THRESHOLD_GRAPH_COMPLETION", "0.95")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"name": "Alice"})
+	env.insertNode("n1", "Alice", "Person", "")
+	env.insertNode("n2", "Bob", "Person", "")
+	env.insertEdge("rel1", "n1", "n2", "KNOWS")
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "who does alice know",
+		"query_type": "GRAPH_COMPLETION",
+		"collection": "entities",
+	})
+
+	if body["abstained"] != true {
+		t.Fatalf("abstained = %v, want true", body["abstained"])
+	}
+	if body["threshold"] != 0.95 {
+		t.Fatalf("threshold = %v, want 0.95", body["threshold"])
+	}
+	if body["answer"] != defaultAbstainMessage {
+		t.Fatalf("answer = %v, want abstain message", body["answer"])
+	}
+	if got := len(llm.promptsSnapshot()); got != 0 {
+		t.Fatalf("llm prompts = %d, want 0 on abstain", got)
 	}
 }
 
@@ -335,4 +388,3 @@ func TestTripletCompletionSearch_SkipsIncompleteTriplets(t *testing.T) {
 		t.Errorf("prompt contains malformed Bob-> line: %s", prompts[0])
 	}
 }
-

--- a/Levara/internal/http/list_debug_envelope_test.go
+++ b/Levara/internal/http/list_debug_envelope_test.go
@@ -1,0 +1,80 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"testing"
+)
+
+func postSearchAny(t *testing.T, env *searchTestEnv, body map[string]any) (int, any) {
+	t.Helper()
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/search/text", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := env.app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	var out any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal response: %v (raw=%s)", err, string(raw))
+	}
+	return resp.StatusCode, out
+}
+
+func TestChunksSearch_LegacyArrayWhenIncludeDebugFalse(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.start()
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"text": "hello"})
+
+	status, out := postSearchAny(t, env, map[string]any{
+		"query_text": "hello",
+		"query_type": "CHUNKS",
+		"collection": "entities",
+		"top_k":      5,
+	})
+	if status != 200 {
+		t.Fatalf("status=%d, want 200", status)
+	}
+	if _, ok := out.([]any); !ok {
+		t.Fatalf("expected legacy []any response, got %T", out)
+	}
+}
+
+func TestChunksSearch_EnvelopeWhenIncludeDebugTrue(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.start()
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"text": "hello"})
+
+	status, out := postSearchAny(t, env, map[string]any{
+		"query_text":    "hello",
+		"query_type":    "CHUNKS",
+		"collection":    "entities",
+		"top_k":         5,
+		"include_debug": true,
+	})
+	if status != 200 {
+		t.Fatalf("status=%d, want 200", status)
+	}
+	obj, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("expected object envelope, got %T", out)
+	}
+	if obj["search_type"] != "CHUNKS" {
+		t.Fatalf("search_type=%v, want CHUNKS", obj["search_type"])
+	}
+	if _, ok := obj["items"].([]any); !ok {
+		t.Fatalf("items missing or wrong type: %#v", obj["items"])
+	}
+	debug, ok := obj["debug"].(map[string]any)
+	if !ok || debug["source"] != "explicit" {
+		t.Fatalf("debug=%v, want source=explicit", obj["debug"])
+	}
+}
+

--- a/Levara/internal/http/rag_confidence_integration_test.go
+++ b/Levara/internal/http/rag_confidence_integration_test.go
@@ -1,0 +1,298 @@
+package http
+
+import (
+	"testing"
+)
+
+func TestRAGCompletionSearch_ResponseIncludesConfidenceAndDebug(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{responses: []string{"Alice writes code."}}
+	env.cfg.LLMProvider = llm
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused-model")
+	t.Setenv("LEVARA_RAG_ABSTAIN_THRESHOLD", "0")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{
+		"name": "Alice", "text": "Alice writes code in Go",
+	})
+
+	status, body := env.postSearch(map[string]any{
+		"query_text": "who writes code",
+		"query_type": "RAG_COMPLETION",
+		"collection": "entities",
+	})
+	if status != 200 {
+		t.Fatalf("status=%d, want 200", status)
+	}
+	if body["answer"] != "Alice writes code." {
+		t.Fatalf("answer=%v, want scripted response", body["answer"])
+	}
+	if body["abstained"] != false {
+		t.Fatalf("abstained=%v, want false", body["abstained"])
+	}
+	if conf, ok := body["confidence"].(float64); !ok || conf <= 0 {
+		t.Fatalf("confidence=%v, want positive float64", body["confidence"])
+	}
+	if _, ok := body["confidence_breakdown"].(map[string]any); !ok {
+		t.Fatalf("confidence_breakdown missing or wrong type: %#v", body["confidence_breakdown"])
+	}
+	if ids, ok := body["evidence_ids"].([]any); !ok || len(ids) == 0 {
+		t.Fatalf("evidence_ids missing/empty: %#v", body["evidence_ids"])
+	}
+
+	debug, ok := body["debug"].(map[string]any)
+	if !ok {
+		t.Fatalf("debug block missing: %#v", body["debug"])
+	}
+	if debug["source"] != "explicit" {
+		t.Fatalf("debug.source=%v, want explicit", debug["source"])
+	}
+}
+
+func TestRAGCompletionSearch_EmptyConfigIncludesAbstainReasonAndDebug(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.cfg.EmbedEndpoint = ""
+	env.cfg.Collections = nil
+	env.start()
+
+	status, body := env.postSearch(map[string]any{
+		"query_text": "anything",
+		"query_type": "RAG_COMPLETION",
+	})
+	if status != 200 {
+		t.Fatalf("status=%d, want 200", status)
+	}
+	if body["abstained"] != true {
+		t.Fatalf("abstained=%v, want true", body["abstained"])
+	}
+	if body["abstain_reason"] != "embedding backend unavailable" {
+		t.Fatalf("abstain_reason=%v", body["abstain_reason"])
+	}
+	if body["confidence"] != float64(0) {
+		t.Fatalf("confidence=%v, want 0", body["confidence"])
+	}
+	debug, ok := body["debug"].(map[string]any)
+	if !ok || debug["source"] != "explicit" {
+		t.Fatalf("debug=%v, want source=explicit", body["debug"])
+	}
+}
+
+func TestRAGCompletionSearch_AbstainsAtHighThreshold(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{responses: []string{"should not be used"}}
+	env.cfg.LLMProvider = llm
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused-model")
+	t.Setenv("LEVARA_RAG_ABSTAIN_THRESHOLD", "0.95")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{
+		"name": "Alice", "text": "Alice writes code in Go",
+	})
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "who writes code",
+		"query_type": "RAG_COMPLETION",
+		"collection": "entities",
+	})
+	if body["abstained"] != true {
+		t.Fatalf("abstained=%v, want true", body["abstained"])
+	}
+	if body["answer"] != defaultAbstainMessage {
+		t.Fatalf("answer=%v, want abstain message", body["answer"])
+	}
+	if got := len(llm.promptsSnapshot()); got != 0 {
+		t.Fatalf("llm prompts=%d, want 0 when abstained", got)
+	}
+}
+
+func TestRAGCompletionSearch_UsesPerTypeThresholdOverride(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{responses: []string{"should not be used"}}
+	env.cfg.LLMProvider = llm
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused-model")
+	t.Setenv("LEVARA_RAG_ABSTAIN_THRESHOLD", "0.10")
+	t.Setenv("LEVARA_RAG_ABSTAIN_THRESHOLD_RAG_COMPLETION", "0.95")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"text": "Go is a programming language"})
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "what is go language?",
+		"query_type": "RAG_COMPLETION",
+		"collection": "entities",
+	})
+	if body["threshold"] != 0.95 {
+		t.Fatalf("threshold=%v, want 0.95 (per-type override)", body["threshold"])
+	}
+	if body["abstained"] != true {
+		t.Fatalf("abstained=%v, want true", body["abstained"])
+	}
+}
+
+func TestRAGCompletionSearch_StrictGroundedAbstainsWithoutEvidence(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{responses: []string{"should not be used"}}
+	env.cfg.LLMProvider = llm
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused-model")
+	t.Setenv("LEVARA_RAG_ABSTAIN_THRESHOLD", "0")
+	env.start()
+
+	_, body := env.postSearch(map[string]any{
+		"query_text":      "what is go language?",
+		"query_type":      "RAG_COMPLETION",
+		"collection":      "entities",
+		"strict_grounded": true,
+	})
+	if body["abstained"] != true {
+		t.Fatalf("abstained=%v, want true", body["abstained"])
+	}
+	if body["abstain_reason"] != "strict_grounded_no_evidence" {
+		t.Fatalf("abstain_reason=%v, want strict_grounded_no_evidence", body["abstain_reason"])
+	}
+	if got := len(llm.promptsSnapshot()); got != 0 {
+		t.Fatalf("llm prompts=%d, want 0 when strict grounded abstains", got)
+	}
+}
+
+func TestRAGCompletionSearch_VerificationFiltersLowScore(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{responses: []string{"verified answer"}}
+	env.cfg.LLMProvider = llm
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused-model")
+	t.Setenv("LEVARA_RAG_ABSTAIN_THRESHOLD", "0")
+	env.start()
+
+	env.insertVector("entities", "high", []float32{1, 0, 0, 0}, map[string]any{"text": "high relevance"})
+	env.insertVector("entities", "low", []float32{0, 1, 0, 0}, map[string]any{"text": "low relevance"})
+
+	_, body := env.postSearch(map[string]any{
+		"query_text":     "relevance",
+		"query_type":     "RAG_COMPLETION",
+		"collection":     "entities",
+		"top_k":          10,
+		"verify_results": true,
+		"min_score":      0.5,
+	})
+
+	ids, _ := body["evidence_ids"].([]any)
+	if len(ids) != 1 {
+		t.Fatalf("evidence_ids len=%d, want 1 after min_score filter", len(ids))
+	}
+	verif, ok := body["verification"].(map[string]any)
+	if !ok {
+		t.Fatalf("verification missing: %#v", body["verification"])
+	}
+	if verif["dropped_low_score"] == float64(0) {
+		t.Fatalf("verification.dropped_low_score=%v, want >0", verif["dropped_low_score"])
+	}
+}
+
+func TestRAGCompletionSearch_RoutedDebugMetadata(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{responses: []string{"Go is a language."}}
+	env.cfg.LLMProvider = llm
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused-model")
+	t.Setenv("LEVARA_RAG_ABSTAIN_THRESHOLD", "0")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"text": "Go is a programming language"})
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "what is go language?",
+		"query_type": "AUTO",
+		"collection": "entities",
+	})
+	if body["search_type"] != "RAG_COMPLETION" {
+		t.Fatalf("search_type=%v, want RAG_COMPLETION", body["search_type"])
+	}
+	debug, ok := body["debug"].(map[string]any)
+	if !ok {
+		t.Fatalf("debug block missing")
+	}
+	if debug["source"] != "routed" {
+		t.Fatalf("debug.source=%v, want routed", debug["source"])
+	}
+	if debug["strategy"] != "RAG_COMPLETION" {
+		t.Fatalf("debug.strategy=%v, want RAG_COMPLETION", debug["strategy"])
+	}
+	if reason, _ := debug["reason"].(string); reason == "" {
+		t.Fatalf("debug.reason empty, want non-empty")
+	}
+}
+
+func TestGraphCompletionSearch_RoutedDebugMetadata(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{responses: []string{"Alice knows Bob."}}
+	env.cfg.LLMProvider = llm
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused-model")
+	env.start()
+
+	vec := []float32{1, 0, 0, 0}
+	env.insertVector("entities", "e1", vec, map[string]any{"name": "Alice"})
+	env.insertNode("n1", "Alice", "Person", "")
+	env.insertNode("n2", "Bob", "Person", "")
+	env.insertEdge("rel1", "n1", "n2", "KNOWS")
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "what is related to alice",
+		"query_type": "AUTO",
+		"collection": "entities",
+	})
+
+	if body["search_type"] != "GRAPH_COMPLETION" {
+		t.Fatalf("search_type=%v, want GRAPH_COMPLETION", body["search_type"])
+	}
+	debug, ok := body["debug"].(map[string]any)
+	if !ok {
+		t.Fatalf("debug block missing: %#v", body["debug"])
+	}
+	if debug["source"] != "routed" {
+		t.Fatalf("debug.source=%v, want routed", debug["source"])
+	}
+	if debug["strategy"] != "GRAPH_COMPLETION" {
+		t.Fatalf("debug.strategy=%v, want GRAPH_COMPLETION", debug["strategy"])
+	}
+	if _, ok := debug["alternatives"].([]any); !ok {
+		t.Fatalf("debug.alternatives missing or wrong type: %#v", debug["alternatives"])
+	}
+	if reason, _ := debug["reason"].(string); reason == "" {
+		t.Fatalf("debug.reason empty, want non-empty")
+	}
+}
+
+func TestGraphCompletionSearch_StrictGroundedAbstainsWithoutEvidence(t *testing.T) {
+	env := newSearchTestEnv(t)
+	llm := &recordingLLM{responses: []string{"should not be used"}}
+	env.cfg.LLMProvider = llm
+	t.Setenv("LLM_ENDPOINT", "http://unused.test")
+	t.Setenv("LLM_MODEL", "unused-model")
+	t.Setenv("LEVARA_RAG_ABSTAIN_THRESHOLD", "0")
+	env.start()
+
+	_, body := env.postSearch(map[string]any{
+		"query_text":      "what is related to alice",
+		"query_type":      "GRAPH_COMPLETION",
+		"collection":      "entities",
+		"strict_grounded": true,
+	})
+	if body["abstained"] != true {
+		t.Fatalf("abstained=%v, want true", body["abstained"])
+	}
+	if body["abstain_reason"] != "strict_grounded_no_evidence" {
+		t.Fatalf("abstain_reason=%v, want strict_grounded_no_evidence", body["abstain_reason"])
+	}
+	if got := len(llm.promptsSnapshot()); got != 0 {
+		t.Fatalf("llm prompts=%d, want 0 when strict grounded abstains", got)
+	}
+}

--- a/Levara/internal/http/response_meta.go
+++ b/Levara/internal/http/response_meta.go
@@ -1,0 +1,46 @@
+package http
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/stek0v/levara/pkg/router"
+)
+
+// attachSearchDebugMetadata enriches response payload with routing metadata
+// so clients can inspect why a strategy was chosen.
+func attachSearchDebugMetadata(c *fiber.Ctx, payload fiber.Map) fiber.Map {
+	if payload == nil {
+		payload = fiber.Map{}
+	}
+	if c == nil {
+		return payload
+	}
+
+	source, _ := c.Locals("routing_source").(string)
+	if source == "" {
+		source = "explicit"
+	}
+	debug := fiber.Map{
+		"source": source,
+	}
+	if rd, ok := c.Locals("routing_decision").(*router.Decision); ok && rd != nil {
+		debug["strategy"] = rd.SearchType
+		debug["confidence"] = rd.Confidence
+		debug["reason"] = rd.Reason
+		debug["alternatives"] = rd.Alternatives
+	}
+	payload["debug"] = debug
+	return payload
+}
+
+// respondSearchItems keeps backward compatibility for list-style endpoints:
+// - default: returns plain array payload (legacy contract)
+// - include_debug=true: returns envelope with debug metadata
+func respondSearchItems(c *fiber.Ctx, req CogneeSearchRequest, searchType string, items any) error {
+	if !req.IncludeDebug {
+		return c.JSON(items)
+	}
+	return c.JSON(attachSearchDebugMetadata(c, fiber.Map{
+		"items":       items,
+		"search_type": searchType,
+	}))
+}

--- a/Levara/internal/http/response_meta_test.go
+++ b/Levara/internal/http/response_meta_test.go
@@ -1,0 +1,52 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stek0v/levara/pkg/router"
+	"github.com/valyala/fasthttp"
+)
+
+func TestAttachSearchDebugMetadata_Defaults(t *testing.T) {
+	out := attachSearchDebugMetadata(nil, fiber.Map{"ok": true})
+	if _, ok := out["debug"]; ok {
+		t.Fatalf("debug should not be added for nil ctx")
+	}
+
+	app := fiber.New()
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+
+	out = attachSearchDebugMetadata(ctx, fiber.Map{"ok": true})
+	debug, ok := out["debug"].(fiber.Map)
+	if !ok {
+		t.Fatalf("debug block missing")
+	}
+	if debug["source"] != "explicit" {
+		t.Fatalf("expected explicit source, got %v", debug["source"])
+	}
+}
+
+func TestAttachSearchDebugMetadata_WithRoutingDecision(t *testing.T) {
+	app := fiber.New()
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	defer app.ReleaseCtx(ctx)
+
+	ctx.Locals("routing_source", "routed")
+	ctx.Locals("routing_decision", &router.Decision{
+		SearchType: "HYBRID",
+		Reason:     "query looks like keyword",
+		Confidence: 0.8,
+	})
+
+	out := attachSearchDebugMetadata(ctx, fiber.Map{})
+	debug, _ := out["debug"].(fiber.Map)
+	if debug["source"] != "routed" {
+		t.Fatalf("source mismatch: got %v", debug["source"])
+	}
+	if debug["strategy"] != "HYBRID" {
+		t.Fatalf("strategy mismatch: got %v", debug["strategy"])
+	}
+}
+

--- a/Levara/internal/http/verify.go
+++ b/Levara/internal/http/verify.go
@@ -1,0 +1,86 @@
+package http
+
+import (
+	"encoding/json"
+	"math"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+type resultVerification struct {
+	Total             int `json:"total"`
+	Kept              int `json:"kept"`
+	DroppedLowScore   int `json:"dropped_low_score"`
+	DroppedBadMeta    int `json:"dropped_bad_metadata"`
+}
+
+func (r resultVerification) Enabled() bool {
+	return r.Total > 0
+}
+
+func verifyScoredResults(results []fiber.Map, minScore float64, verifyMeta bool) ([]fiber.Map, resultVerification) {
+	v := resultVerification{Total: len(results)}
+	if len(results) == 0 {
+		return results, v
+	}
+	out := make([]fiber.Map, 0, len(results))
+	for _, r := range results {
+		if minScore > 0 {
+			score := extractResultScore(r)
+			if score < minScore {
+				v.DroppedLowScore++
+				continue
+			}
+		}
+		if verifyMeta {
+			if !hasValidMetadata(r) {
+				v.DroppedBadMeta++
+				continue
+			}
+		}
+		out = append(out, r)
+	}
+	v.Kept = len(out)
+	return out, v
+}
+
+func extractResultScore(r fiber.Map) float64 {
+	switch s := r["score"].(type) {
+	case float64:
+		if !math.IsNaN(s) && !math.IsInf(s, 0) {
+			return s
+		}
+	case float32:
+		v := float64(s)
+		if !math.IsNaN(v) && !math.IsInf(v, 0) {
+			return v
+		}
+	}
+	if fs, ok := r["fused_score"].(float64); ok && !math.IsNaN(fs) && !math.IsInf(fs, 0) {
+		return fs
+	}
+	return 0
+}
+
+func hasValidMetadata(r fiber.Map) bool {
+	m, ok := r["metadata"]
+	if !ok {
+		return false
+	}
+	switch v := m.(type) {
+	case json.RawMessage:
+		var tmp map[string]any
+		return json.Unmarshal(v, &tmp) == nil
+	case []byte:
+		var tmp map[string]any
+		return json.Unmarshal(v, &tmp) == nil
+	case string:
+		var tmp map[string]any
+		return json.Unmarshal([]byte(v), &tmp) == nil
+	case map[string]any:
+		return true
+	default:
+		return false
+	}
+}
+

--- a/Levara/internal/http/verify_test.go
+++ b/Levara/internal/http/verify_test.go
@@ -1,0 +1,24 @@
+package http
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func TestVerifyScoredResults_FiltersLowScoreAndBadMetadata(t *testing.T) {
+	results := []fiber.Map{
+		{"id": "ok", "score": 0.9, "metadata": json.RawMessage(`{"text":"ok"}`)},
+		{"id": "low", "score": 0.1, "metadata": json.RawMessage(`{"text":"low"}`)},
+		{"id": "badmeta", "score": 0.9, "metadata": json.RawMessage(`{`)},
+	}
+	got, v := verifyScoredResults(results, 0.5, true)
+	if len(got) != 1 || got[0]["id"] != "ok" {
+		t.Fatalf("got=%v, want only 'ok'", got)
+	}
+	if v.DroppedLowScore != 1 || v.DroppedBadMeta != 1 || v.Kept != 1 {
+		t.Fatalf("verification=%+v, want low=1 bad=1 kept=1", v)
+	}
+}
+

--- a/docs/reviews/2026-04-28-functional-proposals-next.md
+++ b/docs/reviews/2026-04-28-functional-proposals-next.md
@@ -1,0 +1,95 @@
+# Levara — следующие функциональные улучшения (после confidence/debug wave)
+
+Дата: 2026-04-28
+
+## 1) Сделать confidence не только retrieval-based, но и evidence-based
+
+Сейчас confidence строится из эвристики top score / gap / coverage и router confidence.
+Это хороший baseline, но он не учитывает:
+- противоречия между chunk'ами,
+- graph support для финальных утверждений,
+- качество grounding самого ответа.
+
+**Предложение:**
+- добавить post-generation verifier: для каждого ключевого утверждения проверять support в `chunks/context`;
+- включить в confidence признаки `supported_claim_ratio`, `conflict_ratio`, `graph_path_support`;
+- вернуть в API `confidence_breakdown` (по компонентам).
+
+Ожидаемый результат: меньше "уверенных, но неверных" ответов.
+
+## 2) Перевести abstention с глобального env-порога на policy-профили
+
+Сейчас порог управляется одним env `LEVARA_RAG_ABSTAIN_THRESHOLD`.
+Это удобно для старта, но плохо для разных доменов/тенантов/типов поиска.
+
+**Предложение:**
+- ввести policy-конфиг на уровне query_type/domain/tenant:
+  - `rag_completion.threshold`
+  - `graph_completion.threshold`
+  - `context_extension.threshold`
+- дать runtime override через settings/API, а не только через env.
+
+Ожидаемый результат: адекватная чувствительность к риску для разных use-case.
+
+## 3) Унифицировать debug-блок для всех search стратегий
+
+Сейчас debug metadata прикрепляется в RAG/graph ветках, но не во всех векторных search type.
+Для клиентов это делает контракт неоднородным.
+
+**Предложение:**
+- добавить единый post-processor response envelope для всех search strategies;
+- всегда возвращать `debug.source`, а для routed запросов — `debug.strategy/reason/alternatives`;
+- документировать стабильный schema для frontend/SDK.
+
+Ожидаемый результат: проще интеграции и observability на клиенте.
+
+## 4) Добавить explainability артефакты: citations + evidence ids
+
+Сейчас есть `answer` + контекстные массивы, но нет строгой привязки утверждений к источникам.
+
+**Предложение:**
+- возвращать `evidence_ids[]` (ids chunks/edges), использованные в ответе;
+- опционально `claims[]` с привязкой claim→evidence;
+- добавить режим strict-grounded-answer (без evidence — abstain).
+
+Ожидаемый результат: проверяемый GraphRAG, лучше для enterprise.
+
+## 5) Включить feedback loop в confidence/router адаптацию
+
+Сейчас router уже умеет adaptive override, но confidence не калибруется по реальному фидбеку.
+
+**Предложение:**
+- писать implicit/explicit feedback в online calibration dataset;
+- периодически пересчитывать калибровку confidence и веса router-а;
+- ввести safe rollout (shadow -> canary -> full).
+
+Ожидаемый результат: система самоулучшается на реальном продовом трафике.
+
+## 6) Добавить операционные метрики качества ответа (не только latency)
+
+Для production нужна не только скорость, но и контролируемое качество.
+
+**Предложение (минимум):**
+- `abstain_rate` по search_type;
+- `supported_claim_ratio`;
+- `llm_call_skipped_total` (из-за abstain);
+- `confidence_histogram` + `error_by_confidence_bucket`.
+
+Ожидаемый результат: можно управлять quality/SLO как инженерной системой.
+
+---
+
+## Короткий практический roadmap
+
+### Sprint 1
+- Confidence breakdown + единый response envelope.
+- Полное покрытие debug metadata для всех search types.
+
+### Sprint 2
+- Evidence ids + strict grounded mode.
+- Per-query-type abstain policy (конфиг + runtime override).
+
+### Sprint 3
+- Feedback-driven recalibration confidence/router.
+- Dashboard quality metrics + alerts.
+


### PR DESCRIPTION
### Motivation

- Improve safety and explainability of search-driven LLM answers by computing a retrieval+routing confidence and abstaining when confidence or evidence is insufficient.
- Provide per-search-type abstention thresholds and a default abstain message to avoid unsafe LLM calls.
- Make search responses more inspectable for clients by attaching routing/debug metadata and returning an optional envelope for list endpoints while preserving the legacy array contract.
- Add result verification and filtering (min score / metadata JSON validation) to reduce malformed or low-quality hits.

### Description

- Implemented confidence and abstention logic in `internal/http/confidence.go` with functions like `ragAbstainThresholdFor`, `buildConfidenceBreakdown`, and `confidenceFromChunks` and a `defaultAbstainMessage`.
- Added result verification utilities in `internal/http/verify.go` (`verifyScoredResults`, `extractResultScore`, `hasValidMetadata`) and evidence helper `internal/http/evidence.go` (`extractEvidenceChunkIDs`).
- Added response helpers `internal/http/response_meta.go` providing `attachSearchDebugMetadata` and `respondSearchItems` to return either legacy arrays or debug envelopes when `IncludeDebug` is set.
- Integrated the new features across search handlers (`api_search.go`, `graph_search.go`, RAG/temporal/summaries/hybrid/bm25/chunks handlers) to verify/filter results, compute confidence and abstention, include `evidence_ids`, `confidence_breakdown`, `threshold`, `abstained` and `abstain_reason`, and to attach routing debug metadata.
- Added tests covering the new behavior: `confidence_test.go`, `verify_test.go`, `evidence_test.go`, `response_meta_test.go`, plus multiple updated and new integration/unit tests under `internal/http` (e.g. `extended_search_test.go`, `graph_search_test.go`, `rag_confidence_integration_test.go`, `list_debug_envelope_test.go`) exercising per-type thresholds, strict-grounded mode, verification, and the debug envelope.

### Testing

- Ran unit and package tests for the modified HTTP layer with `go test ./internal/http` and the test suite completed successfully.
- New unit tests executed include `TestRAGAbstainThreshold_*`, `TestConfidenceFromChunks`, `TestVerifyScoredResults_*`, `TestExtractEvidenceChunkIDs_*` and `TestAttachSearchDebugMetadata_*` and they passed.
- Integration and handler-level tests (e.g. `rag_confidence_integration_test.go`, `graph_search_test.go`, `extended_search_test.go`, `list_debug_envelope_test.go`) were executed to validate end-to-end behavior and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f064ef72bc832d93bd0c94724fde96)