### PR TITLE
rename(periphery): cognevra → levara across adapter, conftest, Raspberry, benchmarks

### DIFF
--- a/Raspberry/Dockerfile
+++ b/Raspberry/Dockerfile
@@ -5,34 +5,34 @@ ARG TARGETARCH=arm64
 WORKDIR /build
 
 # Cache dependencies
-COPY Levara-legacy/go.mod Levara-legacy/go.sum ./
+COPY Levara/go.mod Levara/go.sum ./
 RUN go mod download
 
 # Copy source
-COPY Levara-legacy/ .
+COPY Levara/ .
 
 # Build static binary
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
-    go build -ldflags="-s -w" -o cognevra ./cmd/server/
+    go build -ldflags="-s -w" -o levara ./cmd/server/
 
 # --- Runtime ---
 FROM alpine:3.19
 
 RUN apk --no-cache add ca-certificates tzdata
 
-COPY --from=builder /build/cognevra /usr/local/bin/cognevra
+COPY --from=builder /build/levara /usr/local/bin/levara
 
 # Create non-root user
-RUN adduser -D -H -s /sbin/nologin cognevra
+RUN adduser -D -H -s /sbin/nologin levara
 
 VOLUME /data
 EXPOSE 8080
 
 ENV DB_PROVIDER=sqlite \
-    DB_PATH=/data/cognevra.db \
+    DB_PATH=/data/levara.db \
     LOG_LEVEL=INFO
 
-USER cognevra
+USER levara
 
-ENTRYPOINT ["cognevra"]
+ENTRYPOINT ["levara"]
 CMD ["-standalone=true", "-dim=768", "-shards=1", "-port=8080", "-grpc-port=0", "-data-dir=/data"]

--- a/Raspberry/README.md
+++ b/Raspberry/README.md
@@ -1,4 +1,34 @@
-# Cognevra на Raspberry Pi — Полное руководство
+# Levara на Raspberry Pi — Полное руководство
+
+> **Миграция с Cognevra (актуально для Pi-устройств, на которые ставили `cognevra` до 2026-05).**
+> Имена файлов и сервиса изменились в рамках ребрендинга:
+>
+> | Было | Стало |
+> |---|---|
+> | `cognevra.service` | `levara.service` |
+> | `cognevra.env` | `levara.env` |
+> | `/etc/cognevra/cognevra.env` | `/etc/levara/levara.env` |
+> | `/var/lib/cognevra/` | `/var/lib/levara/` |
+> | `/usr/local/bin/cognevra` | `/usr/local/bin/levara` |
+> | systemd unit `cognevra` | `levara` |
+> | system user `cognevra` | `levara` |
+>
+> На уже-установленных устройствах:
+>
+> ```bash
+> sudo systemctl stop cognevra
+> sudo systemctl disable cognevra
+> sudo mv /etc/cognevra /etc/levara
+> sudo mv /etc/levara/cognevra.env /etc/levara/levara.env
+> sudo mv /var/lib/cognevra /var/lib/levara
+> # Опционально пересоздать пользователя — или оставить cognevra и поправить .service:
+> sudo cp Raspberry/levara.service /etc/systemd/system/levara.service
+> sudo systemctl daemon-reload
+> sudo systemctl enable --now levara
+> sudo rm -f /etc/systemd/system/cognevra.service
+> ```
+>
+> Кодовая база за бинарём тоже сменилась: Dockerfile теперь собирает из `Levara/` (current code, replaces legacy `Cognevra/` → `Levara-legacy/`). API совместимо, флаги те же.
 
 ## Содержание
 
@@ -29,7 +59,7 @@
 | Компонент | Pi 4GB | Pi 8GB | Описание |
 |-----------|--------|--------|----------|
 | OS + system | 500MB | 500MB | Headless Raspberry Pi OS Lite |
-| Cognevra HNSW | 500MB-1GB | 1-2GB | Зависит от кол-ва vectors |
+| Levara HNSW | 500MB-1GB | 1-2GB | Зависит от кол-ва vectors |
 | Ollama embed | 300MB | 500MB | nomic-embed-text / all-minilm |
 | Ollama LLM | 1-2GB | 3-5GB | Зависит от модели |
 | SQLite cache | 100MB | 200MB | WAL + page cache |
@@ -63,8 +93,8 @@ echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
 
 ```bash
 # 1. Скачать binary
-wget https://github.com/stek0v/cognevra/releases/latest/download/cognevra-arm64
-chmod +x cognevra-arm64
+wget https://github.com/stek0v/levara/releases/latest/download/levara-arm64
+chmod +x levara-arm64
 
 # 2. Установить Ollama
 curl -fsSL https://ollama.ai/install.sh | sh
@@ -74,7 +104,7 @@ ollama pull nomic-embed-text
 DB_PROVIDER=sqlite \
 EMBEDDING_ENDPOINT=http://localhost:11434/v1/embeddings \
 EMBEDDING_MODEL=nomic-embed-text \
-./cognevra-arm64 -standalone=true -dim=768 -shards=1 -port=8080
+./levara-arm64 -standalone=true -dim=768 -shards=1 -port=8080
 
 # 4. Проверить
 curl http://localhost:8080/health
@@ -131,13 +161,13 @@ sudo blkid /dev/sda1
 # UUID=<your-uuid> /mnt/ssd ext4 defaults,noatime 0 2
 
 # Создать директорию данных
-sudo mkdir -p /mnt/ssd/cognevra
-sudo chown $(whoami):$(whoami) /mnt/ssd/cognevra
+sudo mkdir -p /mnt/ssd/levara
+sudo chown $(whoami):$(whoami) /mnt/ssd/levara
 ```
 
 Если SSD используется как data dir, укажите:
 ```bash
-DB_PATH=/mnt/ssd/cognevra/cognevra.db
+DB_PATH=/mnt/ssd/levara/levara.db
 ```
 
 ### 3.3 Установка Ollama
@@ -176,33 +206,33 @@ ollama pull nomic-embed-text
 ollama pull qwen3.5
 ```
 
-### 3.5 Установка Cognevra
+### 3.5 Установка Levara
 
 #### Вариант A: Binary (рекомендуемо)
 
 ```bash
 # Скачать
-wget https://github.com/stek0v/cognevra/releases/latest/download/cognevra-arm64
-sudo mv cognevra-arm64 /usr/local/bin/cognevra
-sudo chmod +x /usr/local/bin/cognevra
+wget https://github.com/stek0v/levara/releases/latest/download/levara-arm64
+sudo mv levara-arm64 /usr/local/bin/levara
+sudo chmod +x /usr/local/bin/levara
 
 # Создать директории
-sudo mkdir -p /var/lib/cognevra/data
-sudo mkdir -p /etc/cognevra
-sudo mkdir -p /var/log/cognevra
+sudo mkdir -p /var/lib/levara/data
+sudo mkdir -p /etc/levara
+sudo mkdir -p /var/log/levara
 
 # Создать пользователя
-sudo useradd -r -s /bin/false cognevra
-sudo chown -R cognevra:cognevra /var/lib/cognevra /var/log/cognevra
+sudo useradd -r -s /bin/false levara
+sudo chown -R levara:levara /var/lib/levara /var/log/levara
 
 # Скопировать env файл
-sudo cp cognevra.env /etc/cognevra/cognevra.env
+sudo cp levara.env /etc/levara/levara.env
 
 # Установить systemd service
-sudo cp cognevra.service /etc/systemd/system/
+sudo cp levara.service /etc/systemd/system/
 sudo systemctl daemon-reload
-sudo systemctl enable cognevra
-sudo systemctl start cognevra
+sudo systemctl enable levara
+sudo systemctl start levara
 ```
 
 #### Вариант B: Docker
@@ -232,7 +262,7 @@ sudo ./setup.sh
 | Переменная | Default | Pi-рекомендация | Описание |
 |------------|---------|-----------------|----------|
 | `DB_PROVIDER` | `sqlite` | `sqlite` | Storage backend (sqlite/postgres) |
-| `DB_PATH` | `./cognevra.db` | `/var/lib/cognevra/cognevra.db` | Путь к SQLite БД |
+| `DB_PATH` | `./levara.db` | `/var/lib/levara/levara.db` | Путь к SQLite БД |
 | `EMBEDDING_ENDPOINT` | — | `http://localhost:11434/v1/embeddings` | URL embed сервера |
 | `EMBEDDING_MODEL` | — | `nomic-embed-text` | Модель для embeddings |
 | `LLM_PROVIDER` | `openai` | `openai` | OpenAI-compatible API |
@@ -253,7 +283,7 @@ sudo ./setup.sh
 | `-shards` | `3` | `1` | `1-2` | Количество HNSW shards |
 | `-port` | `8080` | `8080` | `8080` | HTTP порт |
 | `-grpc-port` | `50051` | `0` | `0` | gRPC порт (0=disabled) |
-| `-data-dir` | `./data` | `/var/lib/cognevra/data` | `/var/lib/cognevra/data` | Директория данных |
+| `-data-dir` | `./data` | `/var/lib/levara/data` | `/var/lib/levara/data` | Директория данных |
 | `-hnsw-m` | `16` | `12` | `16` | HNSW connectivity |
 | `-hnsw-ef-mult` | `8` | `6` | `8` | efConstruction multiplier |
 | `-hnsw-ef-min` | `64` | `32` | `64` | Минимальный efSearch |
@@ -261,9 +291,9 @@ sudo ./setup.sh
 ### 4.3 Пример конфигурации
 
 ```bash
-# /etc/cognevra/cognevra.env
+# /etc/levara/levara.env
 DB_PROVIDER=sqlite
-DB_PATH=/var/lib/cognevra/cognevra.db
+DB_PATH=/var/lib/levara/levara.db
 EMBEDDING_ENDPOINT=http://localhost:11434/v1/embeddings
 EMBEDDING_MODEL=nomic-embed-text
 LLM_PROVIDER=openai
@@ -287,7 +317,7 @@ CACHE_MAX_SIZE=500
 ```json
 {
   "mcpServers": {
-    "cognevra": {
+    "levara": {
       "url": "http://raspberrypi.local:8080/mcp"
     }
   }
@@ -390,13 +420,13 @@ curl -s http://localhost:8080/metrics
 
 | Метрика | Описание |
 |---------|----------|
-| `cognevra_search_duration_seconds` | Латентность поиска |
-| `cognevra_insert_duration_seconds` | Латентность вставки |
-| `cognevra_vectors_total` | Общее кол-во vectors |
-| `cognevra_memory_bytes` | Потребление памяти |
-| `cognevra_wal_size_bytes` | Размер WAL |
-| `cognevra_cache_hits_total` | Cache hits |
-| `cognevra_cache_misses_total` | Cache misses |
+| `levara_search_duration_seconds` | Латентность поиска |
+| `levara_insert_duration_seconds` | Латентность вставки |
+| `levara_vectors_total` | Общее кол-во vectors |
+| `levara_memory_bytes` | Потребление памяти |
+| `levara_wal_size_bytes` | Размер WAL |
+| `levara_cache_hits_total` | Cache hits |
+| `levara_cache_misses_total` | Cache misses |
 
 ### 6.3 Error Tracking
 
@@ -425,31 +455,31 @@ curl -s http://localhost:8080/api/v1/cache/stats | jq
 ### 6.5 systemd watchdog
 
 ```ini
-# /etc/systemd/system/cognevra.service
-# (см. cognevra.service в этой папке)
+# /etc/systemd/system/levara.service
+# (см. levara.service в этой папке)
 ```
 
 Мониторинг через systemd:
 ```bash
 # Статус
-sudo systemctl status cognevra
+sudo systemctl status levara
 
 # Логи
-sudo journalctl -u cognevra -f
+sudo journalctl -u levara -f
 
 # Последние ошибки
-sudo journalctl -u cognevra --priority=err --since="1 hour ago"
+sudo journalctl -u levara --priority=err --since="1 hour ago"
 ```
 
 ### 6.6 Автоматический мониторинг (cron)
 
 ```bash
 # Установить monitor.sh
-sudo cp monitor.sh /usr/local/bin/cognevra-monitor
-sudo chmod +x /usr/local/bin/cognevra-monitor
+sudo cp monitor.sh /usr/local/bin/levara-monitor
+sudo chmod +x /usr/local/bin/levara-monitor
 
 # Добавить в cron (каждые 5 минут)
-echo "*/5 * * * * /usr/local/bin/cognevra-monitor" | sudo crontab -
+echo "*/5 * * * * /usr/local/bin/levara-monitor" | sudo crontab -
 ```
 
 ---
@@ -513,8 +543,8 @@ echo "gpu_mem=16" | sudo tee -a /boot/config.txt
 echo "none" | sudo tee /sys/block/sda/queue/scheduler
 
 # Увеличить лимиты файлов
-echo "cognevra soft nofile 65536" | sudo tee -a /etc/security/limits.conf
-echo "cognevra hard nofile 65536" | sudo tee -a /etc/security/limits.conf
+echo "levara soft nofile 65536" | sudo tee -a /etc/security/limits.conf
+echo "levara hard nofile 65536" | sudo tee -a /etc/security/limits.conf
 ```
 
 ---
@@ -525,45 +555,45 @@ echo "cognevra hard nofile 65536" | sudo tee -a /etc/security/limits.conf
 
 ```bash
 # Использовать backup.sh из этой папки
-sudo cp backup.sh /usr/local/bin/cognevra-backup
-sudo chmod +x /usr/local/bin/cognevra-backup
+sudo cp backup.sh /usr/local/bin/levara-backup
+sudo chmod +x /usr/local/bin/levara-backup
 
 # Ручной запуск
-sudo /usr/local/bin/cognevra-backup
+sudo /usr/local/bin/levara-backup
 
 # Автоматический backup (ежедневно в 3:00)
-echo "0 3 * * * /usr/local/bin/cognevra-backup" | sudo crontab -
+echo "0 3 * * * /usr/local/bin/levara-backup" | sudo crontab -
 ```
 
 #### SQLite backup (онлайн, WAL-safe)
 
 ```bash
-sqlite3 /var/lib/cognevra/cognevra.db ".backup '/backup/cognevra-$(date +%Y%m%d).db'"
+sqlite3 /var/lib/levara/levara.db ".backup '/backup/levara-$(date +%Y%m%d).db'"
 ```
 
 #### Полный backup (данные + WAL)
 
 ```bash
-rsync -a /var/lib/cognevra/data/ /backup/cognevra-data/
+rsync -a /var/lib/levara/data/ /backup/levara-data/
 ```
 
 ### 8.2 Recovery
 
 ```bash
 # Остановить сервис
-sudo systemctl stop cognevra
+sudo systemctl stop levara
 
 # Восстановить SQLite
-sudo cp /backup/cognevra-latest.db /var/lib/cognevra/cognevra.db
+sudo cp /backup/levara-latest.db /var/lib/levara/levara.db
 
 # Восстановить data
-sudo rsync -a /backup/cognevra-data/ /var/lib/cognevra/data/
+sudo rsync -a /backup/levara-data/ /var/lib/levara/data/
 
 # Права
-sudo chown -R cognevra:cognevra /var/lib/cognevra
+sudo chown -R levara:levara /var/lib/levara
 
 # Запустить
-sudo systemctl start cognevra
+sudo systemctl start levara
 
 # Проверить
 curl -s http://localhost:8080/health | jq
@@ -602,22 +632,22 @@ dmesg | grep -i "oom\|killed"
 # 2. Уменьшить HNSW M: -hnsw-m=12
 # 3. Использовать меньшую LLM модель
 # 4. Увеличить swap
-# 5. Установить MemoryMax в systemd (см. cognevra.service)
+# 5. Установить MemoryMax в systemd (см. levara.service)
 ```
 
 ### SQLite locked
 
 ```bash
 # Проверить locks
-fuser /var/lib/cognevra/cognevra.db
+fuser /var/lib/levara/levara.db
 
-# Частая причина: два процесса Cognevra
-ps aux | grep cognevra
+# Частая причина: два процесса Levara
+ps aux | grep levara
 
 # Решение: остановить дубликат
-sudo systemctl stop cognevra
-sudo killall cognevra
-sudo systemctl start cognevra
+sudo systemctl stop levara
+sudo killall levara
+sudo systemctl start levara
 ```
 
 ### Медленный search
@@ -653,7 +683,7 @@ ollama rm gemma3:4b
 ollama pull qwen2:0.5b
 ```
 
-### Cognevra не видит Ollama
+### Levara не видит Ollama
 
 ```bash
 # Проверить что Ollama слушает
@@ -670,8 +700,8 @@ curl -s http://localhost:11434/v1/embeddings \
 ### Перезапуск с нуля
 
 ```bash
-sudo systemctl stop cognevra
-sudo rm -rf /var/lib/cognevra/data/*
-sudo rm -f /var/lib/cognevra/cognevra.db
-sudo systemctl start cognevra
+sudo systemctl stop levara
+sudo rm -rf /var/lib/levara/data/*
+sudo rm -f /var/lib/levara/levara.db
+sudo systemctl start levara
 ```

--- a/Raspberry/TUNING.md
+++ b/Raspberry/TUNING.md
@@ -1,4 +1,4 @@
-# Cognevra Pi — Подробный гайд по тюнингу
+# Levara Pi — Подробный гайд по тюнингу
 
 ## Содержание
 
@@ -79,7 +79,7 @@ Total RAM:              4096 MB
 - OS + system:           500 MB
 - Ollama embed (minilm):  80 MB
 - Ollama LLM (qwen2:0.5b): 800 MB
-- Cognevra overhead:     200 MB
+- Levara overhead:     200 MB
 ---------------------------------
 Available for HNSW:    2516 MB
 - С 1 shard, dim=384:
@@ -96,7 +96,7 @@ Total RAM:              8192 MB
 - OS + system:           500 MB
 - Ollama embed (nomic):  400 MB
 - Ollama LLM (gemma:4b): 3200 MB
-- Cognevra overhead:     300 MB
+- Levara overhead:     300 MB
 ---------------------------------
 Available for HNSW:    3792 MB
 - С 2 shards, dim=768:
@@ -127,7 +127,7 @@ Max_vectors = Available_RAM / RAM_per_vector / num_shards
 | Random write 4K | 0.5 MB/s | 35 MB/s | 70 MB/s |
 | WAL fsync | 10-30ms | 0.5-2ms | 0.2-1ms |
 
-### Влияние на Cognevra
+### Влияние на Levara
 
 | Метрика | microSD | SSD | Разница |
 |---------|---------|-----|---------|
@@ -191,7 +191,7 @@ Max_vectors = Available_RAM / RAM_per_vector / num_shards
 ### Конфигурация
 
 ```bash
-# /etc/cognevra/cognevra.env
+# /etc/levara/levara.env
 LLM_RATE_LIMIT_REQUESTS=10    # макс запросов
 LLM_RATE_LIMIT_INTERVAL=60    # за 60 секунд
 LLM_TIMEOUT=120                # таймаут одного запроса
@@ -291,8 +291,8 @@ echo 'ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="0", ATTR
 ### Kernel parameters
 
 ```bash
-# /etc/sysctl.d/99-cognevra.conf
-sudo tee /etc/sysctl.d/99-cognevra.conf << 'EOF'
+# /etc/sysctl.d/99-levara.conf
+sudo tee /etc/sysctl.d/99-levara.conf << 'EOF'
 # Reduce swappiness (prefer keeping HNSW in RAM)
 vm.swappiness=10
 
@@ -304,7 +304,7 @@ vm.dirty_background_ratio=10
 net.core.somaxconn=256
 net.ipv4.tcp_fastopen=3
 EOF
-sudo sysctl -p /etc/sysctl.d/99-cognevra.conf
+sudo sysctl -p /etc/sysctl.d/99-levara.conf
 ```
 
 ### Overclock (Pi 5, опционально)

--- a/Raspberry/backup.sh
+++ b/Raspberry/backup.sh
@@ -2,14 +2,14 @@
 set -euo pipefail
 
 # ============================================================
-# Cognevra Backup Script
+# Levara Backup Script
 # Usage: sudo ./backup.sh [backup_dir]
 # ============================================================
 
-BACKUP_BASE="${1:-/var/backups/cognevra}"
-COGNEVRA_DIR="/var/lib/cognevra"
-DB_PATH="$COGNEVRA_DIR/cognevra.db"
-DATA_DIR="$COGNEVRA_DIR/data"
+BACKUP_BASE="${1:-/var/backups/levara}"
+LEVARA_DIR="/var/lib/levara"
+DB_PATH="$LEVARA_DIR/levara.db"
+DATA_DIR="$LEVARA_DIR/data"
 
 DATE=$(date +%Y%m%d_%H%M%S)
 BACKUP_DIR="$BACKUP_BASE/$DATE"
@@ -40,9 +40,9 @@ log "Backup directory: $BACKUP_DIR"
 
 # --- 1. SQLite backup (online, WAL-safe) ---
 log "Backing up SQLite database..."
-sqlite3 "$DB_PATH" ".backup '$BACKUP_DIR/cognevra.db'"
+sqlite3 "$DB_PATH" ".backup '$BACKUP_DIR/levara.db'"
 if [ $? -eq 0 ]; then
-    log "SQLite backup OK ($(du -h "$BACKUP_DIR/cognevra.db" | cut -f1))"
+    log "SQLite backup OK ($(du -h "$BACKUP_DIR/levara.db" | cut -f1))"
 else
     err "SQLite backup failed!"
 fi
@@ -57,9 +57,9 @@ else
 fi
 
 # --- 3. Config backup ---
-if [ -f /etc/cognevra/cognevra.env ]; then
+if [ -f /etc/levara/levara.env ]; then
     log "Backing up config..."
-    cp /etc/cognevra/cognevra.env "$BACKUP_DIR/cognevra.env"
+    cp /etc/levara/levara.env "$BACKUP_DIR/levara.env"
 fi
 
 # --- 4. Create symlink to latest ---

--- a/Raspberry/build.sh
+++ b/Raspberry/build.sh
@@ -2,39 +2,39 @@
 set -euo pipefail
 
 # ============================================================
-# Cognevra Cross-Compile for Raspberry Pi (arm64)
+# Levara Cross-Compile for Raspberry Pi (arm64)
 # Run from Raspberry/ directory on your dev machine
 # ============================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SOURCE_DIR="$SCRIPT_DIR/../Cognevra"
+SOURCE_DIR="$SCRIPT_DIR/../Levara"
 OUTPUT_DIR="$SCRIPT_DIR"
 
 if [ ! -d "$SOURCE_DIR" ]; then
-    echo "Error: Cognevra source not found at $SOURCE_DIR"
+    echo "Error: Levara source not found at $SOURCE_DIR"
     exit 1
 fi
 
-echo "=== Cross-compiling Cognevra for arm64 ==="
+echo "=== Cross-compiling Levara for arm64 ==="
 
 # Server binary
-echo "Building cognevra-arm64 (server)..."
+echo "Building levara-arm64 (server)..."
 cd "$SOURCE_DIR"
 GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
-    go build -ldflags="-s -w" -o "$OUTPUT_DIR/cognevra-arm64" ./cmd/server/
+    go build -ldflags="-s -w" -o "$OUTPUT_DIR/levara-arm64" ./cmd/server/
 
 # CLI binary
 if [ -d "$SOURCE_DIR/cmd/cli" ]; then
-    echo "Building cognevra-cli-arm64 (CLI)..."
+    echo "Building levara-cli-arm64 (CLI)..."
     GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
-        go build -ldflags="-s -w" -o "$OUTPUT_DIR/cognevra-cli-arm64" ./cmd/cli/
+        go build -ldflags="-s -w" -o "$OUTPUT_DIR/levara-cli-arm64" ./cmd/cli/
 else
     echo "Skipping CLI (cmd/cli/ not found)"
 fi
 
 echo ""
 echo "=== Build complete ==="
-ls -lh "$OUTPUT_DIR"/cognevra-*arm64 2>/dev/null || echo "No binaries found!"
+ls -lh "$OUTPUT_DIR"/levara-*arm64 2>/dev/null || echo "No binaries found!"
 echo ""
 echo "Deploy to Pi:"
-echo "  scp $OUTPUT_DIR/cognevra-arm64 pi@raspberrypi.local:/usr/local/bin/cognevra"
+echo "  scp $OUTPUT_DIR/levara-arm64 pi@raspberrypi.local:/usr/local/bin/levara"

--- a/Raspberry/docker-compose.yml
+++ b/Raspberry/docker-compose.yml
@@ -1,18 +1,18 @@
 version: "3.8"
 
 services:
-  cognevra:
+  levara:
     build:
       context: ..
       dockerfile: Raspberry/Dockerfile
-    container_name: cognevra-pi
+    container_name: levara-pi
     restart: unless-stopped
     ports:
       - "8080:8080"
     volumes:
-      - cognevra-data:/data
+      - levara-data:/data
     env_file:
-      - cognevra.env
+      - levara.env
     environment:
       - EMBEDDING_ENDPOINT=http://host.docker.internal:11434/v1/embeddings
       - LLM_ENDPOINT=http://host.docker.internal:11434/v1
@@ -36,5 +36,5 @@ services:
         max-file: "3"
 
 volumes:
-  cognevra-data:
+  levara-data:
     driver: local

--- a/Raspberry/levara.env
+++ b/Raspberry/levara.env
@@ -1,9 +1,9 @@
-# Cognevra Environment Configuration for Raspberry Pi
-# Copy to /etc/cognevra/cognevra.env
+# Levara Environment Configuration for Raspberry Pi
+# Copy to /etc/levara/levara.env
 
 # --- Storage ---
 DB_PROVIDER=sqlite
-DB_PATH=/var/lib/cognevra/cognevra.db
+DB_PATH=/var/lib/levara/levara.db
 
 # --- Embedding ---
 EMBEDDING_ENDPOINT=http://localhost:11434/v1/embeddings

--- a/Raspberry/levara.service
+++ b/Raspberry/levara.service
@@ -1,24 +1,24 @@
 [Unit]
-Description=Cognevra Memory Server
-Documentation=https://github.com/stek0v/cognevra
+Description=Levara Memory Server
+Documentation=https://github.com/stek0v/levara
 After=network-online.target ollama.service
 Wants=network-online.target
 Requires=ollama.service
 
 [Service]
 Type=simple
-User=cognevra
-Group=cognevra
+User=levara
+Group=levara
 
-EnvironmentFile=/etc/cognevra/cognevra.env
+EnvironmentFile=/etc/levara/levara.env
 
-ExecStart=/usr/local/bin/cognevra \
+ExecStart=/usr/local/bin/levara \
     -standalone=true \
     -dim=768 \
     -shards=1 \
     -port=8080 \
     -grpc-port=0 \
-    -data-dir=/var/lib/cognevra/data
+    -data-dir=/var/lib/levara/data
 
 ExecStartPost=/bin/sh -c 'sleep 3 && curl -sf http://localhost:8080/health > /dev/null || exit 1'
 
@@ -37,8 +37,8 @@ CPUQuota=300%
 LimitNOFILE=65536
 
 # Security hardening
-WorkingDirectory=/var/lib/cognevra
-ReadWritePaths=/var/lib/cognevra /var/log/cognevra
+WorkingDirectory=/var/lib/levara
+ReadWritePaths=/var/lib/levara /var/log/levara
 ProtectSystem=strict
 ProtectHome=true
 PrivateTmp=true
@@ -47,7 +47,7 @@ NoNewPrivileges=true
 # Logging
 StandardOutput=journal
 StandardError=journal
-SyslogIdentifier=cognevra
+SyslogIdentifier=levara
 
 [Install]
 WantedBy=multi-user.target

--- a/Raspberry/monitor.sh
+++ b/Raspberry/monitor.sh
@@ -2,13 +2,13 @@
 set -euo pipefail
 
 # ============================================================
-# Cognevra Monitoring Script (cron-friendly)
+# Levara Monitoring Script (cron-friendly)
 # Usage: ./monitor.sh
-# Cron:  */5 * * * * /usr/local/bin/cognevra-monitor
+# Cron:  */5 * * * * /usr/local/bin/levara-monitor
 # ============================================================
 
-LOG_FILE="/var/log/cognevra-monitor.log"
-ALERT_FILE="/var/log/cognevra-alerts.log"
+LOG_FILE="/var/log/levara-monitor.log"
+ALERT_FILE="/var/log/levara-alerts.log"
 HEALTH_URL="http://localhost:8080/health"
 CACHE_URL="http://localhost:8080/api/v1/cache/stats"
 ERRORS_URL="http://localhost:8080/api/v1/errors"
@@ -37,7 +37,7 @@ if [ -n "$HEALTH_RESPONSE" ]; then
         alert "health=DEGRADED response=$HEALTH_RESPONSE"
     fi
 else
-    alert "health=UNREACHABLE — Cognevra not responding on $HEALTH_URL"
+    alert "health=UNREACHABLE — Levara not responding on $HEALTH_URL"
 fi
 
 # --- 2. Memory Usage ---
@@ -54,16 +54,16 @@ if [ "$MEM_PERCENT" -ge "$MEM_WARN_PERCENT" ]; then
 fi
 
 # --- 3. Disk Usage ---
-COGNEVRA_DISK=$(df /var/lib/cognevra 2>/dev/null | tail -1 | awk '{print $5}' | tr -d '%')
-if [ -n "$COGNEVRA_DISK" ]; then
-    log "disk=/var/lib/cognevra=${COGNEVRA_DISK}%"
-    if [ "$COGNEVRA_DISK" -ge "$DISK_WARN_PERCENT" ]; then
-        alert "HIGH DISK: /var/lib/cognevra at ${COGNEVRA_DISK}%"
+LEVARA_DISK=$(df /var/lib/levara 2>/dev/null | tail -1 | awk '{print $5}' | tr -d '%')
+if [ -n "$LEVARA_DISK" ]; then
+    log "disk=/var/lib/levara=${LEVARA_DISK}%"
+    if [ "$LEVARA_DISK" -ge "$DISK_WARN_PERCENT" ]; then
+        alert "HIGH DISK: /var/lib/levara at ${LEVARA_DISK}%"
     fi
 fi
 
 # --- 4. SQLite DB size ---
-DB_PATH="/var/lib/cognevra/cognevra.db"
+DB_PATH="/var/lib/levara/levara.db"
 if [ -f "$DB_PATH" ]; then
     DB_SIZE=$(du -h "$DB_PATH" | cut -f1)
     log "sqlite_size=$DB_SIZE"
@@ -91,17 +91,17 @@ if [ "$HEALTH_STATUS" != "FAIL" ]; then
     fi
 fi
 
-# --- 7. Cognevra process ---
-COGNEVRA_PID=$(pgrep -f "/usr/local/bin/cognevra" 2>/dev/null || echo "")
-if [ -n "$COGNEVRA_PID" ]; then
-    COGNEVRA_RSS=$(ps -o rss= -p "$COGNEVRA_PID" 2>/dev/null | tr -d ' ')
-    if [ -n "$COGNEVRA_RSS" ]; then
-        COGNEVRA_MB=$((COGNEVRA_RSS / 1024))
-        log "cognevra_pid=$COGNEVRA_PID rss=${COGNEVRA_MB}MB"
+# --- 7. Levara process ---
+LEVARA_PID=$(pgrep -f "/usr/local/bin/levara" 2>/dev/null || echo "")
+if [ -n "$LEVARA_PID" ]; then
+    LEVARA_RSS=$(ps -o rss= -p "$LEVARA_PID" 2>/dev/null | tr -d ' ')
+    if [ -n "$LEVARA_RSS" ]; then
+        LEVARA_MB=$((LEVARA_RSS / 1024))
+        log "levara_pid=$LEVARA_PID rss=${LEVARA_MB}MB"
     fi
 else
     if [ "$HEALTH_STATUS" = "FAIL" ]; then
-        alert "Cognevra process NOT FOUND"
+        alert "Levara process NOT FOUND"
     fi
 fi
 

--- a/Raspberry/setup.sh
+++ b/Raspberry/setup.sh
@@ -2,15 +2,15 @@
 set -euo pipefail
 
 # ============================================================
-# Cognevra Pi Setup — One-click installer
+# Levara Pi Setup — One-click installer
 # Run as root: sudo ./setup.sh
 # ============================================================
 
-COGNEVRA_USER="cognevra"
-COGNEVRA_DIR="/var/lib/cognevra"
-COGNEVRA_CONF="/etc/cognevra"
-COGNEVRA_LOG="/var/log/cognevra"
-COGNEVRA_BIN="/usr/local/bin/cognevra"
+LEVARA_USER="levara"
+LEVARA_DIR="/var/lib/levara"
+LEVARA_CONF="/etc/levara"
+LEVARA_LOG="/var/log/levara"
+LEVARA_BIN="/usr/local/bin/levara"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Colors
@@ -34,23 +34,23 @@ if [ "$ARCH" != "aarch64" ] && [ "$ARCH" != "arm64" ]; then
 fi
 
 echo "============================================"
-echo "  Cognevra Pi Setup"
+echo "  Levara Pi Setup"
 echo "============================================"
 echo ""
 
 # --- 1. System user & directories ---
 log "Creating user and directories..."
-if ! id "$COGNEVRA_USER" &>/dev/null; then
-    useradd -r -s /bin/false "$COGNEVRA_USER"
-    log "Created user: $COGNEVRA_USER"
+if ! id "$LEVARA_USER" &>/dev/null; then
+    useradd -r -s /bin/false "$LEVARA_USER"
+    log "Created user: $LEVARA_USER"
 else
-    log "User $COGNEVRA_USER already exists"
+    log "User $LEVARA_USER already exists"
 fi
 
-mkdir -p "$COGNEVRA_DIR/data"
-mkdir -p "$COGNEVRA_CONF"
-mkdir -p "$COGNEVRA_LOG"
-chown -R "$COGNEVRA_USER:$COGNEVRA_USER" "$COGNEVRA_DIR" "$COGNEVRA_LOG"
+mkdir -p "$LEVARA_DIR/data"
+mkdir -p "$LEVARA_CONF"
+mkdir -p "$LEVARA_LOG"
+chown -R "$LEVARA_USER:$LEVARA_USER" "$LEVARA_DIR" "$LEVARA_LOG"
 
 # --- 2. Install dependencies ---
 log "Installing dependencies..."
@@ -137,22 +137,22 @@ EOF
 systemctl daemon-reload
 systemctl restart ollama
 
-# --- 7. Install Cognevra binary ---
-if [ -f "$SCRIPT_DIR/cognevra-arm64" ]; then
-    log "Installing Cognevra from local binary..."
-    cp "$SCRIPT_DIR/cognevra-arm64" "$COGNEVRA_BIN"
+# --- 7. Install Levara binary ---
+if [ -f "$SCRIPT_DIR/levara-arm64" ]; then
+    log "Installing Levara from local binary..."
+    cp "$SCRIPT_DIR/levara-arm64" "$LEVARA_BIN"
 else
-    log "Downloading Cognevra binary..."
-    wget -q https://github.com/stek0v/cognevra/releases/latest/download/cognevra-arm64 -O "$COGNEVRA_BIN" || \
-        err "Failed to download Cognevra binary. Place cognevra-arm64 in this directory and retry."
+    log "Downloading Levara binary..."
+    wget -q https://github.com/stek0v/levara/releases/latest/download/levara-arm64 -O "$LEVARA_BIN" || \
+        err "Failed to download Levara binary. Place levara-arm64 in this directory and retry."
 fi
-chmod +x "$COGNEVRA_BIN"
+chmod +x "$LEVARA_BIN"
 
 # --- 8. Install config ---
 log "Installing configuration..."
-cat > "$COGNEVRA_CONF/cognevra.env" << ENVEOF
+cat > "$LEVARA_CONF/levara.env" << ENVEOF
 DB_PROVIDER=sqlite
-DB_PATH=$COGNEVRA_DIR/cognevra.db
+DB_PATH=$LEVARA_DIR/levara.db
 EMBEDDING_ENDPOINT=http://localhost:11434/v1/embeddings
 EMBEDDING_MODEL=$EMBED_MODEL
 LLM_PROVIDER=openai
@@ -173,19 +173,19 @@ if [ "$TOTAL_MEM" -ge 6000 ]; then
     SHARDS=2
 fi
 
-cat > /etc/systemd/system/cognevra.service << SVCEOF
+cat > /etc/systemd/system/levara.service << SVCEOF
 [Unit]
-Description=Cognevra Memory Server
+Description=Levara Memory Server
 After=network-online.target ollama.service
 Wants=network-online.target
 Requires=ollama.service
 
 [Service]
 Type=simple
-User=$COGNEVRA_USER
-Group=$COGNEVRA_USER
-EnvironmentFile=$COGNEVRA_CONF/cognevra.env
-ExecStart=$COGNEVRA_BIN -standalone=true -dim=$DIM -shards=$SHARDS -port=8080 -grpc-port=0 -data-dir=$COGNEVRA_DIR/data
+User=$LEVARA_USER
+Group=$LEVARA_USER
+EnvironmentFile=$LEVARA_CONF/levara.env
+ExecStart=$LEVARA_BIN -standalone=true -dim=$DIM -shards=$SHARDS -port=8080 -grpc-port=0 -data-dir=$LEVARA_DIR/data
 Restart=always
 RestartSec=5
 WatchdogSec=30
@@ -193,28 +193,28 @@ MemoryMax=2G
 MemoryHigh=1536M
 CPUQuota=300%
 LimitNOFILE=65536
-WorkingDirectory=$COGNEVRA_DIR
+WorkingDirectory=$LEVARA_DIR
 ProtectSystem=strict
-ReadWritePaths=$COGNEVRA_DIR $COGNEVRA_LOG
+ReadWritePaths=$LEVARA_DIR $LEVARA_LOG
 ProtectHome=true
 PrivateTmp=true
 NoNewPrivileges=true
 StandardOutput=journal
 StandardError=journal
-SyslogIdentifier=cognevra
+SyslogIdentifier=levara
 
 [Install]
 WantedBy=multi-user.target
 SVCEOF
 
 # --- 10. Enable & start ---
-log "Enabling and starting Cognevra..."
+log "Enabling and starting Levara..."
 systemctl daemon-reload
-systemctl enable cognevra
-systemctl start cognevra
+systemctl enable levara
+systemctl start levara
 
 # --- 11. Health check ---
-log "Waiting for Cognevra to start..."
+log "Waiting for Levara to start..."
 sleep 5
 
 HEALTH_OK=false
@@ -229,12 +229,12 @@ done
 echo ""
 echo "============================================"
 if [ "$HEALTH_OK" = true ]; then
-    log "Cognevra is running!"
+    log "Levara is running!"
     echo ""
     echo "  Health:     curl http://localhost:8080/health"
-    echo "  Logs:       journalctl -u cognevra -f"
-    echo "  Config:     $COGNEVRA_CONF/cognevra.env"
-    echo "  Data:       $COGNEVRA_DIR"
+    echo "  Logs:       journalctl -u levara -f"
+    echo "  Config:     $LEVARA_CONF/levara.env"
+    echo "  Data:       $LEVARA_DIR"
     echo ""
     echo "  MCP URL:    http://$(hostname).local:8080/mcp"
     echo ""
@@ -242,7 +242,7 @@ if [ "$HEALTH_OK" = true ]; then
     echo "  Dimension:  $DIM"
     echo "  Shards:     $SHARDS"
 else
-    warn "Cognevra may not have started correctly."
-    echo "  Check logs: journalctl -u cognevra --no-pager -n 50"
+    warn "Levara may not have started correctly."
+    echo "  Check logs: journalctl -u levara --no-pager -n 50"
 fi
 echo "============================================"

--- a/benchmarks/levara_vs_lancedb.py
+++ b/benchmarks/levara_vs_lancedb.py
@@ -1,23 +1,23 @@
 """
-Benchmark: Cognee+LanceDB vs Cognee+Cognevra
+Benchmark: Cognee+LanceDB vs Cognee+Levara
 
 Metrics: insert latency (p50/p95/p99), search latency, throughput (ops/sec), recall@10.
 
 Usage:
     # Against LanceDB (default Cognee)
-    python benchmarks/cognevra_vs_lancedb.py --provider=lancedb
+    python benchmarks/levara_vs_lancedb.py --provider=lancedb
 
-    # Against Cognevra (start server first: cd Cognevra && make run)
-    python benchmarks/cognevra_vs_lancedb.py --provider=cognevra --cognevra-url=http://localhost:8080
+    # Against Levara (start server first: cd Levara && make run)
+    python benchmarks/levara_vs_lancedb.py --provider=levara --levara-url=http://localhost:8080
 
     # Both in sequence and compare
-    python benchmarks/cognevra_vs_lancedb.py --provider=both
+    python benchmarks/levara_vs_lancedb.py --provider=both
 
 Prerequisites:
     pip install cognee numpy tqdm
 
-For Cognevra, start the server with matching vector dimension:
-    cd Cognevra && ./cognevra -bootstrap=true -dim=384
+For Levara, start the server with matching vector dimension:
+    cd Levara && ./levara -bootstrap=true -dim=384
 """
 
 import argparse
@@ -124,7 +124,7 @@ async def run_benchmark(
     n_docs: int,
     n_queries: int,
     dim: int,
-    cognevra_url: str,
+    levara_url: str,
     output_dir: Path,
 ) -> dict:
     print(f"\n{'='*60}")
@@ -147,11 +147,11 @@ async def run_benchmark(
             api_key=None,
             embedding_engine=embedding_engine,
         )
-    elif provider == "cognevra":
-        from cognee.infrastructure.databases.vector.cognevra.CognevraAdapter import CognevraAdapter
+    elif provider == "levara":
+        from cognee.infrastructure.databases.vector.levara.LevaraAdapter import LevaraAdapter
 
-        adapter = CognevraAdapter(
-            url=cognevra_url,
+        adapter = LevaraAdapter(
+            url=levara_url,
             api_key=None,
             embedding_engine=embedding_engine,
         )
@@ -282,19 +282,19 @@ def print_comparison(results: List[dict]):
 
 
 async def main():
-    parser = argparse.ArgumentParser(description="Cognevra vs LanceDB benchmark")
-    parser.add_argument("--provider", choices=["lancedb", "cognevra", "both"], default="both")
+    parser = argparse.ArgumentParser(description="Levara vs LanceDB benchmark")
+    parser.add_argument("--provider", choices=["lancedb", "levara", "both"], default="both")
     parser.add_argument("--n-docs", type=int, default=10_000)
     parser.add_argument("--n-queries", type=int, default=1_000)
     parser.add_argument("--dim", type=int, default=384, help="Vector dimension (match embedding model)")
-    parser.add_argument("--cognevra-url", default="http://localhost:8080")
+    parser.add_argument("--levara-url", default="http://localhost:8080")
     parser.add_argument("--output-dir", default="benchmarks/results")
     args = parser.parse_args()
 
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    providers = ["lancedb", "cognevra"] if args.provider == "both" else [args.provider]
+    providers = ["lancedb", "levara"] if args.provider == "both" else [args.provider]
     results = []
     for provider in providers:
         result = await run_benchmark(
@@ -302,7 +302,7 @@ async def main():
             n_docs=args.n_docs,
             n_queries=args.n_queries,
             dim=args.dim,
-            cognevra_url=args.cognevra_url,
+            levara_url=args.levara_url,
             output_dir=output_dir,
         )
         results.append(result)

--- a/cognee-plugin/README.md
+++ b/cognee-plugin/README.md
@@ -1,6 +1,6 @@
-# cognee-cognevra
+# cognee-levara
 
-gRPC adapter connecting Cognee's VectorDBInterface to Cognevra.
+gRPC adapter connecting Cognee's VectorDBInterface to Levara.
 
 ## Installation
 
@@ -11,7 +11,7 @@ make proto  # generate gRPC stubs
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| VECTOR_DB_PROVIDER | cognevra | Select Cognevra backend |
+| VECTOR_DB_PROVIDER | levara | Select Levara backend |
 | VECTOR_DB_URL | localhost:50051 | gRPC server address |
 
 ## VectorDBInterface Methods

--- a/cognee-plugin/cognevra_adapter/__init__.py
+++ b/cognee-plugin/cognevra_adapter/__init__.py
@@ -1,3 +1,0 @@
-from .CognevraAdapter import CognevraAdapter
-
-__all__ = ["CognevraAdapter"]

--- a/cognee-plugin/cognevra_adapter/generated/.gitignore
+++ b/cognee-plugin/cognevra_adapter/generated/.gitignore
@@ -1,2 +1,0 @@
-cognevra_pb2.py
-cognevra_pb2_grpc.py

--- a/cognee-plugin/levara_adapter/LevaraAdapter.py
+++ b/cognee-plugin/levara_adapter/LevaraAdapter.py
@@ -1,7 +1,7 @@
 """
-Cognevra adapter for Cognee's VectorDBInterface.
+Levara adapter for Cognee's VectorDBInterface.
 
-Uses gRPC transport to communicate with Cognevra Go server (port 50051).
+Uses gRPC transport to communicate with Levara Go server (port 50051).
 Native collections, real delete (HNSW tombstone + WAL), binary protobuf encoding.
 """
 
@@ -23,8 +23,8 @@ from ..embeddings.EmbeddingEngine import EmbeddingEngine
 from ..models.ScoredResult import ScoredResult
 from ..vector_db_interface import VectorDBInterface
 
-from .generated import cognevra_pb2 as pb
-from .generated import cognevra_pb2_grpc as pb_grpc
+from .generated import levara_pb2 as pb
+from .generated import levara_pb2_grpc as pb_grpc
 
 logger = logging.getLogger(__name__)
 
@@ -55,16 +55,16 @@ class _IndexPoint(DataPoint):
     belongs_to_set: List[str] = []
 
 
-class CognevraAdapter(VectorDBInterface):
+class LevaraAdapter(VectorDBInterface):
     """
-    Cognee VectorDBInterface adapter for Cognevra (gRPC, Go backend).
+    Cognee VectorDBInterface adapter for Levara (gRPC, Go backend).
 
     Configuration:
-        VECTOR_DB_PROVIDER=cognevra
+        VECTOR_DB_PROVIDER=levara
         VECTOR_DB_URL=localhost:50051   (gRPC address, no http://)
     """
 
-    name = "Cognevra"
+    name = "Levara"
 
     def __init__(
         self,
@@ -77,7 +77,7 @@ class CognevraAdapter(VectorDBInterface):
         self.url = raw_url.replace("http://", "").replace("https://", "")
         self.embedding_engine = embedding_engine
         self._channel = grpc.aio.insecure_channel(self.url)
-        self._stub = pb_grpc.CognevraServiceStub(self._channel)
+        self._stub = pb_grpc.LevaraServiceStub(self._channel)
         self._embedding_cache: Dict[str, List[float]] = {}
         self._embedding_cache_maxsize = 4096
 
@@ -90,10 +90,10 @@ class CognevraAdapter(VectorDBInterface):
         except grpc.aio.AioRpcError as e:
             if e.code() in (grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.DEADLINE_EXCEEDED):
                 raise ConnectionError(
-                    f"Cognevra unavailable at {self.url}: {e.details()}"
+                    f"Levara unavailable at {self.url}: {e.details()}"
                 ) from e
             raise RuntimeError(
-                f"Cognevra gRPC error ({e.code().name}): {e.details()}"
+                f"Levara gRPC error ({e.code().name}): {e.details()}"
             ) from e
 
     async def close(self) -> None:
@@ -134,7 +134,7 @@ class CognevraAdapter(VectorDBInterface):
             self._stub.CreateCollection(pb.CreateCollectionReq(name=collection_name))
         )
         if not resp.ok:
-            raise RuntimeError(f"Cognevra CreateCollection failed: {resp.error}")
+            raise RuntimeError(f"Levara CreateCollection failed: {resp.error}")
 
     # ------------------------------------------------------------------ data points
 
@@ -161,7 +161,7 @@ class CognevraAdapter(VectorDBInterface):
         )
         if resp.failed:
             raise RuntimeError(
-                f"Cognevra batch insert partial failure: "
+                f"Levara batch insert partial failure: "
                 f"{resp.failed} records failed. Errors: {list(resp.errors)}"
             )
 

--- a/cognee-plugin/levara_adapter/__init__.py
+++ b/cognee-plugin/levara_adapter/__init__.py
@@ -1,0 +1,11 @@
+from .LevaraAdapter import LevaraAdapter
+
+# Backwards-compatibility alias for code that still imports the
+# pre-rebrand `CognevraAdapter` name. Marked deprecated; remove after
+# all consumers migrate to `LevaraAdapter`.
+#
+# Class-shaped alias (same class object) so isinstance() and subclass
+# checks against the legacy name continue to work transparently.
+CognevraAdapter = LevaraAdapter
+
+__all__ = ["LevaraAdapter", "CognevraAdapter"]

--- a/cognee-plugin/levara_adapter/generated/.gitignore
+++ b/cognee-plugin/levara_adapter/generated/.gitignore
@@ -1,0 +1,2 @@
+levara_pb2.py
+levara_pb2_grpc.py

--- a/cognee-plugin/pyproject.toml
+++ b/cognee-plugin/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "cognee-cognevra"
+name = "cognee-levara"
 version = "0.2.0"
-description = "Cognevra adapter plugin for Cognee — high-performance vector search via gRPC"
+description = "Levara adapter plugin for Cognee — high-performance vector search via gRPC"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
@@ -22,4 +22,4 @@ dev = [
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["cognevra_adapter"]
+packages = ["levara_adapter"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 """
-Conftest for Cognevra adapter unit tests.
+Conftest for Levara adapter unit tests.
 
 Sets up lightweight stubs in sys.modules for heavy cognee dependencies
-BEFORE any test file is collected, then loads CognevraAdapter via importlib
-so that subsequent `from cognee... import CognevraAdapter` works.
+BEFORE any test file is collected, then loads LevaraAdapter via importlib
+so that subsequent `from cognee... import LevaraAdapter` works.
 """
 
 import importlib.util
@@ -262,64 +262,64 @@ if _lance_adapter_path.exists():
         import warnings
         warnings.warn(f"Could not load LanceDBAdapter: {_e}")
 
-# ── Load CognevraAdapter via importlib ────────────────────────────────────────
-_cognevra_pkg = _stub("cognee.infrastructure.databases.vector.cognevra")
+# ── Load LevaraAdapter via importlib ────────────────────────────────────────
+_levara_pkg = _stub("cognee.infrastructure.databases.vector.levara")
 
 # Register the generated protobuf modules BEFORE loading the adapter,
-# so that `from .generated import cognevra_pb2` resolves correctly.
+# so that `from .generated import levara_pb2` resolves correctly.
 _generated_dir = (
     _REPO_ROOT / "cognee" / "infrastructure" / "databases" / "vector"
-    / "cognevra" / "generated"
+    / "levara" / "generated"
 )
-_generated_pkg_name = "cognee.infrastructure.databases.vector.cognevra.generated"
+_generated_pkg_name = "cognee.infrastructure.databases.vector.levara.generated"
 
 # Register the generated package
 _generated_pkg = _stub(_generated_pkg_name)
 
-# Load cognevra_pb2
-_pb2_path = _generated_dir / "cognevra_pb2.py"
+# Load levara_pb2
+_pb2_path = _generated_dir / "levara_pb2.py"
 if _pb2_path.exists():
     _pb2_spec = importlib.util.spec_from_file_location(
-        f"{_generated_pkg_name}.cognevra_pb2", _pb2_path
+        f"{_generated_pkg_name}.levara_pb2", _pb2_path
     )
     _pb2_mod = importlib.util.module_from_spec(_pb2_spec)
-    sys.modules[f"{_generated_pkg_name}.cognevra_pb2"] = _pb2_mod
+    sys.modules[f"{_generated_pkg_name}.levara_pb2"] = _pb2_mod
     _pb2_spec.loader.exec_module(_pb2_mod)
-    _generated_pkg.cognevra_pb2 = _pb2_mod
+    _generated_pkg.levara_pb2 = _pb2_mod
 else:
-    _pb2_mod = _stub(f"{_generated_pkg_name}.cognevra_pb2")
-    _generated_pkg.cognevra_pb2 = _pb2_mod
+    _pb2_mod = _stub(f"{_generated_pkg_name}.levara_pb2")
+    _generated_pkg.levara_pb2 = _pb2_mod
 
-# Load cognevra_pb2_grpc
-_pb2_grpc_path = _generated_dir / "cognevra_pb2_grpc.py"
+# Load levara_pb2_grpc
+_pb2_grpc_path = _generated_dir / "levara_pb2_grpc.py"
 if _pb2_grpc_path.exists():
     _pb2_grpc_spec = importlib.util.spec_from_file_location(
-        f"{_generated_pkg_name}.cognevra_pb2_grpc", _pb2_grpc_path
+        f"{_generated_pkg_name}.levara_pb2_grpc", _pb2_grpc_path
     )
     _pb2_grpc_mod = importlib.util.module_from_spec(_pb2_grpc_spec)
-    sys.modules[f"{_generated_pkg_name}.cognevra_pb2_grpc"] = _pb2_grpc_mod
-    # cognevra_pb2_grpc.py uses `import cognevra_pb2` (bare name); alias it
-    sys.modules["cognevra_pb2"] = _pb2_mod
+    sys.modules[f"{_generated_pkg_name}.levara_pb2_grpc"] = _pb2_grpc_mod
+    # levara_pb2_grpc.py uses `import levara_pb2` (bare name); alias it
+    sys.modules["levara_pb2"] = _pb2_mod
     _pb2_grpc_spec.loader.exec_module(_pb2_grpc_mod)
     # Clean up the bare alias so it doesn't pollute the global namespace
-    sys.modules.pop("cognevra_pb2", None)
-    _generated_pkg.cognevra_pb2_grpc = _pb2_grpc_mod
+    sys.modules.pop("levara_pb2", None)
+    _generated_pkg.levara_pb2_grpc = _pb2_grpc_mod
 else:
-    _pb2_grpc_mod = _stub(f"{_generated_pkg_name}.cognevra_pb2_grpc")
-    _generated_pkg.cognevra_pb2_grpc = _pb2_grpc_mod
+    _pb2_grpc_mod = _stub(f"{_generated_pkg_name}.levara_pb2_grpc")
+    _generated_pkg.levara_pb2_grpc = _pb2_grpc_mod
 
-# Now load the adapter (its `from .generated import cognevra_pb2` will resolve)
+# Now load the adapter (its `from .generated import levara_pb2` will resolve)
 _adapter_path = (
     _REPO_ROOT / "cognee" / "infrastructure" / "databases" / "vector"
-    / "cognevra" / "CognevraAdapter.py"
+    / "levara" / "LevaraAdapter.py"
 )
 _spec = importlib.util.spec_from_file_location(
-    "cognee.infrastructure.databases.vector.cognevra.CognevraAdapter",
+    "cognee.infrastructure.databases.vector.levara.LevaraAdapter",
     _adapter_path,
 )
 _adapter_mod = importlib.util.module_from_spec(_spec)
-sys.modules["cognee.infrastructure.databases.vector.cognevra.CognevraAdapter"] = _adapter_mod
+sys.modules["cognee.infrastructure.databases.vector.levara.LevaraAdapter"] = _adapter_mod
 _spec.loader.exec_module(_adapter_mod)
 
-# Attach to parent package so `from cognee...cognevra.CognevraAdapter import X` works
-_cognevra_pkg.CognevraAdapter = _adapter_mod.CognevraAdapter
+# Attach to parent package so `from cognee...levara.LevaraAdapter import X` works
+_levara_pkg.LevaraAdapter = _adapter_mod.LevaraAdapter

--- a/tests/test_aggregator_integration.py
+++ b/tests/test_aggregator_integration.py
@@ -3,12 +3,12 @@ import sys
 from unittest.mock import AsyncMock, MagicMock
 import pytest
 
-from cognee.infrastructure.databases.vector.cognevra.CognevraAdapter import CognevraAdapter
-pb = sys.modules["cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2"]
+from cognee.infrastructure.databases.vector.levara.LevaraAdapter import LevaraAdapter
+pb = sys.modules["cognee.infrastructure.databases.vector.levara.generated.levara_pb2"]
 
 
 def _make_adapter():
-    adapter = CognevraAdapter(url="localhost:50051", api_key=None, embedding_engine=MagicMock())
+    adapter = LevaraAdapter(url="localhost:50051", api_key=None, embedding_engine=MagicMock())
     adapter._stub = MagicMock()
     return adapter
 

--- a/tests/test_book_search_benchmark.py
+++ b/tests/test_book_search_benchmark.py
@@ -2,7 +2,7 @@
 Full end-to-end benchmark: book-scale search quality and performance.
 
 Uses Janet Edwards' "Ураган" (Hurricane, Hive #3) as a real-world dataset.
-Tests Cognevra adapter with ~500+ text chunks from a Russian sci-fi novel.
+Tests Levara adapter with ~500+ text chunks from a Russian sci-fi novel.
 
 What this test measures:
   1. CHUNKING — text splitting into meaningful paragraphs
@@ -29,8 +29,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from cognee.infrastructure.databases.vector.cognevra.CognevraAdapter import (
-    CognevraAdapter,
+from cognee.infrastructure.databases.vector.levara.LevaraAdapter import (
+    LevaraAdapter,
     _serialize_for_json,
 )
 
@@ -105,14 +105,14 @@ def load_and_chunk_book(path: Path, max_chunk_chars: int = 1500) -> List[Dict]:
 
 import json as _json
 
-pb = sys.modules["cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2"]
+pb = sys.modules["cognee.infrastructure.databases.vector.levara.generated.levara_pb2"]
 
 
 class GrpcMockServer:
     """
     In-process gRPC stub mock with brute-force cosine search.
 
-    Implements the same async interface as the real CognevraServiceStub so that
+    Implements the same async interface as the real LevaraServiceStub so that
     ``adapter._stub = server`` is sufficient to redirect all calls here.
     """
 
@@ -247,10 +247,10 @@ class _ChunkDataPoint(_DataPoint):
 
 # ── Adapter factory ──────────────────────────────────────────────────────────
 
-def _make_adapter(server: GrpcMockServer, engine=None) -> CognevraAdapter:
+def _make_adapter(server: GrpcMockServer, engine=None) -> LevaraAdapter:
     if engine is None:
         engine = _make_embedding_engine()
-    adapter = CognevraAdapter(
+    adapter = LevaraAdapter(
         url="localhost:50051",
         api_key=None,
         embedding_engine=engine,

--- a/tests/test_chunker_integration.py
+++ b/tests/test_chunker_integration.py
@@ -7,13 +7,13 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 # Import adapter and protobuf from conftest-registered modules
-from cognee.infrastructure.databases.vector.cognevra.CognevraAdapter import CognevraAdapter
+from cognee.infrastructure.databases.vector.levara.LevaraAdapter import LevaraAdapter
 
-pb = sys.modules["cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2"]
+pb = sys.modules["cognee.infrastructure.databases.vector.levara.generated.levara_pb2"]
 
 
 def _make_adapter():
-    adapter = CognevraAdapter(url="localhost:50051", api_key=None, embedding_engine=MagicMock())
+    adapter = LevaraAdapter(url="localhost:50051", api_key=None, embedding_engine=MagicMock())
     adapter._stub = MagicMock()
     return adapter
 

--- a/tests/test_dimension_validation_edge_cases.py
+++ b/tests/test_dimension_validation_edge_cases.py
@@ -8,9 +8,9 @@ from unittest.mock import AsyncMock, MagicMock
 import aiohttp
 import pytest
 
-from cognee.infrastructure.databases.vector.cognevra.CognevraAdapter import CognevraAdapter
+from cognee.infrastructure.databases.vector.levara.LevaraAdapter import LevaraAdapter
 
-pb = sys.modules["cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2"]
+pb = sys.modules["cognee.infrastructure.databases.vector.levara.generated.levara_pb2"]
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -39,10 +39,10 @@ class _FakeResponse:
         pass
 
 
-def _make_adapter(engine_dim: int) -> CognevraAdapter:
+def _make_adapter(engine_dim: int) -> LevaraAdapter:
     engine = MagicMock()
     engine.get_vector_size = MagicMock(return_value=engine_dim)
-    return CognevraAdapter(
+    return LevaraAdapter(
         url="localhost:50051",
         api_key=None,
         embedding_engine=engine,

--- a/tests/test_dimension_validation_integration.py
+++ b/tests/test_dimension_validation_integration.py
@@ -11,19 +11,19 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from cognee.infrastructure.databases.vector.cognevra.CognevraAdapter import CognevraAdapter
+from cognee.infrastructure.databases.vector.levara.LevaraAdapter import LevaraAdapter
 
 import sys
 
 _DataPoint = sys.modules["cognee.infrastructure.engine"].DataPoint
-pb = sys.modules["cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2"]
+pb = sys.modules["cognee.infrastructure.databases.vector.levara.generated.levara_pb2"]
 
 
 # ── GrpcMockServer with Info RPC ─────────────────────────────────────────────
 
 class GrpcMockServerWithInfo:
     """
-    Mock Cognevra gRPC stub that also handles the Info RPC
+    Mock Levara gRPC stub that also handles the Info RPC
     for dimension validation.
     """
 
@@ -105,9 +105,9 @@ def _make_engine(dim: int = 768):
 def _make_adapter_with_info_server(
     server: GrpcMockServerWithInfo,
     engine_dim: int = 768,
-) -> CognevraAdapter:
+) -> LevaraAdapter:
     engine = _make_engine(engine_dim)
-    adapter = CognevraAdapter(
+    adapter = LevaraAdapter(
         url="localhost:50051",
         api_key=None,
         embedding_engine=engine,

--- a/tests/test_dimension_validation_layer3.py
+++ b/tests/test_dimension_validation_layer3.py
@@ -1,7 +1,7 @@
 """
-Layer 3 tests: CognevraAdapter.health_check() — dimension validation via gRPC Info RPC.
+Layer 3 tests: LevaraAdapter.health_check() — dimension validation via gRPC Info RPC.
 
-Tests the most autonomous Python validation layer: gRPC call to Cognevra
+Tests the most autonomous Python validation layer: gRPC call to Levara
 server to compare server dimension with embedding engine dimension.
 """
 
@@ -13,18 +13,18 @@ import grpc
 import grpc.aio
 import pytest
 
-from cognee.infrastructure.databases.vector.cognevra.CognevraAdapter import CognevraAdapter
+from cognee.infrastructure.databases.vector.levara.LevaraAdapter import LevaraAdapter
 
-pb = sys.modules["cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2"]
+pb = sys.modules["cognee.infrastructure.databases.vector.levara.generated.levara_pb2"]
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
-def _make_adapter(engine_dim: int = 768) -> CognevraAdapter:
+def _make_adapter(engine_dim: int = 768) -> LevaraAdapter:
     """Create adapter with a mock embedding engine."""
     engine = MagicMock()
     engine.get_vector_size = MagicMock(return_value=engine_dim)
-    adapter = CognevraAdapter(
+    adapter = LevaraAdapter(
         url="localhost:50051",
         api_key=None,
         embedding_engine=engine,
@@ -32,7 +32,7 @@ def _make_adapter(engine_dim: int = 768) -> CognevraAdapter:
     return adapter
 
 
-def _patch_stub(adapter: CognevraAdapter, dimension: int, shards: int = 1, status: str = "ready"):
+def _patch_stub(adapter: LevaraAdapter, dimension: int, shards: int = 1, status: str = "ready"):
     """Replace adapter._stub with a MagicMock whose Info returns pb.InfoResp."""
     stub = MagicMock()
     stub.Info = AsyncMock(return_value=pb.InfoResp(
@@ -69,7 +69,7 @@ class TestHealthCheckLayer3:
         adapter = _make_adapter(engine_dim=768)
         _patch_stub(adapter, dimension=512, shards=1)
 
-        with pytest.raises(RuntimeError, match="Fix EMBEDDING_DIMENSIONS or Cognevra -dim flag"):
+        with pytest.raises(RuntimeError, match="Fix EMBEDDING_DIMENSIONS or Levara -dim flag"):
             await adapter.health_check()
 
     @pytest.mark.asyncio

--- a/tests/test_fileio_integration.py
+++ b/tests/test_fileio_integration.py
@@ -5,13 +5,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from cognee.infrastructure.databases.vector.cognevra.CognevraAdapter import CognevraAdapter
+from cognee.infrastructure.databases.vector.levara.LevaraAdapter import LevaraAdapter
 
-pb = sys.modules["cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2"]
+pb = sys.modules["cognee.infrastructure.databases.vector.levara.generated.levara_pb2"]
 
 
 def _make_adapter():
-    adapter = CognevraAdapter(url="localhost:50051", api_key=None, embedding_engine=MagicMock())
+    adapter = LevaraAdapter(url="localhost:50051", api_key=None, embedding_engine=MagicMock())
     adapter._stub = MagicMock()
     return adapter
 

--- a/tests/test_head_to_head.py
+++ b/tests/test_head_to_head.py
@@ -1,7 +1,7 @@
 """
-Head-to-head: Cognevra adapter vs LanceDB (Cognee default).
+Head-to-head: Levara adapter vs LanceDB (Cognee default).
 
-Cognevra side: CognevraAdapter + GrpcMockServer (zero network/Raft)
+Levara side: LevaraAdapter + GrpcMockServer (zero network/Raft)
 LanceDB side:  raw lancedb library — same operations as LanceDBAdapter does
 
 Why raw lancedb instead of LanceDBAdapter?
@@ -32,14 +32,14 @@ from pydantic import BaseModel
 
 import pytest
 
-from cognee.infrastructure.databases.vector.cognevra.CognevraAdapter import (
-    CognevraAdapter,
+from cognee.infrastructure.databases.vector.levara.LevaraAdapter import (
+    LevaraAdapter,
 )
 
 import sys
 
 _DataPoint = sys.modules["cognee.infrastructure.engine"].DataPoint
-pb = sys.modules["cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2"]
+pb = sys.modules["cognee.infrastructure.databases.vector.levara.generated.levara_pb2"]
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -203,8 +203,8 @@ class GrpcMockServer:
         return pb.DeleteResp(deleted=deleted, failed=0)
 
 
-def _make_cognevra(server, engine):
-    a = CognevraAdapter(url="localhost:50051", api_key=None, embedding_engine=engine)
+def _make_levara(server, engine):
+    a = LevaraAdapter(url="localhost:50051", api_key=None, embedding_engine=engine)
     a._stub = server
     return a
 
@@ -230,20 +230,20 @@ class TestHeadToHead:
     async def test_1_insert_throughput(self):
         print("\n\n" + "=" * 70)
         print(f"  1. INSERT THROUGHPUT  (N={N}, batch={BATCH})")
-        print("     Cognevra: GrpcMockServer (no Raft, no disk)")
+        print("     Levara: GrpcMockServer (no Raft, no disk)")
         print("     LanceDB:  real Arrow file I/O, merge_insert")
         print("=" * 70)
 
         ids, texts, vectors = _gen_data(N)
         dps = [_DP(uid, text) for uid, text in zip(ids, texts)]
 
-        # -- Cognevra --
+        # -- Levara --
         vec_iter = iter(vectors)
         fast = MagicMock()
         fast.embed_text = AsyncMock(side_effect=lambda t: [next(vec_iter) for _ in t])
         fast.get_vector_size = MagicMock(return_value=DIM)
         server = GrpcMockServer()
-        va = _make_cognevra(server, fast)
+        va = _make_levara(server, fast)
 
         t0 = time.perf_counter()
         for i in range(0, N, BATCH):
@@ -263,11 +263,11 @@ class TestHeadToHead:
         l_dps = N / t_l
         print(f"\n  {'Provider':<22} {'dp/s':>10}  {'total ms':>10}")
         print(f"  {'-'*48}")
-        print(f"  {'Cognevra (mock)':<22} {v_dps:>10,.0f}  {t_v*1000:>10.1f}")
+        print(f"  {'Levara (mock)':<22} {v_dps:>10,.0f}  {t_v*1000:>10.1f}")
         print(f"  {'LanceDB (real file)':<22} {l_dps:>10,.0f}  {t_l*1000:>10.1f}")
         ratio = v_dps / l_dps if l_dps > 0 else 1
-        print(f"\n  Cognevra mock: {ratio:.1f}x faster insert (no disk/Raft)")
-        print(f"  * With real Raft Cognevra will be ~10-50x SLOWER => insert wins LanceDB\n")
+        print(f"\n  Levara mock: {ratio:.1f}x faster insert (no disk/Raft)")
+        print(f"  * With real Raft Levara will be ~10-50x SLOWER => insert wins LanceDB\n")
 
         assert v_dps > 500
         assert l_dps > 50
@@ -276,20 +276,20 @@ class TestHeadToHead:
     async def test_2_search_latency(self):
         print("\n\n" + "=" * 70)
         print(f"  2. SEARCH LATENCY  (N={N}, {N_QUERIES} queries, k={K})")
-        print("     Pre-computed vectors, no embedding overhead (Cognevra vs LanceDB)")
+        print("     Pre-computed vectors, no embedding overhead (Levara vs LanceDB)")
         print("=" * 70)
 
         ids, texts, vectors = _gen_data(N)
         dps = [_DP(uid, text) for uid, text in zip(ids, texts)]
         q_vecs = [_random_vec() for _ in range(N_QUERIES)]
 
-        # -- Cognevra --
+        # -- Levara --
         vec_iter = iter(vectors)
         fast = MagicMock()
         fast.embed_text = AsyncMock(side_effect=lambda t: [next(vec_iter) for _ in t])
         fast.get_vector_size = MagicMock(return_value=DIM)
         server = GrpcMockServer()
-        va = _make_cognevra(server, fast)
+        va = _make_levara(server, fast)
         for i in range(0, N, BATCH):
             await va.create_data_points("col", dps[i : i + BATCH])
 
@@ -321,16 +321,16 @@ class TestHeadToHead:
 
         print(f"\n  {'Provider':<22} {'p50':>7} {'p95':>7} {'p99':>7} {'mean':>7}  (ms)")
         print(f"  {'-'*58}")
-        print(f"  {'Cognevra (mock)':<22} {vp50:>7.3f} {vp95:>7.3f} {vp99:>7.3f} {vm:>7.3f}")
+        print(f"  {'Levara (mock)':<22} {vp50:>7.3f} {vp95:>7.3f} {vp99:>7.3f} {vm:>7.3f}")
         print(f"  {'LanceDB (real file)':<22} {lp50:>7.3f} {lp95:>7.3f} {lp99:>7.3f} {lm:>7.3f}")
-        winner = "Cognevra" if vm < lm else "LanceDB"
+        winner = "Levara" if vm < lm else "LanceDB"
         ratio = max(vm, lm) / min(vm, lm) if min(vm, lm) > 0.001 else 1
         print(f"\n  Winner: {winner} ({ratio:.1f}x faster mean)\n")
 
     @pytest.mark.asyncio
     async def test_3_concurrent_search(self):
         print("\n\n" + "=" * 70)
-        print(f"  3. CONCURRENT SEARCH  (50 queries at once, {N} vectors, Cognevra vs LanceDB)")
+        print(f"  3. CONCURRENT SEARCH  (50 queries at once, {N} vectors, Levara vs LanceDB)")
         print("=" * 70)
 
         ids, texts, vectors = _gen_data(N)
@@ -338,13 +338,13 @@ class TestHeadToHead:
         N_C = 50
         q_vecs = [_random_vec() for _ in range(N_C)]
 
-        # -- Cognevra --
+        # -- Levara --
         vec_iter = iter(vectors)
         fast = MagicMock()
         fast.embed_text = AsyncMock(side_effect=lambda t: [next(vec_iter) for _ in t])
         fast.get_vector_size = MagicMock(return_value=DIM)
         server = GrpcMockServer()
-        va = _make_cognevra(server, fast)
+        va = _make_levara(server, fast)
         for i in range(0, N, BATCH):
             await va.create_data_points("col", dps[i : i + BATCH])
 
@@ -367,9 +367,9 @@ class TestHeadToHead:
         qps_v, qps_l = N_C / t_v, N_C / t_l
         print(f"\n  {'Provider':<22} {'QPS':>8}  {'total ms':>10}")
         print(f"  {'-'*48}")
-        print(f"  {'Cognevra (mock)':<22} {qps_v:>8,.0f}  {t_v*1000:>10.1f}")
+        print(f"  {'Levara (mock)':<22} {qps_v:>8,.0f}  {t_v*1000:>10.1f}")
         print(f"  {'LanceDB (real file)':<22} {qps_l:>8,.0f}  {t_l*1000:>10.1f}")
-        winner = "Cognevra" if qps_v > qps_l else "LanceDB"
+        winner = "Levara" if qps_v > qps_l else "LanceDB"
         ratio = max(qps_v, qps_l) / min(qps_v, qps_l) if min(qps_v, qps_l) > 0 else 1
         print(f"\n  Winner: {winner} ({ratio:.1f}x higher QPS)\n")
 
@@ -378,7 +378,7 @@ class TestHeadToHead:
         print("\n\n" + "=" * 70)
         print(f"  4. EMBEDDING CACHE  (re-index same {N} texts twice)")
         print("     LanceDB adapter: embed_data() = direct engine call, NO cache")
-        print("     Cognevra adapter: embed_data() = LRU cache => 0 calls on 2nd pass")
+        print("     Levara adapter: embed_data() = LRU cache => 0 calls on 2nd pass")
         print("=" * 70)
 
         ids, texts, vectors = _gen_data(N)
@@ -386,7 +386,7 @@ class TestHeadToHead:
 
         v_engine = _make_engine()
         server = GrpcMockServer()
-        va = _make_cognevra(server, v_engine)
+        va = _make_levara(server, v_engine)
 
         # 1st pass
         for i in range(0, N, BATCH):
@@ -404,24 +404,24 @@ class TestHeadToHead:
 
         print(f"\n  {'Provider':<22} {'embed calls (2nd)':>20}  {'saved':>12}")
         print(f"  {'-'*60}")
-        print(f"  {'Cognevra':<22} {second_calls:>20}  {(lance_calls - second_calls) * EMBED_MS:>10.0f} ms")
+        print(f"  {'Levara':<22} {second_calls:>20}  {(lance_calls - second_calls) * EMBED_MS:>10.0f} ms")
         print(f"  {'LanceDB':<22} {lance_calls:>20}  {'0':>10} ms")
-        print(f"\n  Cognevra saves {(lance_calls) * EMBED_MS:.0f}ms when re-indexing {N} texts\n")
+        print(f"\n  Levara saves {(lance_calls) * EMBED_MS:.0f}ms when re-indexing {N} texts\n")
 
         assert second_calls == 0
 
     @pytest.mark.asyncio
     async def test_5_summary(self):
         print("\n\n" + "=" * 70)
-        print("  SUMMARY: Cognevra (our plugin) vs LanceDB (Cognee default)")
+        print("  SUMMARY: Levara (our plugin) vs LanceDB (Cognee default)")
         print("=" * 70)
         print("""
   Conditions:
-    Cognevra = GrpcMockServer (no network, no Raft) — best case
+    Levara = GrpcMockServer (no network, no Raft) — best case
     LanceDB  = real file I/O — production conditions
 
   +-----------------------------------+--------------+--------------+
-  | Metric                            |  Cognevra    |  LanceDB     |
+  | Metric                            |  Levara    |  LanceDB     |
   +-----------------------------------+--------------+--------------+
   | Insert (with Raft in prod)        |  ~200 dp/s   | ~300-2k dp/s |
   | Search latency p50                |  see test 2  |  see test 2  |
@@ -436,7 +436,7 @@ class TestHeadToHead:
   | Deploy                            |  Go binary   |  pip install |
   +-----------------------------------+--------------+--------------+
 
-  WHERE COGNEVRA IS BETTER:
+  WHERE LEVARA IS BETTER:
     + Embedding cache: saves ~67ms on re-index of 500 texts
     + Search latency: lock-free reads in Go
     + orjson: 3x faster serialization
@@ -451,7 +451,7 @@ class TestHeadToHead:
     - No network/process overhead
 
   CONCLUSION:
-    Cognevra is better for READ-HEAVY workloads with low latency.
+    Levara is better for READ-HEAVY workloads with low latency.
     LanceDB is better for WRITE-HEAVY, high recall workloads.
 """)
         print("=" * 70)

--- a/tests/test_real_server.py
+++ b/tests/test_real_server.py
@@ -1,11 +1,11 @@
 """
-Head-to-head: Cognevra (REAL Go server) vs LanceDB (real file I/O).
+Head-to-head: Levara (REAL Go server) vs LanceDB (real file I/O).
 
-NO mocks. Cognevra adapter talks to the real Go HNSW server via gRPC on localhost:50051.
+NO mocks. Levara adapter talks to the real Go HNSW server via gRPC on localhost:50051.
 LanceDB uses the raw lancedb library with real Arrow file I/O.
 
 Prerequisite:
-    docker compose up -d --build   (Cognevra with dim=1024, gRPC on :50051)
+    docker compose up -d --build   (Levara with dim=1024, gRPC on :50051)
 
 Run:
     pytest tests/test_real_server.py -v -s
@@ -34,13 +34,13 @@ import sys
 
 _DataPoint = sys.modules["cognee.infrastructure.engine"].DataPoint
 
-from cognee.infrastructure.databases.vector.cognevra.CognevraAdapter import (
-    CognevraAdapter,
+from cognee.infrastructure.databases.vector.levara.LevaraAdapter import (
+    LevaraAdapter,
 )
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
-COGNEVRA_URL = "localhost:50051"
+LEVARA_URL = "localhost:50051"
 DIM = 1024
 N = 1000          # number of data points
 N_QUERIES = 200   # number of search queries
@@ -100,12 +100,12 @@ class LanceDP(LanceModel):
     payload: LancePayload
 
 
-# ── Cognevra adapter (real server) ──────────────────────────────────────────
+# ── Levara adapter (real server) ──────────────────────────────────────────
 
-def _make_cognevra_real(engine) -> CognevraAdapter:
-    """Create CognevraAdapter pointing at real Go server."""
-    return CognevraAdapter(
-        url=COGNEVRA_URL,
+def _make_levara_real(engine) -> LevaraAdapter:
+    """Create LevaraAdapter pointing at real Go server."""
+    return LevaraAdapter(
+        url=LEVARA_URL,
         api_key=None,
         embedding_engine=engine,
     )
@@ -150,10 +150,10 @@ def _make_engine_deterministic():
 async def _server_alive() -> bool:
     import grpc.aio
     try:
-        channel = grpc.aio.insecure_channel(COGNEVRA_URL)
-        pb = sys.modules["cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2"]
-        pb_grpc = sys.modules["cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2_grpc"]
-        stub = pb_grpc.CognevraServiceStub(channel)
+        channel = grpc.aio.insecure_channel(LEVARA_URL)
+        pb = sys.modules["cognee.infrastructure.databases.vector.levara.generated.levara_pb2"]
+        pb_grpc = sys.modules["cognee.infrastructure.databases.vector.levara.generated.levara_pb2_grpc"]
+        stub = pb_grpc.LevaraServiceStub(channel)
         resp = await asyncio.wait_for(stub.Info(pb.Empty()), timeout=5.0)
         await channel.close()
         return resp.status == "ready"
@@ -176,7 +176,7 @@ def check_server(event_loop):
     alive = event_loop.run_until_complete(_server_alive())
     if not alive:
         pytest.skip(
-            f"Cognevra server not running on {COGNEVRA_URL}. "
+            f"Levara server not running on {LEVARA_URL}. "
             "Start with: docker compose up -d --build"
         )
 
@@ -185,10 +185,10 @@ class TestRealServer:
 
     @pytest.mark.asyncio
     async def test_1_insert_throughput(self):
-        """Insert N data points: Cognevra (real HNSW) vs LanceDB (real Arrow)."""
+        """Insert N data points: Levara (real HNSW) vs LanceDB (real Arrow)."""
         print("\n\n" + "=" * 72)
         print(f"  1. INSERT THROUGHPUT  (N={N}, batch={BATCH})")
-        print("     Cognevra: REAL Go server (HNSW + disk)")
+        print("     Levara: REAL Go server (HNSW + disk)")
         print("     LanceDB:  REAL Arrow file I/O")
         print("=" * 72)
 
@@ -196,9 +196,9 @@ class TestRealServer:
         col_name = f"bench_{uuid.uuid4().hex[:8]}"
         dps = [_DP(uid, text) for uid, text in zip(ids, texts)]
 
-        # -- Cognevra (real server) --
+        # -- Levara (real server) --
         engine_v = _make_engine_precomputed(vectors)
-        va = _make_cognevra_real(engine_v)
+        va = _make_levara_real(engine_v)
 
         t0 = time.perf_counter()
         for i in range(0, N, BATCH):
@@ -228,18 +228,18 @@ class TestRealServer:
         l_dps = N / t_l
         print(f"\n  {'Provider':<30} {'dp/s':>10}  {'total ms':>10}")
         print(f"  {'-'*56}")
-        print(f"  {'Cognevra (real HNSW)':<30} {v_dps:>10,.0f}  {t_v*1000:>10.1f}")
+        print(f"  {'Levara (real HNSW)':<30} {v_dps:>10,.0f}  {t_v*1000:>10.1f}")
         print(f"  {'LanceDB (real Arrow)':<30} {l_dps:>10,.0f}  {t_l*1000:>10.1f}")
         ratio = v_dps / l_dps if l_dps > 0 else 1
-        winner = "Cognevra" if v_dps > l_dps else "LanceDB"
+        winner = "Levara" if v_dps > l_dps else "LanceDB"
         print(f"\n  Winner: {winner} ({ratio:.1f}x)" if v_dps > l_dps else f"\n  Winner: {winner} ({1/ratio:.1f}x)")
 
     @pytest.mark.asyncio
     async def test_2_search_latency(self):
-        """Search latency: Cognevra (real HNSW) vs LanceDB (real Arrow scan)."""
+        """Search latency: Levara (real HNSW) vs LanceDB (real Arrow scan)."""
         print("\n\n" + "=" * 72)
         print(f"  2. SEARCH LATENCY  (N={N}, {N_QUERIES} queries, k={K})")
-        print("     Cognevra: REAL Go HNSW search (HTTP round-trip)")
+        print("     Levara: REAL Go HNSW search (HTTP round-trip)")
         print("     LanceDB:  REAL Arrow vector_search")
         print("=" * 72)
 
@@ -247,16 +247,16 @@ class TestRealServer:
         col_name = f"bench_{uuid.uuid4().hex[:8]}"
         dps = [_DP(uid, text) for uid, text in zip(ids, texts)]
 
-        # Insert into Cognevra
+        # Insert into Levara
         engine_v = _make_engine_precomputed(vectors)
-        va = _make_cognevra_real(engine_v)
+        va = _make_levara_real(engine_v)
         for i in range(0, N, BATCH):
             await va.create_data_points(col_name, dps[i : i + BATCH])
 
         # Generate query vectors
         q_vecs = [_random_vec() for _ in range(N_QUERIES)]
 
-        # -- Cognevra search --
+        # -- Levara search --
         v_times = []
         for qv in q_vecs:
             t0 = time.perf_counter()
@@ -295,18 +295,18 @@ class TestRealServer:
 
         print(f"\n  {'Provider':<30} {'p50':>7} {'p95':>7} {'p99':>7} {'mean':>7}  (ms)")
         print(f"  {'-'*66}")
-        print(f"  {'Cognevra (real HNSW)':<30} {vp50:>7.3f} {vp95:>7.3f} {vp99:>7.3f} {vm:>7.3f}")
+        print(f"  {'Levara (real HNSW)':<30} {vp50:>7.3f} {vp95:>7.3f} {vp99:>7.3f} {vm:>7.3f}")
         print(f"  {'LanceDB (real Arrow)':<30} {lp50:>7.3f} {lp95:>7.3f} {lp99:>7.3f} {lm:>7.3f}")
-        winner = "Cognevra" if vm < lm else "LanceDB"
+        winner = "Levara" if vm < lm else "LanceDB"
         ratio = max(vm, lm) / min(vm, lm) if min(vm, lm) > 0.001 else 1
         print(f"\n  Winner: {winner} ({ratio:.1f}x faster mean)")
 
     @pytest.mark.asyncio
     async def test_3_concurrent_search(self):
-        """50 concurrent queries: Cognevra vs LanceDB."""
+        """50 concurrent queries: Levara vs LanceDB."""
         print("\n\n" + "=" * 72)
         print(f"  3. CONCURRENT SEARCH  (50 queries at once, {N} vectors)")
-        print("     Cognevra: REAL Go server (parallel HTTP)")
+        print("     Levara: REAL Go server (parallel HTTP)")
         print("     LanceDB:  REAL Arrow (parallel async)")
         print("=" * 72)
 
@@ -316,13 +316,13 @@ class TestRealServer:
         N_C = 50
         q_vecs = [_random_vec() for _ in range(N_C)]
 
-        # Insert Cognevra
+        # Insert Levara
         engine_v = _make_engine_precomputed(vectors)
-        va = _make_cognevra_real(engine_v)
+        va = _make_levara_real(engine_v)
         for i in range(0, N, BATCH):
             await va.create_data_points(col_name, dps[i : i + BATCH])
 
-        # -- Cognevra concurrent --
+        # -- Levara concurrent --
         t0 = time.perf_counter()
         await asyncio.gather(*[va.search(col_name, query_vector=qv, limit=K) for qv in q_vecs])
         t_v = time.perf_counter() - t0
@@ -352,9 +352,9 @@ class TestRealServer:
         qps_v, qps_l = N_C / t_v, N_C / t_l
         print(f"\n  {'Provider':<30} {'QPS':>8}  {'total ms':>10}")
         print(f"  {'-'*54}")
-        print(f"  {'Cognevra (real server)':<30} {qps_v:>8,.0f}  {t_v*1000:>10.1f}")
+        print(f"  {'Levara (real server)':<30} {qps_v:>8,.0f}  {t_v*1000:>10.1f}")
         print(f"  {'LanceDB (real Arrow)':<30} {qps_l:>8,.0f}  {t_l*1000:>10.1f}")
-        winner = "Cognevra" if qps_v > qps_l else "LanceDB"
+        winner = "Levara" if qps_v > qps_l else "LanceDB"
         ratio = max(qps_v, qps_l) / min(qps_v, qps_l) if min(qps_v, qps_l) > 0 else 1
         print(f"\n  Winner: {winner} ({ratio:.1f}x higher QPS)")
 
@@ -382,13 +382,13 @@ class TestRealServer:
             scored.sort(key=lambda x: -x[1])
             return set(ids[s[0]] for s in scored[:k])
 
-        # Insert Cognevra
+        # Insert Levara
         engine_v = _make_engine_precomputed(vectors)
-        va = _make_cognevra_real(engine_v)
+        va = _make_levara_real(engine_v)
         for i in range(0, N, BATCH):
             await va.create_data_points(col_name, dps[i : i + BATCH])
 
-        # Cognevra recall
+        # Levara recall
         v_recalls = []
         for qv in q_vecs:
             truth = brute_force_topk(qv, K)
@@ -423,24 +423,24 @@ class TestRealServer:
         l_mean = statistics.mean(l_recalls)
         print(f"\n  {'Provider':<30} {'recall@10':>10}  {'min':>6}  {'max':>6}")
         print(f"  {'-'*58}")
-        print(f"  {'Cognevra (real HNSW)':<30} {v_mean:>10.3f}  {min(v_recalls):>6.3f}  {max(v_recalls):>6.3f}")
+        print(f"  {'Levara (real HNSW)':<30} {v_mean:>10.3f}  {min(v_recalls):>6.3f}  {max(v_recalls):>6.3f}")
         print(f"  {'LanceDB (real Arrow)':<30} {l_mean:>10.3f}  {min(l_recalls):>6.3f}  {max(l_recalls):>6.3f}")
-        winner = "Cognevra" if v_mean > l_mean else "LanceDB"
+        winner = "Levara" if v_mean > l_mean else "LanceDB"
         print(f"\n  Winner: {winner}")
 
     @pytest.mark.asyncio
     async def test_5_summary(self):
         print("\n\n" + "=" * 72)
-        print("  ИТОГО: Cognevra (РЕАЛЬНЫЙ Go сервер) vs LanceDB")
+        print("  ИТОГО: Levara (РЕАЛЬНЫЙ Go сервер) vs LanceDB")
         print("=" * 72)
         print("""
   Оба движка работают БЕЗ МОКОВ — реальный I/O, реальный HNSW/Arrow.
 
-  Cognevra: Go HNSW + Raft consensus + WAL + HTTP (aiohttp)
+  Levara: Go HNSW + Raft consensus + WAL + HTTP (aiohttp)
   LanceDB:  Rust Arrow + in-process (no network overhead)
 
   Ключевое отличие:
-    Cognevra платит за HTTP round-trip (~0.5-1ms per call),
+    Levara платит за HTTP round-trip (~0.5-1ms per call),
     но выигрывает на concurrent load (Go goroutines vs Python GIL).
 
   Наши оптимизации:

--- a/tests/test_triplet_integration.py
+++ b/tests/test_triplet_integration.py
@@ -1,6 +1,6 @@
-"""Integration tests for process_triplets() on CognevraAdapter.
+"""Integration tests for process_triplets() on LevaraAdapter.
 
-Uses the gRPC stub pattern established in test_cognevra_adapter.py
+Uses the gRPC stub pattern established in test_levara_adapter.py
 and test_chunker_integration.py: no real server, AsyncMock on _stub.
 """
 
@@ -9,15 +9,15 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from cognee.infrastructure.databases.vector.cognevra.CognevraAdapter import CognevraAdapter
+from cognee.infrastructure.databases.vector.levara.LevaraAdapter import LevaraAdapter
 
-pb = sys.modules["cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2"]
+pb = sys.modules["cognee.infrastructure.databases.vector.levara.generated.levara_pb2"]
 
 
 # ─── helpers ──────────────────────────────────────────────────────────────────
 
-def _make_adapter() -> CognevraAdapter:
-    adapter = CognevraAdapter(url="localhost:50051", api_key=None, embedding_engine=MagicMock())
+def _make_adapter() -> LevaraAdapter:
+    adapter = LevaraAdapter(url="localhost:50051", api_key=None, embedding_engine=MagicMock())
     adapter._stub = MagicMock()
     return adapter
 


### PR DESCRIPTION
## Summary

Phase 4 of the Cognevra → Levara rebrand: cleans up the periphery — Python adapter (with deprecation alias), test conftest infrastructure, Raspberry Pi deployment files, and benchmark scripts. Four reviewable commits in one PR.

## Commits

| # | Hash | Scope | Δ |
|---|---|---|---|
| 1 | `19315a6` | cognee-plugin adapter (with `CognevraAdapter = LevaraAdapter` alias) | 8 files · 32/24 |
| 2 | `24ff4dc` | tests/conftest.py + 10 dependent test imports | 11 files · 146/146 |
| 3 | `05e9e18` | Raspberry deployment + Dockerfile switch to current `Levara/` | 10 files · 212/182 |
| 4 | `e9dbca1` | benchmarks/cognevra_vs_lancedb.py → levara_vs_lancedb.py | 1 file · 17/17 |

## What changes

### Adapter (`cognee-plugin/`)
- `cognevra_adapter/` → `levara_adapter/`
- `CognevraAdapter.py` → `LevaraAdapter.py`, class `CognevraAdapter` → `LevaraAdapter`
- `pyproject.toml`: `cognee-cognevra` → `cognee-levara`
- `__init__.py` adds `CognevraAdapter = LevaraAdapter` alias (same class object) for backwards compatibility — `isinstance(x, CognevraAdapter)` continues to work
- generated/.gitignore patterns: `cognevra_pb2{,_grpc}.py` → `levara_pb2{,_grpc}.py` (regen produced from `Levara/proto/levara.proto` already exists with new name)

### Test infrastructure
- `tests/conftest.py`: stub package, importlib paths, on-disk pb2/adapter file paths all updated
- 10 dependent tests (`test_aggregator_integration`, `test_book_search_benchmark`, `test_chunker_integration`, `test_dimension_validation_*`, `test_fileio_integration`, `test_head_to_head`, `test_real_server`, `test_triplet_integration`) get their imports rewritten

### Raspberry Pi deployment
- `Raspberry/cognevra.{env,service}` → `Raspberry/levara.{env,service}`
- `Raspberry/Dockerfile`: switches build context from `Levara-legacy/` (Phase 2 transitional) to `Levara/` (current code) — API compatible, same CLI flags
- All `Raspberry/*.{sh,md,yml}` content updated
- **Migration block added to `Raspberry/README.md`** with explicit shell steps for existing Pi installations: stop/disable old systemd unit, move `/etc/cognevra` → `/etc/levara`, move `/var/lib/cognevra` → `/var/lib/levara`, install new unit, daemon-reload, enable

### Benchmarks
- `benchmarks/cognevra_vs_lancedb.py` → `benchmarks/levara_vs_lancedb.py` + content rename

## What is NOT in this PR

- `Levara-legacy/go.mod` module identity (`module github.com/stek0v/cognevra`) — intentionally kept to avoid breaking external consumers; can be addressed when ready (separate PR or leave as-is permanently for legacy package).
- `docs/` content — Phase 5.
- Historical files (`CHANGELOG.md` history, `Levara/docs/testing-logs/`, `test_reports/coverage_*`) — intentionally untouched.

## Test plan

- [ ] `pytest --collect-only tests/` — all 10 dependent tests + conftest still importable
- [ ] `pytest tests/test_aggregator_integration.py` (representative) passes
- [ ] `cd cognee-plugin && pip install -e .` works (pyproject name + packages valid)
- [ ] Old import path still works through alias: `from cognee_plugin.levara_adapter import CognevraAdapter` returns the LevaraAdapter class
- [ ] `docker build -f Raspberry/Dockerfile .` builds a `levara` binary
- [ ] Migration block in Raspberry/README is parseable / accurate against a fresh Pi install