### PR TITLE
test: final cleanup of cognevra mentions in test suite

### DIFF
--- a/tests/test_cognee_pipeline_nlp.py
+++ b/tests/test_cognee_pipeline_nlp.py
@@ -145,26 +145,26 @@ class TestCogneePipelineNLP:
         assert cnt > 0, f"Expected entities in Neo4j, got {cnt}"
         print(f"\n  Neo4j nodes: {cnt}")
 
-    def test_cognevra_has_collections(self, pipeline_result):
-        """Cognify should have created vector collections in Cognevra."""
+    def test_levara_has_collections(self, pipeline_result):
+        """Cognify should have created vector collections in Levara."""
         if pipeline_result["cognify_status"] != 200:
             pytest.skip("Cognify failed")
         import grpc
         ch = grpc.insecure_channel("localhost:50051")
         try:
             grpc.channel_ready_future(ch).result(timeout=3)
-            stub = pb_grpc.CognevraServiceStub(ch)
+            stub = pb_grpc.LevaraServiceStub(ch)
             resp = stub.ListCollections(pb.Empty())
             colls = list(resp.collections)
-            print(f"\n  Cognevra collections: {colls}")
-            assert len(colls) > 0, "Expected collections in Cognevra"
+            print(f"\n  Levara collections: {colls}")
+            assert len(colls) > 0, "Expected collections in Levara"
         except Exception as e:
-            print(f"\n  Cognevra check failed: {e}")
+            print(f"\n  Levara check failed: {e}")
         finally:
             ch.close()
 
 
 # Import proto stubs for collection check
 import sys
-pb = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2")
-pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2_grpc")
+pb = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2")
+pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2_grpc")

--- a/tests/test_comprehensive_comparison.py
+++ b/tests/test_comprehensive_comparison.py
@@ -1,5 +1,5 @@
 """
-Comprehensive Cognevra vs LanceDB comparison: 10-step benchmark.
+Comprehensive Levara vs LanceDB comparison: 10-step benchmark.
 
 Same book «Ураган», same embed-server, same queries.
 Covers: throughput, latency, quality (NDCG/MRR), concurrency,
@@ -7,7 +7,7 @@ Covers: throughput, latency, quality (NDCG/MRR), concurrency,
 
 Requires:
   - embed-server on :9001 (pplx-embed-context-v1-0.6b, dim=1024)
-  - Cognevra on :8080 (dim=1024, 3 shards)
+  - Levara on :8080 (dim=1024, 3 shards)
 
 Run:
     pytest tests/test_comprehensive_comparison.py -v -s
@@ -38,7 +38,7 @@ import pytest
 
 BOOK_PATH = Path(__file__).parent.parent / "Edvards_Dzanet_Uragan_r4_P61XH.txt"
 EMBED_URL = "http://localhost:9001/v1/embeddings"
-COGNEVRA_URL = "http://localhost:8080"
+LEVARA_URL = "http://localhost:8080"
 EMBED_MODEL = "pplx-embed-context-v1-0.6b"
 DIM = 1024
 MIN_CHUNK_CHARS = 80
@@ -134,7 +134,7 @@ def _check(url):
 
 pytestmark = pytest.mark.skipif(
     not (_check("http://localhost:9001/health") and _check("http://localhost:8080/metrics")),
-    reason="Need embed-server:9001 + Cognevra:8080",
+    reason="Need embed-server:9001 + Levara:8080",
 )
 
 
@@ -199,41 +199,41 @@ def percentile_stats(values: List[float]) -> Dict[str, float]:
     }
 
 
-# ── Cognevra helpers ──────────────────────────────────────────────────────────
+# ── Levara helpers ──────────────────────────────────────────────────────────
 
-async def cognevra_insert(session: aiohttp.ClientSession, records: List[Dict]) -> Dict:
-    async with session.post(f"{COGNEVRA_URL}/api/v1/batch_insert", json={"records": records}) as r:
+async def levara_insert(session: aiohttp.ClientSession, records: List[Dict]) -> Dict:
+    async with session.post(f"{LEVARA_URL}/api/v1/batch_insert", json={"records": records}) as r:
         r.raise_for_status()
         return await r.json()
 
 
-async def cognevra_search(session: aiohttp.ClientSession, vector: List[float],
+async def levara_search(session: aiohttp.ClientSession, vector: List[float],
                         k: int = K) -> List[Dict]:
-    async with session.post(f"{COGNEVRA_URL}/api/v1/search", json={"vector": vector, "k": k}) as r:
+    async with session.post(f"{LEVARA_URL}/api/v1/search", json={"vector": vector, "k": k}) as r:
         r.raise_for_status()
         data = await r.json()
     return data.get("results", [])
 
 
-async def cognevra_delete(session: aiohttp.ClientSession, ids: List[str]) -> Dict:
-    async with session.post(f"{COGNEVRA_URL}/api/v1/delete", json={"ids": ids}) as r:
+async def levara_delete(session: aiohttp.ClientSession, ids: List[str]) -> Dict:
+    async with session.post(f"{LEVARA_URL}/api/v1/delete", json={"ids": ids}) as r:
         r.raise_for_status()
         return await r.json()
 
 
-async def cognevra_info(session: aiohttp.ClientSession) -> Dict:
-    async with session.get(f"{COGNEVRA_URL}/api/v1/info") as r:
+async def levara_info(session: aiohttp.ClientSession) -> Dict:
+    async with session.get(f"{LEVARA_URL}/api/v1/info") as r:
         r.raise_for_status()
         return await r.json()
 
 
-async def ensure_cognevra_healthy(max_wait: int = 30) -> bool:
-    """Check Cognevra health, restart if needed. Returns True if healthy."""
+async def ensure_levara_healthy(max_wait: int = 30) -> bool:
+    """Check Levara health, restart if needed. Returns True if healthy."""
     # First check if already healthy
     try:
         async with aiohttp.ClientSession() as session:
             async with session.get(
-                f"{COGNEVRA_URL}/api/v1/info",
+                f"{LEVARA_URL}/api/v1/info",
                 timeout=aiohttp.ClientTimeout(total=2),
             ) as r:
                 if r.status == 200:
@@ -244,7 +244,7 @@ async def ensure_cognevra_healthy(max_wait: int = 30) -> bool:
     # Try to restart via docker compose
     cwd = str(Path(__file__).parent.parent)
     subprocess.run(
-        ["docker", "compose", "up", "-d", "cognevra"],
+        ["docker", "compose", "up", "-d", "levara"],
         capture_output=True, text=True, timeout=60,
         cwd=cwd,
     )
@@ -254,7 +254,7 @@ async def ensure_cognevra_healthy(max_wait: int = 30) -> bool:
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.get(
-                    f"{COGNEVRA_URL}/api/v1/info",
+                    f"{LEVARA_URL}/api/v1/info",
                     timeout=aiohttp.ClientTimeout(total=2),
                 ) as r:
                     if r.status == 200:
@@ -265,17 +265,17 @@ async def ensure_cognevra_healthy(max_wait: int = 30) -> bool:
     return False
 
 
-async def cognevra_search_safe(session: aiohttp.ClientSession, vector: List[float],
+async def levara_search_safe(session: aiohttp.ClientSession, vector: List[float],
                               k: int = K) -> List[Dict]:
     """Search with error handling — returns empty list on connection error."""
     try:
-        return await cognevra_search(session, vector, k)
+        return await levara_search(session, vector, k)
     except (aiohttp.ClientError, ConnectionError):
         return []
 
 
 def _extract_text(result: Dict) -> str:
-    """Extract text from Cognevra or LanceDB result metadata/payload."""
+    """Extract text from Levara or LanceDB result metadata/payload."""
     meta = result.get("metadata", result.get("payload", {}))
     if isinstance(meta, str):
         try:
@@ -321,7 +321,7 @@ def book_data():
 
 
 class TestComprehensiveComparison:
-    """10-step comprehensive benchmark: Cognevra vs LanceDB."""
+    """10-step comprehensive benchmark: Levara vs LanceDB."""
 
     # Class-level storage for cross-test state
     _lance_tmpdir: str = None
@@ -340,7 +340,7 @@ class TestComprehensiveComparison:
 
     @pytest.mark.asyncio
     async def test_02_insert_throughput(self, book_data):
-        """Step 2: Insert throughput — Cognevra (HTTP) vs LanceDB (in-process)."""
+        """Step 2: Insert throughput — Levara (HTTP) vs LanceDB (in-process)."""
         chunks, vecs, _ = book_data
         N = len(chunks)
         BATCH = 50
@@ -349,7 +349,7 @@ class TestComprehensiveComparison:
         print(f"  STEP 2: INSERT THROUGHPUT  ({N} chunks, dim={DIM}, batch={BATCH})")
         print("=" * 72)
 
-        # ── Cognevra ──
+        # ── Levara ──
         batch_latencies_v = []
         async with aiohttp.ClientSession() as session:
             t0_total = time.perf_counter()
@@ -361,7 +361,7 @@ class TestComprehensiveComparison:
                                  "chapter": chunks[i]["chapter"]},
                 } for i in range(start, min(start + BATCH, N))]
                 t0 = time.perf_counter()
-                await cognevra_insert(session, batch)
+                await levara_insert(session, batch)
                 batch_latencies_v.append((time.perf_counter() - t0) * 1000)
             t_v = time.perf_counter() - t0_total
 
@@ -394,16 +394,16 @@ class TestComprehensiveComparison:
         l_stats = percentile_stats(batch_latencies_l)
 
         self.__class__._insert_results = {
-            "cognevra_dps": v_dps, "lance_dps": l_dps,
-            "cognevra_ms": t_v * 1000, "lance_ms": t_l * 1000,
+            "levara_dps": v_dps, "lance_dps": l_dps,
+            "levara_ms": t_v * 1000, "lance_ms": t_l * 1000,
         }
 
         print(f"\n  {'Provider':<30} {'dp/s':>8} {'total ms':>10} {'p50 ms':>8} {'p95 ms':>8} {'p99 ms':>8}")
         print(f"  {'-'*75}")
-        print(f"  {'Cognevra':<30} {v_dps:>8,.0f} {t_v*1000:>10.1f} {v_stats['p50']:>8.1f} {v_stats['p95']:>8.1f} {v_stats['p99']:>8.1f}")
+        print(f"  {'Levara':<30} {v_dps:>8,.0f} {t_v*1000:>10.1f} {v_stats['p50']:>8.1f} {v_stats['p95']:>8.1f} {v_stats['p99']:>8.1f}")
         print(f"  {'LanceDB':<30} {l_dps:>8,.0f} {t_l*1000:>10.1f} {l_stats['p50']:>8.1f} {l_stats['p95']:>8.1f} {l_stats['p99']:>8.1f}")
         ratio = max(v_dps, l_dps) / max(min(v_dps, l_dps), 1)
-        winner = "Cognevra" if v_dps > l_dps else "LanceDB"
+        winner = "Levara" if v_dps > l_dps else "LanceDB"
         print(f"\n  Winner: {winner} ({ratio:.1f}x)")
 
     # ── Step 3: Search Latency (single-threaded) ──────────────────────────
@@ -421,13 +421,13 @@ class TestComprehensiveComparison:
         # Let async HNSW indexer finish
         await asyncio.sleep(3)
 
-        # ── Cognevra ──
+        # ── Levara ──
         v_lats = []
         async with aiohttp.ClientSession() as session:
             for _ in range(PASSES):
                 for qv in q_vecs:
                     t0 = time.perf_counter()
-                    await cognevra_search(session, qv, k=K)
+                    await levara_search(session, qv, k=K)
                     v_lats.append((time.perf_counter() - t0) * 1000)
 
         # ── LanceDB ──
@@ -446,10 +446,10 @@ class TestComprehensiveComparison:
 
         print(f"\n  {'Provider':<30} {'p50':>7} {'p95':>7} {'p99':>7} {'mean':>7} {'max':>7}  (ms)")
         print(f"  {'-'*75}")
-        print(f"  {'Cognevra':<30} {v_stats['p50']:>7.1f} {v_stats['p95']:>7.1f} {v_stats['p99']:>7.1f} {v_stats['mean']:>7.1f} {v_stats['max']:>7.1f}")
+        print(f"  {'Levara':<30} {v_stats['p50']:>7.1f} {v_stats['p95']:>7.1f} {v_stats['p99']:>7.1f} {v_stats['mean']:>7.1f} {v_stats['max']:>7.1f}")
         print(f"  {'LanceDB':<30} {l_stats['p50']:>7.1f} {l_stats['p95']:>7.1f} {l_stats['p99']:>7.1f} {l_stats['mean']:>7.1f} {l_stats['max']:>7.1f}")
         ratio = max(v_stats['mean'], l_stats['mean']) / max(min(v_stats['mean'], l_stats['mean']), 0.001)
-        winner = "Cognevra" if v_stats['mean'] < l_stats['mean'] else "LanceDB"
+        winner = "Levara" if v_stats['mean'] < l_stats['mean'] else "LanceDB"
         print(f"\n  Winner: {winner} ({ratio:.1f}x faster)")
 
     # ── Step 4: Concurrent QPS ────────────────────────────────────────────
@@ -464,12 +464,12 @@ class TestComprehensiveComparison:
         print(f"  STEP 4: CONCURRENT QPS  ({len(QUERIES)} queries × {ROUNDS} rounds)")
         print("=" * 72)
 
-        # ── Cognevra ──
+        # ── Levara ──
         v_times = []
         async with aiohttp.ClientSession() as session:
             for _ in range(ROUNDS):
                 t0 = time.perf_counter()
-                await asyncio.gather(*[cognevra_search(session, qv, k=K) for qv in q_vecs])
+                await asyncio.gather(*[levara_search(session, qv, k=K) for qv in q_vecs])
                 v_times.append(time.perf_counter() - t0)
 
         # ── LanceDB ──
@@ -489,16 +489,16 @@ class TestComprehensiveComparison:
         l_mean_ms = statistics.mean(l_times) * 1000
 
         self.__class__._qps_results = {
-            "cognevra_qps": v_mean_qps, "lance_qps": l_mean_qps,
-            "cognevra_ms": v_mean_ms, "lance_ms": l_mean_ms,
+            "levara_qps": v_mean_qps, "lance_qps": l_mean_qps,
+            "levara_ms": v_mean_ms, "lance_ms": l_mean_ms,
         }
 
         print(f"\n  {'Provider':<30} {'avg QPS':>10} {'avg round ms':>14} {'best QPS':>10}")
         print(f"  {'-'*68}")
-        print(f"  {'Cognevra':<30} {v_mean_qps:>10,.0f} {v_mean_ms:>14.1f} {max(v_qps):>10,.0f}")
+        print(f"  {'Levara':<30} {v_mean_qps:>10,.0f} {v_mean_ms:>14.1f} {max(v_qps):>10,.0f}")
         print(f"  {'LanceDB':<30} {l_mean_qps:>10,.0f} {l_mean_ms:>14.1f} {max(l_qps):>10,.0f}")
         ratio = max(v_mean_qps, l_mean_qps) / max(min(v_mean_qps, l_mean_qps), 1)
-        winner = "Cognevra" if v_mean_qps > l_mean_qps else "LanceDB"
+        winner = "Levara" if v_mean_qps > l_mean_qps else "LanceDB"
         print(f"\n  Winner: {winner} ({ratio:.1f}x)")
 
     # ── Step 5: Keyword Hit Rate ──────────────────────────────────────────
@@ -512,12 +512,12 @@ class TestComprehensiveComparison:
         print(f"  STEP 5: KEYWORD HIT RATE  ({len(QUERIES)} queries, k={K})")
         print("=" * 72)
 
-        # ── Cognevra ──
+        # ── Levara ──
         v_hits = 0
         v_detail = []
         async with aiohttp.ClientSession() as session:
             for cq, qv in zip(QUERIES, q_vecs):
-                results = await cognevra_search(session, qv, k=K)
+                results = await levara_search(session, qv, k=K)
                 combined = " ".join(_extract_text(r) for r in results).lower()
                 hit = any(kw.lower() in combined for kw in cq["keywords"])
                 if hit:
@@ -540,11 +540,11 @@ class TestComprehensiveComparison:
         l_rate = l_hits / len(QUERIES)
 
         self.__class__._hit_rate_results = {
-            "cognevra_rate": v_rate, "lance_rate": l_rate,
-            "cognevra_hits": v_hits, "lance_hits": l_hits,
+            "levara_rate": v_rate, "lance_rate": l_rate,
+            "levara_hits": v_hits, "lance_hits": l_hits,
         }
 
-        print(f"\n  {'Query':<30} {'Cognevra':>10} {'LanceDB':>10}")
+        print(f"\n  {'Query':<30} {'Levara':>10} {'LanceDB':>10}")
         print(f"  {'-'*52}")
         for i, cq in enumerate(QUERIES):
             v_ok = "HIT" if v_detail[i][2] else "MISS"
@@ -582,8 +582,8 @@ class TestComprehensiveComparison:
                 sim_map = {idx: sim for idx, sim in bf_topk}
                 relevant_set = set(ideal_indices[:K])
 
-                # ── Cognevra results ──
-                v_results = await cognevra_search(session, qv, k=K)
+                # ── Levara results ──
+                v_results = await levara_search(session, qv, k=K)
                 v_indices = []
                 for r in v_results:
                     rid = r.get("id", "")
@@ -620,30 +620,30 @@ class TestComprehensiveComparison:
                 l_recall10.append(len(l_set & set(ideal_indices[:K])) / K)
 
         results = {
-            "cognevra_ndcg": statistics.mean(v_ndcgs),
+            "levara_ndcg": statistics.mean(v_ndcgs),
             "lance_ndcg": statistics.mean(l_ndcgs),
-            "cognevra_mrr": statistics.mean(v_mrrs),
+            "levara_mrr": statistics.mean(v_mrrs),
             "lance_mrr": statistics.mean(l_mrrs),
-            "cognevra_recall1": statistics.mean(v_recall1),
-            "cognevra_recall5": statistics.mean(v_recall5),
-            "cognevra_recall10": statistics.mean(v_recall10),
+            "levara_recall1": statistics.mean(v_recall1),
+            "levara_recall5": statistics.mean(v_recall5),
+            "levara_recall10": statistics.mean(v_recall10),
             "lance_recall1": statistics.mean(l_recall1),
             "lance_recall5": statistics.mean(l_recall5),
             "lance_recall10": statistics.mean(l_recall10),
         }
         self.__class__._ranking_results = results
 
-        print(f"\n  {'Metric':<30} {'Cognevra':>10} {'LanceDB':>10}")
+        print(f"\n  {'Metric':<30} {'Levara':>10} {'LanceDB':>10}")
         print(f"  {'-'*52}")
-        print(f"  {'NDCG@10':<30} {results['cognevra_ndcg']:>10.4f} {results['lance_ndcg']:>10.4f}")
-        print(f"  {'MRR':<30} {results['cognevra_mrr']:>10.4f} {results['lance_mrr']:>10.4f}")
-        print(f"  {'Recall@1':<30} {results['cognevra_recall1']:>10.4f} {results['lance_recall1']:>10.4f}")
-        print(f"  {'Recall@5':<30} {results['cognevra_recall5']:>10.4f} {results['lance_recall5']:>10.4f}")
-        print(f"  {'Recall@10':<30} {results['cognevra_recall10']:>10.4f} {results['lance_recall10']:>10.4f}")
+        print(f"  {'NDCG@10':<30} {results['levara_ndcg']:>10.4f} {results['lance_ndcg']:>10.4f}")
+        print(f"  {'MRR':<30} {results['levara_mrr']:>10.4f} {results['lance_mrr']:>10.4f}")
+        print(f"  {'Recall@1':<30} {results['levara_recall1']:>10.4f} {results['lance_recall1']:>10.4f}")
+        print(f"  {'Recall@5':<30} {results['levara_recall5']:>10.4f} {results['lance_recall5']:>10.4f}")
+        print(f"  {'Recall@10':<30} {results['levara_recall10']:>10.4f} {results['lance_recall10']:>10.4f}")
 
         # Per-query breakdown
         print(f"\n  Per-query NDCG@10:")
-        print(f"  {'Query':<30} {'Cognevra':>10} {'LanceDB':>10}")
+        print(f"  {'Query':<30} {'Levara':>10} {'LanceDB':>10}")
         print(f"  {'-'*52}")
         for i, cq in enumerate(QUERIES):
             print(f"  {cq['desc']:<30} {v_ndcgs[i]:>10.4f} {l_ndcgs[i]:>10.4f}")
@@ -676,16 +676,16 @@ class TestComprehensiveComparison:
         # affect timing, so just reuse)
         extra_vecs = [vecs[i % len(vecs)] for i in range(200)]
 
-        # ── Cognevra: search-only baseline ──
+        # ── Levara: search-only baseline ──
         baseline_lats = []
         async with aiohttp.ClientSession() as session:
             for i in range(N_SEARCH):
                 qv = q_vecs[i % len(q_vecs)]
                 t0 = time.perf_counter()
-                await cognevra_search(session, qv, k=K)
+                await levara_search(session, qv, k=K)
                 baseline_lats.append((time.perf_counter() - t0) * 1000)
 
-        # ── Cognevra: search with concurrent writes ──
+        # ── Levara: search with concurrent writes ──
         write_done = asyncio.Event()
         loaded_lats = []
 
@@ -698,7 +698,7 @@ class TestComprehensiveComparison:
                         "metadata": {"text": extra_chunks[j]["text"][:300],
                                      "chapter": extra_chunks[j]["chapter"]},
                     } for j in range(i, min(i + 10, 200))]
-                    await cognevra_insert(ws, batch)
+                    await levara_insert(ws, batch)
                     await asyncio.sleep(0.05)
             write_done.set()
 
@@ -707,7 +707,7 @@ class TestComprehensiveComparison:
                 for i in range(N_SEARCH):
                     qv = q_vecs[i % len(q_vecs)]
                     t0 = time.perf_counter()
-                    await cognevra_search(ss, qv, k=K)
+                    await levara_search(ss, qv, k=K)
                     loaded_lats.append((time.perf_counter() - t0) * 1000)
 
         await asyncio.gather(background_writer(), foreground_searcher())
@@ -751,7 +751,7 @@ class TestComprehensiveComparison:
             else:
                 collections["chapter_3"].append((i, c))
 
-        # ── Cognevra: insert with collection prefixes ──
+        # ── Levara: insert with collection prefixes ──
         async with aiohttp.ClientSession() as session:
             for col_name, col_chunks in collections.items():
                 if not col_chunks:
@@ -764,11 +764,11 @@ class TestComprehensiveComparison:
                                      "chapter": col_chunks[j][1]["chapter"],
                                      "collection": col_name},
                     } for j in range(start, min(start + 50, len(col_chunks)))]
-                    await cognevra_insert(session, batch)
+                    await levara_insert(session, batch)
 
         await asyncio.sleep(2)  # Let HNSW index
 
-        # ── Cognevra: search and check isolation ──
+        # ── Levara: search and check isolation ──
         leakage_count = 0
         total_checks = 0
 
@@ -779,7 +779,7 @@ class TestComprehensiveComparison:
 
                 # Use first chunk's vector as query
                 query_idx = col_chunks[0][0]
-                results = await cognevra_search(session, vecs[query_idx], k=20)
+                results = await levara_search(session, vecs[query_idx], k=20)
 
                 # Filter results by collection prefix
                 for r in results:
@@ -834,8 +834,8 @@ class TestComprehensiveComparison:
                     lance_leakage += 1
 
         self.__class__._isolation_results = {
-            "cognevra_leakage": leakage_count,
-            "cognevra_total": total_checks,
+            "levara_leakage": leakage_count,
+            "levara_total": total_checks,
             "lance_leakage": lance_leakage,
             "lance_total": lance_total,
         }
@@ -846,12 +846,12 @@ class TestComprehensiveComparison:
         print(f"\n  Collections: {', '.join(f'{k}({len(v)} chunks)' for k, v in collections.items())}")
         print(f"\n  {'Provider':<30} {'Leakage':>10} {'Total checks':>14} {'Rate':>8}")
         print(f"  {'-'*65}")
-        print(f"  {'Cognevra (prefix-based)':<30} {leakage_count:>10} {total_checks:>14} {leak_rate_v:>7.1f}%")
+        print(f"  {'Levara (prefix-based)':<30} {leakage_count:>10} {total_checks:>14} {leak_rate_v:>7.1f}%")
         print(f"  {'LanceDB (separate tables)':<30} {lance_leakage:>10} {lance_total:>14} {leak_rate_l:>7.1f}%")
 
         if leakage_count > 0:
-            print(f"\n  WARNING: Cognevra cross-collection leakage detected!")
-            print(f"  Cognevra uses prefix-based filtering, not physical isolation.")
+            print(f"\n  WARNING: Levara cross-collection leakage detected!")
+            print(f"  Levara uses prefix-based filtering, not physical isolation.")
             print(f"  For queries returning global IDs (comp:, bg:), this is expected.")
 
     # ── Step 9: Scale Test (5K-10K vectors) ──────────────────────────────
@@ -869,10 +869,10 @@ class TestComprehensiveComparison:
         print(f"  Base: {N_base} chunks × {MULTIPLIER} = ~{TARGET} vectors")
         print("=" * 72)
 
-        # Ensure Cognevra is healthy (may have crashed from accumulated data)
-        print(f"  Checking Cognevra health...")
-        if not await ensure_cognevra_healthy(max_wait=30):
-            pytest.skip("Cognevra not available for scale test")
+        # Ensure Levara is healthy (may have crashed from accumulated data)
+        print(f"  Checking Levara health...")
+        if not await ensure_levara_healthy(max_wait=30):
+            pytest.skip("Levara not available for scale test")
 
         # Generate scaled data (reuse vectors with unique IDs)
         scale_chunks = []
@@ -889,7 +889,7 @@ class TestComprehensiveComparison:
         N_scale = len(scale_chunks)
         BATCH = 100
 
-        # ── Cognevra: scale insert ──
+        # ── Levara: scale insert ──
         v_batch_lats = []
         async with aiohttp.ClientSession() as session:
             t0_total = time.perf_counter()
@@ -901,7 +901,7 @@ class TestComprehensiveComparison:
                                  "chapter": scale_chunks[i]["chapter"]},
                 } for i in range(start, min(start + BATCH, N_scale))]
                 t0 = time.perf_counter()
-                await cognevra_insert(session, batch)
+                await levara_insert(session, batch)
                 v_batch_lats.append((time.perf_counter() - t0) * 1000)
             t_v_insert = time.perf_counter() - t0_total
 
@@ -934,7 +934,7 @@ class TestComprehensiveComparison:
         print(f"\n  Insert throughput at scale ({N_scale} vectors):")
         print(f"  {'Provider':<30} {'dp/s':>10} {'total sec':>10}")
         print(f"  {'-'*52}")
-        print(f"  {'Cognevra':<30} {v_insert_dps:>10,.0f} {t_v_insert:>10.1f}")
+        print(f"  {'Levara':<30} {v_insert_dps:>10,.0f} {t_v_insert:>10.1f}")
         print(f"  {'LanceDB':<30} {l_insert_dps:>10,.0f} {t_l_insert:>10.1f}")
 
         # Wait for HNSW indexing
@@ -947,7 +947,7 @@ class TestComprehensiveComparison:
             for _ in range(PASSES):
                 for qv in q_vecs:
                     t0 = time.perf_counter()
-                    await cognevra_search(session, qv, k=K)
+                    await levara_search(session, qv, k=K)
                     v_lats.append((time.perf_counter() - t0) * 1000)
 
         l_lats = []
@@ -963,7 +963,7 @@ class TestComprehensiveComparison:
         print(f"\n  Search latency at scale ({N_scale} vectors):")
         print(f"  {'Provider':<30} {'p50':>7} {'p95':>7} {'p99':>7} {'mean':>7}  (ms)")
         print(f"  {'-'*65}")
-        print(f"  {'Cognevra':<30} {v_search_stats['p50']:>7.1f} {v_search_stats['p95']:>7.1f} {v_search_stats['p99']:>7.1f} {v_search_stats['mean']:>7.1f}")
+        print(f"  {'Levara':<30} {v_search_stats['p50']:>7.1f} {v_search_stats['p95']:>7.1f} {v_search_stats['p99']:>7.1f} {v_search_stats['mean']:>7.1f}")
         print(f"  {'LanceDB':<30} {l_search_stats['p50']:>7.1f} {l_search_stats['p95']:>7.1f} {l_search_stats['p99']:>7.1f} {l_search_stats['mean']:>7.1f}")
 
         # ── Recall at scale ──
@@ -977,7 +977,7 @@ class TestComprehensiveComparison:
                 bf_topk = brute_force_topk(qv, scale_vecs, k=K)
                 ideal_set = set(idx for idx, _ in bf_topk)
 
-                v_results = await cognevra_search(session, qv, k=K)
+                v_results = await levara_search(session, qv, k=K)
                 v_indices = set()
                 for r in v_results:
                     rid = r.get("id", "")
@@ -1000,7 +1000,7 @@ class TestComprehensiveComparison:
         print(f"\n  Recall@10 at scale (sampled {len(v_recall10_vals)} queries):")
         print(f"  {'Provider':<30} {'Recall@10':>10}")
         print(f"  {'-'*42}")
-        print(f"  {'Cognevra':<30} {v_recall_mean:>10.4f}")
+        print(f"  {'Levara':<30} {v_recall_mean:>10.4f}")
         print(f"  {'LanceDB':<30} {l_recall_mean:>10.4f}")
 
         # Compare with baseline
@@ -1009,25 +1009,25 @@ class TestComprehensiveComparison:
 
         self.__class__._scale_results = {
             "n_vectors": N_scale,
-            "cognevra_insert_dps": v_insert_dps,
+            "levara_insert_dps": v_insert_dps,
             "lance_insert_dps": l_insert_dps,
-            "cognevra_search_mean": v_search_stats["mean"],
+            "levara_search_mean": v_search_stats["mean"],
             "lance_search_mean": l_search_stats["mean"],
-            "cognevra_recall10": v_recall_mean,
+            "levara_recall10": v_recall_mean,
             "lance_recall10": l_recall_mean,
         }
 
         if baseline_latency and baseline_insert:
             v_lat_growth = ((v_search_stats["mean"] - baseline_latency.get("mean", 0))
                             / max(baseline_latency.get("mean", 1), 0.001)) * 100
-            v_tp_change = ((v_insert_dps - baseline_insert.get("cognevra_dps", 0))
-                           / max(baseline_insert.get("cognevra_dps", 1), 1)) * 100
+            v_tp_change = ((v_insert_dps - baseline_insert.get("levara_dps", 0))
+                           / max(baseline_insert.get("levara_dps", 1), 1)) * 100
 
             print(f"\n  Scale vs baseline ({N_base} → {N_scale} vectors, {MULTIPLIER}x):")
-            print(f"  Cognevra latency change: {v_lat_growth:+.1f}%")
-            print(f"  Cognevra throughput change: {v_tp_change:+.1f}%")
+            print(f"  Levara latency change: {v_lat_growth:+.1f}%")
+            print(f"  Levara throughput change: {v_tp_change:+.1f}%")
 
-    # ── Step 10: Crash Recovery (Cognevra only) ───────────────────────────
+    # ── Step 10: Crash Recovery (Levara only) ───────────────────────────
 
     @pytest.mark.asyncio
     async def test_10_crash_recovery(self, book_data):
@@ -1035,13 +1035,13 @@ class TestComprehensiveComparison:
         chunks, vecs, q_vecs = book_data
 
         print("\n" + "=" * 72)
-        print(f"  STEP 10: CRASH RECOVERY (Cognevra only)")
+        print(f"  STEP 10: CRASH RECOVERY (Levara only)")
         print("=" * 72)
 
-        # Ensure Cognevra is healthy first
-        if not await ensure_cognevra_healthy(max_wait=30):
-            self.__class__._crash_results = {"status": "SKIP", "reason": "Cognevra not available"}
-            pytest.skip("Cognevra not available for crash recovery test")
+        # Ensure Levara is healthy first
+        if not await ensure_levara_healthy(max_wait=30):
+            self.__class__._crash_results = {"status": "SKIP", "reason": "Levara not available"}
+            pytest.skip("Levara not available for crash recovery test")
 
         # Insert recovery test data
         RECOVERY_N = 500
@@ -1059,7 +1059,7 @@ class TestComprehensiveComparison:
                         "metadata": {"text": chunks[i]["text"][:300],
                                      "chapter": chunks[i]["chapter"]},
                     })
-                await cognevra_insert(session, batch)
+                await levara_insert(session, batch)
 
         inserted = len(recovery_ids)
         print(f"  Inserted {inserted} records with 'recovery:' prefix")
@@ -1069,22 +1069,22 @@ class TestComprehensiveComparison:
 
         # Verify pre-restart search works
         async with aiohttp.ClientSession() as session:
-            pre_results = await cognevra_search(session, vecs[0], k=50)
+            pre_results = await levara_search(session, vecs[0], k=50)
             pre_recovery = [r for r in pre_results if r.get("id", "").startswith("recovery:")]
             print(f"  Pre-restart: found {len(pre_recovery)} recovery records in top-50")
 
-        # Restart Cognevra container
-        print(f"  Restarting Cognevra container...")
+        # Restart Levara container
+        print(f"  Restarting Levara container...")
         cwd = str(Path(__file__).parent.parent)
         restart_ok = False
         try:
             result = subprocess.run(
-                ["docker", "compose", "restart", "cognevra"],
+                ["docker", "compose", "restart", "levara"],
                 capture_output=True, text=True, timeout=60,
                 cwd=cwd,
             )
             if result.returncode != 0:
-                for name in ["new_db-cognevra-1", "new-db-cognevra-1"]:
+                for name in ["new_db-levara-1", "new-db-levara-1"]:
                     result = subprocess.run(
                         ["docker", "restart", name],
                         capture_output=True, text=True, timeout=60,
@@ -1096,7 +1096,7 @@ class TestComprehensiveComparison:
             if not restart_ok:
                 print(f"  stderr: {result.stderr}")
                 result = subprocess.run(
-                    ["docker", "compose", "up", "-d", "cognevra"],
+                    ["docker", "compose", "up", "-d", "levara"],
                     capture_output=True, text=True, timeout=60,
                     cwd=cwd,
                 )
@@ -1107,21 +1107,21 @@ class TestComprehensiveComparison:
 
         if not restart_ok:
             self.__class__._crash_results = {"status": "SKIP", "reason": "container restart failed"}
-            pytest.skip("Could not restart Cognevra container")
+            pytest.skip("Could not restart Levara container")
 
-        # Wait for Cognevra to come back up (up to 60s)
-        print(f"  Waiting for Cognevra to recover...")
+        # Wait for Levara to come back up (up to 60s)
+        print(f"  Waiting for Levara to recover...")
         recovered = False
         for attempt in range(60):
             try:
                 async with aiohttp.ClientSession() as session:
                     async with session.get(
-                        f"{COGNEVRA_URL}/api/v1/info",
+                        f"{LEVARA_URL}/api/v1/info",
                         timeout=aiohttp.ClientTimeout(total=2),
                     ) as r:
                         if r.status == 200:
                             info = await r.json()
-                            print(f"  Cognevra back online (attempt {attempt + 1}): {info}")
+                            print(f"  Levara back online (attempt {attempt + 1}): {info}")
                             recovered = True
                             break
             except Exception:
@@ -1130,7 +1130,7 @@ class TestComprehensiveComparison:
 
         if not recovered:
             subprocess.run(
-                ["docker", "compose", "up", "-d", "cognevra"],
+                ["docker", "compose", "up", "-d", "levara"],
                 capture_output=True, text=True, timeout=60,
                 cwd=cwd,
             )
@@ -1138,7 +1138,7 @@ class TestComprehensiveComparison:
                 try:
                     async with aiohttp.ClientSession() as session:
                         async with session.get(
-                            f"{COGNEVRA_URL}/api/v1/info",
+                            f"{LEVARA_URL}/api/v1/info",
                             timeout=aiohttp.ClientTimeout(total=2),
                         ) as r:
                             if r.status == 200:
@@ -1149,8 +1149,8 @@ class TestComprehensiveComparison:
                 await asyncio.sleep(1)
 
         if not recovered:
-            self.__class__._crash_results = {"status": "FAIL", "reason": "Cognevra did not recover in 90s"}
-            pytest.fail("Cognevra did not come back online after restart")
+            self.__class__._crash_results = {"status": "FAIL", "reason": "Levara did not recover in 90s"}
+            pytest.fail("Levara did not come back online after restart")
 
         # Allow WAL recovery + HNSW rebuild
         await asyncio.sleep(8)
@@ -1160,9 +1160,9 @@ class TestComprehensiveComparison:
         crashed = False
         async with aiohttp.ClientSession() as session:
             for i in range(0, min(10, len(vecs))):
-                results = await cognevra_search_safe(session, vecs[i], k=50)
+                results = await levara_search_safe(session, vecs[i], k=50)
                 if not results and i == 0:
-                    print(f"  WARNING: Cognevra crashed during post-restart search!")
+                    print(f"  WARNING: Levara crashed during post-restart search!")
                     print(f"  This indicates a DiskStore.Read bug in WAL recovery.")
                     crashed = True
                     break
@@ -1178,7 +1178,7 @@ class TestComprehensiveComparison:
                 "sampled": 0,
                 "found": 0,
                 "recovery_rate": 0,
-                "note": "Cognevra panics on search after WAL recovery (DiskStore.Read makeslice)",
+                "note": "Levara panics on search after WAL recovery (DiskStore.Read makeslice)",
             }
             print(f"\n  {'Metric':<30} {'Value':>10}")
             print(f"  {'-'*42}")
@@ -1215,20 +1215,20 @@ class TestComprehensiveComparison:
 
         print("\n")
         print("=" * 80)
-        print("  COMPREHENSIVE COMPARISON: Cognevra vs LanceDB")
+        print("  COMPREHENSIVE COMPARISON: Levara vs LanceDB")
         print(f"  Book: «Ураган» (Джанет Эдвардс), {len(chunks)} base chunks, dim={DIM}")
         print(f"  Embeddings: pplx-embed-context-v1-0.6b (real)")
         print("=" * 80)
 
-        print(f"\n  {'#':<4} {'Test':<35} {'Cognevra':>12} {'LanceDB':>12} {'Winner':>10}")
+        print(f"\n  {'#':<4} {'Test':<35} {'Levara':>12} {'LanceDB':>12} {'Winner':>10}")
         print(f"  {'-'*75}")
 
         # Step 2: Insert
         ir = self.__class__._insert_results
         if ir:
-            c_val = f"{ir.get('cognevra_dps', 0):,.0f} dp/s"
+            c_val = f"{ir.get('levara_dps', 0):,.0f} dp/s"
             l_val = f"{ir.get('lance_dps', 0):,.0f} dp/s"
-            winner = "Cognevra" if ir.get('cognevra_dps', 0) > ir.get('lance_dps', 0) else "LanceDB"
+            winner = "Levara" if ir.get('levara_dps', 0) > ir.get('lance_dps', 0) else "LanceDB"
             print(f"  {'2':<4} {'Insert throughput':<35} {v_val:>12} {l_val:>12} {winner:>10}")
 
         # Step 3: Latency
@@ -1236,41 +1236,41 @@ class TestComprehensiveComparison:
         if lr:
             v_val = f"{lr.get('vectra', {}).get('mean', 0):.1f} ms"
             l_val = f"{lr.get('lance', {}).get('mean', 0):.1f} ms"
-            winner = "Cognevra" if lr.get('vectra', {}).get('mean', 999) < lr.get('lance', {}).get('mean', 999) else "LanceDB"
+            winner = "Levara" if lr.get('vectra', {}).get('mean', 999) < lr.get('lance', {}).get('mean', 999) else "LanceDB"
             print(f"  {'3':<4} {'Search latency (mean)':<35} {v_val:>12} {l_val:>12} {winner:>10}")
 
         # Step 4: QPS
         qr = self.__class__._qps_results
         if qr:
-            c_val = f"{qr.get('cognevra_qps', 0):,.0f} qps"
+            c_val = f"{qr.get('levara_qps', 0):,.0f} qps"
             l_val = f"{qr.get('lance_qps', 0):,.0f} qps"
-            winner = "Cognevra" if qr.get('cognevra_qps', 0) > qr.get('lance_qps', 0) else "LanceDB"
+            winner = "Levara" if qr.get('levara_qps', 0) > qr.get('lance_qps', 0) else "LanceDB"
             print(f"  {'4':<4} {'Concurrent QPS':<35} {v_val:>12} {l_val:>12} {winner:>10}")
 
         # Step 5: Hit rate
         hr = self.__class__._hit_rate_results
         if hr:
-            c_val = f"{hr.get('cognevra_rate', 0):.0%}"
+            c_val = f"{hr.get('levara_rate', 0):.0%}"
             l_val = f"{hr.get('lance_rate', 0):.0%}"
-            winner = "Cognevra" if hr.get('cognevra_rate', 0) >= hr.get('lance_rate', 0) else "LanceDB"
+            winner = "Levara" if hr.get('levara_rate', 0) >= hr.get('lance_rate', 0) else "LanceDB"
             print(f"  {'5':<4} {'Keyword hit rate':<35} {v_val:>12} {l_val:>12} {winner:>10}")
 
         # Step 6: Ranking
         rr = self.__class__._ranking_results
         if rr:
-            c_val = f"{rr.get('cognevra_ndcg', 0):.4f}"
+            c_val = f"{rr.get('levara_ndcg', 0):.4f}"
             l_val = f"{rr.get('lance_ndcg', 0):.4f}"
-            winner = "Cognevra" if rr.get('cognevra_ndcg', 0) >= rr.get('lance_ndcg', 0) else "LanceDB"
+            winner = "Levara" if rr.get('levara_ndcg', 0) >= rr.get('lance_ndcg', 0) else "LanceDB"
             print(f"  {'6':<4} {'NDCG@10':<35} {v_val:>12} {l_val:>12} {winner:>10}")
 
-            c_val = f"{rr.get('cognevra_mrr', 0):.4f}"
+            c_val = f"{rr.get('levara_mrr', 0):.4f}"
             l_val = f"{rr.get('lance_mrr', 0):.4f}"
-            winner = "Cognevra" if rr.get('cognevra_mrr', 0) >= rr.get('lance_mrr', 0) else "LanceDB"
+            winner = "Levara" if rr.get('levara_mrr', 0) >= rr.get('lance_mrr', 0) else "LanceDB"
             print(f"  {'6':<4} {'MRR':<35} {v_val:>12} {l_val:>12} {winner:>10}")
 
-            c_val = f"{rr.get('cognevra_recall10', 0):.4f}"
+            c_val = f"{rr.get('levara_recall10', 0):.4f}"
             l_val = f"{rr.get('lance_recall10', 0):.4f}"
-            winner = "Cognevra" if rr.get('cognevra_recall10', 0) >= rr.get('lance_recall10', 0) else "LanceDB"
+            winner = "Levara" if rr.get('levara_recall10', 0) >= rr.get('lance_recall10', 0) else "LanceDB"
             print(f"  {'6':<4} {'Recall@10':<35} {v_val:>12} {l_val:>12} {winner:>10}")
 
         # Step 7: Concurrent R+W
@@ -1287,7 +1287,7 @@ class TestComprehensiveComparison:
         # Step 8: Isolation
         iso = self.__class__._isolation_results
         if iso:
-            v_leak = iso.get("cognevra_leakage", 0)
+            v_leak = iso.get("levara_leakage", 0)
             l_leak = iso.get("lance_leakage", 0)
             print(f"  {'8':<4} {'Cross-collection leakage':<35} {v_leak:>12} {l_leak:>12} {'LanceDB' if v_leak > l_leak else 'Tie':>10}")
 
@@ -1295,9 +1295,9 @@ class TestComprehensiveComparison:
         sr = self.__class__._scale_results
         if sr:
             n = sr.get("n_vectors", 0)
-            c_val = f"{sr.get('cognevra_search_mean', 0):.1f} ms"
+            c_val = f"{sr.get('levara_search_mean', 0):.1f} ms"
             l_val = f"{sr.get('lance_search_mean', 0):.1f} ms"
-            winner = "Cognevra" if sr.get('cognevra_search_mean', 999) < sr.get('lance_search_mean', 999) else "LanceDB"
+            winner = "Levara" if sr.get('levara_search_mean', 999) < sr.get('lance_search_mean', 999) else "LanceDB"
             print(f"  {'9':<4} {'Scale search (' + str(n) + ' vecs)':<35} {v_val:>12} {l_val:>12} {winner:>10}")
 
         # Step 10: Crash recovery
@@ -1317,7 +1317,7 @@ class TestComprehensiveComparison:
         print(f"""
   РЕКОМЕНДАЦИЯ:
   ┌──────────────────────────────────────────────────────────────────────┐
-  │ Cognevra лучше когда:                                              │
+  │ Levara лучше когда:                                              │
   │   - Нужен отдельный сервер (microservice architecture)             │
   │   - Высокий concurrent throughput (HTTP pipelining)                │
   │   - WAL-based durability + crash recovery                          │

--- a/tests/test_context_extension.py
+++ b/tests/test_context_extension.py
@@ -20,7 +20,7 @@ import asyncio
 import aiohttp
 import pytest
 
-BASE = os.getenv("COGNEVRA_HTTP_URL", "http://localhost:8080/api/v1")
+BASE = os.getenv("LEVARA_HTTP_URL", "http://localhost:8080/api/v1")
 TIMEOUT = aiohttp.ClientTimeout(total=300)
 
 pytestmark = pytest.mark.asyncio

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -196,7 +196,7 @@ async def test_upload_csv_file():
     """Upload CSV file.
     Docs: https://docs.cognee.ai/core-concepts/main-operations/add
     """
-    csv_content = b"name,type,description\nCognevra,database,Vector DB\nNeo4j,database,Graph DB\nPostgreSQL,database,Relational DB"
+    csv_content = b"name,type,description\nLevara,database,Vector DB\nNeo4j,database,Graph DB\nPostgreSQL,database,Relational DB"
     async with aiohttp.ClientSession() as s:
         h, _ = await _auth(s)
         form = aiohttp.FormData()
@@ -209,7 +209,7 @@ async def test_upload_json_file():
     """Upload JSON file.
     Docs: https://docs.cognee.ai/core-concepts/main-operations/add
     """
-    json_content = b'[{"entity": "Cognevra", "type": "database"}, {"entity": "HNSW", "type": "algorithm"}]'
+    json_content = b'[{"entity": "Levara", "type": "database"}, {"entity": "HNSW", "type": "algorithm"}]'
     async with aiohttp.ClientSession() as s:
         h, _ = await _auth(s)
         form = aiohttp.FormData()
@@ -442,12 +442,12 @@ async def test_cognify_custom_prompt():
 
 # ═══════════════════════════════════════════════════════════
 # LOW PRIORITY: Multi-dataset search (/search/dual)
-# Cognevra extension — not in Cognee docs
+# Levara extension — not in Cognee docs
 # ═══════════════════════════════════════════════════════════
 
 async def test_dual_search():
     """Dual search across multiple collections with different dims.
-    Cognevra extension: POST /search/dual
+    Levara extension: POST /search/dual
     """
     async with aiohttp.ClientSession() as s:
         h, _ = await _auth(s)
@@ -463,12 +463,12 @@ async def test_dual_search():
 
 # ═══════════════════════════════════════════════════════════
 # LOW PRIORITY: Collections CRUD with metadata
-# Cognevra extension
+# Levara extension
 # ═══════════════════════════════════════════════════════════
 
 async def test_collection_create_with_dim():
     """Create collection with specific dim and model.
-    Cognevra extension: POST /collections
+    Levara extension: POST /collections
     """
     async with aiohttp.ClientSession() as s:
         h, _ = await _auth(s)
@@ -488,7 +488,7 @@ async def test_collection_create_with_dim():
 
 async def test_collection_meta_update():
     """Update collection metadata (model, version).
-    Cognevra extension: PUT /collections/:name/meta
+    Levara extension: PUT /collections/:name/meta
     """
     async with aiohttp.ClientSession() as s:
         h, _ = await _auth(s)
@@ -506,7 +506,7 @@ async def test_collection_meta_update():
 
 async def test_collection_list_with_metadata():
     """List collections returns metadata (dim, model, count).
-    Cognevra extension: GET /collections
+    Levara extension: GET /collections
     """
     async with aiohttp.ClientSession() as s:
         h, _ = await _auth(s)
@@ -522,12 +522,12 @@ async def test_collection_list_with_metadata():
 
 # ═══════════════════════════════════════════════════════════
 # LOW PRIORITY: Re-embed endpoint
-# Cognevra extension
+# Levara extension
 # ═══════════════════════════════════════════════════════════
 
 async def test_reembed_empty_source():
     """Re-embed from empty source → completes with 0 records.
-    Cognevra extension: POST /reembed
+    Levara extension: POST /reembed
     """
     async with aiohttp.ClientSession() as s:
         h, _ = await _auth(s)
@@ -705,7 +705,7 @@ async def test_memify_node_type_filter():
 
 async def test_health_details_all_services():
     """Health details shows all 7 services.
-    Cognevra extension: GET /health/details
+    Levara extension: GET /health/details
     """
     async with aiohttp.ClientSession() as s:
         async with s.get(f"{MCP_URL}/health/details") as r:
@@ -725,7 +725,7 @@ async def test_metrics_endpoint():
         async with s.get(f"{MCP_URL}/metrics") as r:
             assert r.status == 200
             text = await r.text()
-            assert "cognevra" in text.lower() or "go_" in text or "process_" in text
+            assert "levara" in text.lower() or "go_" in text or "process_" in text
 
 
 # ═══════════════════════════════════════════════════════════

--- a/tests/test_dataset_ui.py
+++ b/tests/test_dataset_ui.py
@@ -6,7 +6,7 @@ import pytest
 from playwright.sync_api import Page, expect
 
 BASE = "http://localhost:3000"
-EMAIL = "admin@cognevra.dev"
+EMAIL = "admin@levara.dev"
 PASSWORD = "admin123456"
 
 
@@ -87,7 +87,7 @@ def test_mcp_shows_services(page: Page):
     page.wait_for_timeout(3000)
     body = page.inner_text("body")
     # Should show backend service
-    assert "Backend" in body or "Cognevra" in body or "connected" in body.lower()
+    assert "Backend" in body or "Levara" in body or "connected" in body.lower()
 
 def test_mcp_shows_tools(page: Page):
     login(page)

--- a/tests/test_e2e_add_pipeline.py
+++ b/tests/test_e2e_add_pipeline.py
@@ -2,7 +2,7 @@
 
 Tests: IngestData, ExtractText (tabula: PDF/DOCX/PPTX/XLSX/HTML),
 dedup, incremental, Cyrillic, mixed batch, markdown export.
-Requires: Cognevra gRPC:50051, embed-server:9001 (for some tests).
+Requires: Levara gRPC:50051, embed-server:9001 (for some tests).
 """
 import grpc
 import json
@@ -13,8 +13,8 @@ from pathlib import Path
 
 import pytest
 
-pb = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2")
-pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2_grpc")
+pb = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2")
+pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2_grpc")
 if pb is None or pb_grpc is None:
     pytest.skip("Proto stubs not loaded", allow_module_level=True)
 
@@ -28,8 +28,8 @@ def _stub():
     try:
         grpc.channel_ready_future(ch).result(timeout=3)
     except grpc.FutureTimeoutError:
-        pytest.skip("Cognevra not running")
-    return pb_grpc.CognevraServiceStub(ch), ch
+        pytest.skip("Levara not running")
+    return pb_grpc.LevaraServiceStub(ch), ch
 
 
 # ── ADD: Text ──

--- a/tests/test_e2e_search_all_types.py
+++ b/tests/test_e2e_search_all_types.py
@@ -2,7 +2,7 @@
 
 Setup: ingest texts, embed, index to vector + BM25.
 Then test every search type.
-Requires: Cognevra gRPC:50051, embed-server:9001.
+Requires: Levara gRPC:50051, embed-server:9001.
 """
 import grpc
 import json
@@ -12,8 +12,8 @@ import urllib.request
 
 import pytest
 
-pb = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2")
-pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2_grpc")
+pb = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2")
+pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2_grpc")
 if pb is None or pb_grpc is None:
     pytest.skip("Proto stubs not loaded", allow_module_level=True)
 
@@ -33,12 +33,12 @@ def _check():
         return False
 
 
-pytestmark = pytest.mark.skipif(not _check(), reason="Need embed-server + Cognevra")
+pytestmark = pytest.mark.skipif(not _check(), reason="Need embed-server + Levara")
 
 
 def _stub():
     ch = grpc.insecure_channel(GRPC)
-    return pb_grpc.CognevraServiceStub(ch), ch
+    return pb_grpc.LevaraServiceStub(ch), ch
 
 
 def _embed(texts):
@@ -56,7 +56,7 @@ def setup_data():
         ("s1", "Quantum computers use qubits for superposition and entanglement"),
         ("s2", "Natural language processing analyzes text using transformers"),
         ("s3", "HNSW algorithm provides fast approximate nearest neighbor search"),
-        ("s4", "In March 2024 Cognevra released v1.0 with WAL support"),
+        ("s4", "In March 2024 Levara released v1.0 with WAL support"),
         ("s5", "BM25 is a probabilistic ranking function for keyword retrieval"),
     ]
     vecs = _embed([t for _, t in docs])
@@ -151,7 +151,7 @@ class TestTemporalSearch:
     def test_06_temporal_range(self, setup_data):
         stub, ch = _stub()
         # Use doc s4 directly which has "March 2024"
-        text = "In March 2024 Cognevra released v1.0. On 2024-06-15 gRPC was added."
+        text = "In March 2024 Levara released v1.0. On 2024-06-15 gRPC was added."
         resp = stub.TemporalSearch(pb.TemporalSearchReq(
             text=text, date_from="2024-01-01", date_to="2024-12-31"))
         assert resp.total_extracted >= 1

--- a/tests/test_embed_optimization.py
+++ b/tests/test_embed_optimization.py
@@ -11,7 +11,7 @@ Each experiment records a ResultRecord; the final test prints a comparison table
 
 Requires running stack:
   - embed-server on :9001 (pplx-embed-context-v1-0.6b, dim=1024)
-  - Cognevra on :8080 (dim=1024, 3 shards)
+  - Levara on :8080 (dim=1024, 3 shards)
 
 Run:
     pytest tests/test_embed_optimization.py -v -s
@@ -34,7 +34,7 @@ import pytest
 
 BOOK_PATH = Path(__file__).parent.parent / "Edvards_Dzanet_Uragan_r4_P61XH.txt"
 EMBED_URL = "http://localhost:9001/v1/embeddings"
-COGNEVRA_URL = "http://localhost:8080"
+LEVARA_URL = "http://localhost:8080"
 EMBED_MODEL = "pplx-embed-context-v1-0.6b"
 DIM = 1024
 MIN_CHUNK_CHARS = 80
@@ -60,7 +60,7 @@ def _stack_available() -> bool:
 
 pytestmark = pytest.mark.skipif(
     not _stack_available(),
-    reason="Real stack not running (need embed-server:9001 + Cognevra:8080)",
+    reason="Real stack not running (need embed-server:9001 + Levara:8080)",
 )
 
 
@@ -192,20 +192,20 @@ async def embed_texts_concurrent(
     return results  # type: ignore[return-value]
 
 
-# ── Cognevra client ──────────────────────────────────────────────────────────
+# ── Levara client ──────────────────────────────────────────────────────────
 
-async def cognevra_insert(
+async def levara_insert(
     session: aiohttp.ClientSession,
     records: List[dict],
 ) -> dict:
     payload = {"records": records}
     async with session.post(
-        f"{COGNEVRA_URL}/api/v1/batch_insert", json=payload,
+        f"{LEVARA_URL}/api/v1/batch_insert", json=payload,
     ) as resp:
         if resp.status == 404:
             for rec in records:
                 async with session.post(
-                    f"{COGNEVRA_URL}/api/v1/insert", json=rec,
+                    f"{LEVARA_URL}/api/v1/insert", json=rec,
                 ) as r:
                     r.raise_for_status()
             return {"inserted": len(records), "failed": 0}
@@ -213,14 +213,14 @@ async def cognevra_insert(
         return await resp.json()
 
 
-async def cognevra_search(
+async def levara_search(
     session: aiohttp.ClientSession,
     vector: List[float],
     k: int = 10,
 ) -> List[dict]:
     payload = {"vector": vector, "k": k}
     async with session.post(
-        f"{COGNEVRA_URL}/api/v1/search", json=payload,
+        f"{LEVARA_URL}/api/v1/search", json=payload,
     ) as resp:
         resp.raise_for_status()
         data = await resp.json()
@@ -273,7 +273,7 @@ async def _measure_hit_rate(
     query_vectors = await embed_texts(session, query_texts)
     hits = 0
     for cq, qvec in zip(CONTEXTUAL_QUERIES, query_vectors):
-        results = await cognevra_search(session, qvec, k=10)
+        results = await levara_search(session, qvec, k=10)
         combined = " ".join(
             r.get("metadata", {}).get("text", "") for r in results
         ).lower()
@@ -298,7 +298,7 @@ async def _insert_with_prefix(
 
     t0 = time.perf_counter()
     for start in range(0, len(records), insert_batch):
-        await cognevra_insert(session, records[start:start + insert_batch])
+        await levara_insert(session, records[start:start + insert_batch])
     return time.perf_counter() - t0
 
 
@@ -573,7 +573,7 @@ class TestPipelineOverlap:
                             "chapter": c["chapter"],
                         },
                     } for c, v in zip(batch_chunks, vecs)]
-                    await cognevra_insert(session, records)
+                    await levara_insert(session, records)
                     inserted_count += len(records)
 
             # Also measure embed-only time for comparison

--- a/tests/test_final_features.py
+++ b/tests/test_final_features.py
@@ -28,7 +28,7 @@ Integration (2):
   test_all_search_types_work            Все search types → 200
   test_full_system_health               /health/details + /metrics + /errors + /cache/stats
 
-Requires: Cognevra HTTP :8080, embed-server :9001.
+Requires: Levara HTTP :8080, embed-server :9001.
 НЕ используем pytest.skip() — если сервис упал, тест FAIL.
 """
 import asyncio
@@ -756,7 +756,7 @@ async def test_full_system_health():
             )
             text = await r.text()
             assert len(text) > 0, "GET /metrics пустой ответ"
-            assert "HELP" in text or "TYPE" in text or "cognevra_" in text, (
+            assert "HELP" in text or "TYPE" in text or "levara_" in text, (
                 f"GET /metrics не prometheus format. Начало: {text[:200]}"
             )
 

--- a/tests/test_functional_cognee.py
+++ b/tests/test_functional_cognee.py
@@ -1,7 +1,7 @@
 """Functional tests for Cognee full platform (add → cognify → search).
 
-Mirror of test_functional_cognevra.py — same operations, same data, same assertions.
-Uses: Cognee API:8002 (includes Cognevra + Neo4j + PostgreSQL + Redis).
+Mirror of test_functional_levara.py — same operations, same data, same assertions.
+Uses: Cognee API:8002 (includes Levara + Neo4j + PostgreSQL + Redis).
 """
 import asyncio
 import io
@@ -189,20 +189,20 @@ class TestFunctionalCognee:
 
     # ── 4. Collection management ──
 
-    def test_08_cognevra_collections_created(self, state):
+    def test_08_levara_collections_created(self, state):
         """Cognify should have created vector collections."""
         import grpc
         try:
             ch = grpc.insecure_channel("localhost:50051")
             grpc.channel_ready_future(ch).result(timeout=3)
             import sys
-            _pb = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2")
-            _pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2_grpc")
-            stub = _pb_grpc.CognevraServiceStub(ch)
+            _pb = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2")
+            _pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2_grpc")
+            stub = _pb_grpc.LevaraServiceStub(ch)
             resp = stub.ListCollections(_pb.Empty())
             colls = list(resp.collections)
             ch.close()
-            print(f"\n  Cognevra collections ({len(colls)}): {colls}")
+            print(f"\n  Levara collections ({len(colls)}): {colls}")
             assert len(colls) > 0
         except Exception as e:
             print(f"\n  Collection check: {e}")

--- a/tests/test_go_rpcs_real_data.py
+++ b/tests/test_go_rpcs_real_data.py
@@ -1,7 +1,7 @@
 """A2: Test new Go RPCs (SearchTriplets, DeduplicateGraph, BatchEmbedAndIndex)
 with real book data and real embeddings. No mocks.
 
-Requires: embed-server:9001, Cognevra gRPC:50051.
+Requires: embed-server:9001, Levara gRPC:50051.
 """
 import grpc
 import json
@@ -11,8 +11,8 @@ import uuid
 
 import pytest
 
-pb = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2")
-pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2_grpc")
+pb = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2")
+pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2_grpc")
 if pb is None or pb_grpc is None:
     pytest.skip("Proto stubs not loaded", allow_module_level=True)
 
@@ -22,7 +22,7 @@ def _channel():
     try:
         grpc.channel_ready_future(ch).result(timeout=3)
     except grpc.FutureTimeoutError:
-        pytest.skip("Cognevra not running on localhost:50051")
+        pytest.skip("Levara not running on localhost:50051")
     return ch
 
 
@@ -57,7 +57,7 @@ class TestDeduplicateGraphRealData:
 
     def test_dedup_removes_duplicates(self):
         ch = _channel()
-        stub = pb_grpc.CognevraServiceStub(ch)
+        stub = pb_grpc.LevaraServiceStub(ch)
 
         # Add duplicates
         nodes = []
@@ -91,7 +91,7 @@ class TestDeduplicateGraphRealData:
 
     def test_triplet_text_format(self):
         ch = _channel()
-        stub = pb_grpc.CognevraServiceStub(ch)
+        stub = pb_grpc.LevaraServiceStub(ch)
 
         resp = stub.DeduplicateGraph(pb.DeduplicateGraphReq(
             nodes=[
@@ -118,7 +118,7 @@ class TestDeduplicateGraphRealData:
     def test_uuid5_deterministic(self):
         """Triplet IDs should be deterministic (same input → same UUID5)."""
         ch = _channel()
-        stub = pb_grpc.CognevraServiceStub(ch)
+        stub = pb_grpc.LevaraServiceStub(ch)
 
         req = pb.DeduplicateGraphReq(
             nodes=[pb.DedupNodeMsg(id="a", name="A"), pb.DedupNodeMsg(id="b", name="B")],
@@ -135,7 +135,7 @@ class TestBatchEmbedAndIndexRealData:
 
     def test_embed_and_index_characters(self):
         ch = _channel()
-        stub = pb_grpc.CognevraServiceStub(ch)
+        stub = pb_grpc.LevaraServiceStub(ch)
 
         items = [
             pb.IndexItem(id=cid, text=f"{name}: {desc}", metadata_json=json.dumps({"name": name}))
@@ -179,7 +179,7 @@ class TestBatchEmbedAndIndexRealData:
     def test_multi_group_embed(self):
         """Embed+index multiple collections in one call."""
         ch = _channel()
-        stub = pb_grpc.CognevraServiceStub(ch)
+        stub = pb_grpc.LevaraServiceStub(ch)
 
         resp = stub.BatchEmbedAndIndex(pb.BatchEmbedAndIndexReq(
             groups=[
@@ -208,7 +208,7 @@ class TestSearchTripletsRealData:
 
     def test_search_with_character_graph(self):
         ch = _channel()
-        stub = pb_grpc.CognevraServiceStub(ch)
+        stub = pb_grpc.LevaraServiceStub(ch)
 
         # Build graph
         nodes = [
@@ -259,7 +259,7 @@ class TestSearchTripletsRealData:
     def test_performance_large_graph(self):
         """1000+ edges should complete in <10ms."""
         ch = _channel()
-        stub = pb_grpc.CognevraServiceStub(ch)
+        stub = pb_grpc.LevaraServiceStub(ch)
 
         nodes = [pb.TripletNode(id=f"n{i}", name=f"Entity{i}") for i in range(200)]
         edges = [

--- a/tests/test_graph_search.py
+++ b/tests/test_graph_search.py
@@ -78,7 +78,7 @@ Integration Tests (3):
 
 Итого: 18 тестов.
 
-Requires: Cognevra HTTP :8080. Neo4j, LLM — опционально (skip если нет).
+Requires: Levara HTTP :8080. Neo4j, LLM — опционально (skip если нет).
 """
 import os
 import time
@@ -87,7 +87,7 @@ import asyncio
 import pytest
 import aiohttp
 
-BASE = os.getenv("COGNEVRA_HTTP_URL", "http://localhost:8080/api/v1")
+BASE = os.getenv("LEVARA_HTTP_URL", "http://localhost:8080/api/v1")
 BASE_ROOT = BASE.rsplit("/api/v1", 1)[0]  # http://localhost:8080
 
 pytestmark = pytest.mark.asyncio

--- a/tests/test_http_functional.py
+++ b/tests/test_http_functional.py
@@ -420,7 +420,7 @@ async def test_settings_get_defaults():
         async with s.get(f"{BASE_URL}/settings") as r:
             assert r.status == 200
             data = await r.json()
-            assert data["vector_engine"] == "cognevra"
+            assert data["vector_engine"] == "levara"
             assert "embedding_dimension" in data
 
 async def test_settings_put():

--- a/tests/test_http_smoke.py
+++ b/tests/test_http_smoke.py
@@ -167,7 +167,7 @@ async def test_settings_get():
         async with s.get(f"{BASE_URL}/settings") as r:
             assert r.status == 200
             data = await r.json()
-            assert data["vector_engine"] == "cognevra"
+            assert data["vector_engine"] == "levara"
             assert "chunk_strategy" in data
             assert "embedding_dimension" in data
 

--- a/tests/test_integration_real.py
+++ b/tests/test_integration_real.py
@@ -67,7 +67,7 @@ async def test_int_cognify_writes_graph():
             ds_id = (await r.json())["id"]
 
         async with s.post(f"{BASE_URL}/cognify", json={
-            "texts": ["Cognevra uses HNSW indexing. It was created by stek0v for fast vector search."],
+            "texts": ["Levara uses HNSW indexing. It was created by stek0v for fast vector search."],
             "datasetIds": [ds_id],
         }, headers=h) as r:
             run_id = (await r.json())["pipeline_run_id"]

--- a/tests/test_journey_basic_rag.py
+++ b/tests/test_journey_basic_rag.py
@@ -1,5 +1,5 @@
 """Journey A: Basic RAG Application — add → cognify → search.
-The core 3-step user journey that every Cognee/Cognevra user follows.
+The core 3-step user journey that every Cognee/Levara user follows.
 Tests the complete pipeline from data ingestion to search results.
 """
 import asyncio
@@ -25,7 +25,7 @@ async def test_add_text_returns_ok():
     async with aiohttp.ClientSession() as s:
         h = await _auth(s)
         async with s.post(f"{BASE_URL}/add",
-            data="Cognevra is a high-performance vector database written in Go. "
+            data="Levara is a high-performance vector database written in Go. "
                  "It uses HNSW indexing with WAL durability for crash recovery.",
             headers={**h, "Content-Type": "text/plain"}
         ) as r:
@@ -143,7 +143,7 @@ async def test_upload_file_multipart():
         h = await _auth(s)
         form = aiohttp.FormData()
         form.add_field("data",
-            b"Chapter 1: Introduction\n\nCognevra is a vector database that combines "
+            b"Chapter 1: Introduction\n\nLevara is a vector database that combines "
             b"HNSW indexing with WAL durability. It supports both HTTP and gRPC APIs.\n\n"
             b"Chapter 2: Architecture\n\nThe system uses sharded HNSW indexes with "
             b"memory-mapped arenas for efficient vector storage.",

--- a/tests/test_journey_config_settings.py
+++ b/tests/test_journey_config_settings.py
@@ -26,7 +26,7 @@ async def test_get_default_settings():
         async with s.get(f"{BASE_URL}/settings", headers=h) as r:
             assert r.status == 200
             data = await r.json()
-            assert data["vector_engine"] == "cognevra"
+            assert data["vector_engine"] == "levara"
             assert "embedding_model" in data
             assert "embedding_dimension" in data
             assert "llm_provider" in data

--- a/tests/test_new_ui_features.py
+++ b/tests/test_new_ui_features.py
@@ -19,9 +19,9 @@ import uuid
 import pytest
 import aiohttp
 
-BASE = os.getenv("COGNEVRA_HTTP_URL", "http://localhost:8080/api/v1")
+BASE = os.getenv("LEVARA_HTTP_URL", "http://localhost:8080/api/v1")
 BASE_ROOT = BASE.rsplit("/api/v1", 1)[0]  # http://localhost:8080
-FRONTEND = os.getenv("COGNEVRA_FRONTEND_URL", "http://localhost:3000")
+FRONTEND = os.getenv("LEVARA_FRONTEND_URL", "http://localhost:3000")
 
 pytestmark = pytest.mark.asyncio
 

--- a/tests/test_new_ui_screenshots.py
+++ b/tests/test_new_ui_screenshots.py
@@ -9,8 +9,8 @@ from playwright.sync_api import Page
 
 BASE = "http://localhost:3000"
 API = "http://localhost:8080/api/v1"
-DIR = "/tmp/cognevra_screenshots_new"
-EMAIL = "admin@cognevra.dev"
+DIR = "/tmp/levara_screenshots_new"
+EMAIL = "admin@levara.dev"
 PASSWORD = "admin123456"
 
 os.makedirs(DIR, exist_ok=True)

--- a/tests/test_phase2_features.py
+++ b/tests/test_phase2_features.py
@@ -82,7 +82,7 @@ Rate Limiting (4):
   test_rate_limit_provider_stable       #8 3 sequential cognify → all COMPLETED
   test_rate_limit_concurrent            #8 2 concurrent cognify → no deadlock
 
-Requires: Cognevra HTTP :8080, embed-server :9001, CLI binary.
+Requires: Levara HTTP :8080, embed-server :9001, CLI binary.
 НЕ используем pytest.skip() — если сервис упал, тест FAIL.
 """
 import asyncio
@@ -104,7 +104,7 @@ pytestmark = pytest.mark.asyncio
 
 BASE = BASE_URL  # http://localhost:8080/api/v1
 TIMEOUT = aiohttp.ClientTimeout(total=300)
-CLI = os.path.join(os.path.dirname(__file__), "..", "Cognevra", "cognevra")
+CLI = os.path.join(os.path.dirname(__file__), "..", "Levara", "levara")
 
 # Тестовый Python-код для code extraction
 PYTHON_CODE = (
@@ -494,44 +494,44 @@ async def test_code_search_after_cognify():
 
 
 def test_cli_health():
-    """DoD: cognevra health → exit code 0, output contains "HEALTHY".
+    """DoD: levara health → exit code 0, output contains "HEALTHY".
     Проверяет: CLI binary существует и может проверить здоровье сервера.
     Риски: #6 (CLI binary не собран).
     """
     rc, stdout, stderr = _run_cli("health")
     assert rc == 0, (
-        f"cognevra health exit code={rc}. "
+        f"levara health exit code={rc}. "
         f"#6: CLI binary не найден или не работает. "
         f"stderr: {stderr[:300]}"
     )
     output = (stdout + stderr).upper()
     assert "HEALTHY" in output or "OK" in output, (
-        f"cognevra health не содержит HEALTHY/OK. "
+        f"levara health не содержит HEALTHY/OK. "
         f"#6: сервер не отвечает? stdout: {stdout[:300]}"
     )
 
 
 def test_cli_datasets_list():
-    """DoD: cognevra datasets list → exit code 0, output содержит table.
+    """DoD: levara datasets list → exit code 0, output содержит table.
     Проверяет: CLI может показать список datasets.
     Риски: #6 (binary missing), #7 (output format).
     """
     rc, stdout, stderr = _run_cli("datasets", "list")
     assert rc == 0, (
-        f"cognevra datasets list exit code={rc}. "
+        f"levara datasets list exit code={rc}. "
         f"#6: CLI не работает. stderr: {stderr[:300]}"
     )
     # Минимальная проверка — вывод не пустой (может быть пустая таблица)
     output = stdout + stderr
     assert len(output.strip()) > 0, (
-        f"cognevra datasets list — пустой вывод. "
+        f"levara datasets list — пустой вывод. "
         f"#7: формат вывода изменился или endpoint не работает"
     )
 
 
 def test_cli_add_and_search():
-    """DoD: cognevra add "Test CLI text" → exit 0.
-    cognevra search "CLI text" → exit 0, output содержит results.
+    """DoD: levara add "Test CLI text" → exit 0.
+    levara search "CLI text" → exit 0, output содержит results.
     Проверяет: CLI round-trip add → search.
     Риски: #6 (binary missing).
     """
@@ -539,36 +539,36 @@ def test_cli_add_and_search():
     test_text = f"Test CLI text for phase2 {uuid.uuid4().hex[:8]}"
     rc, stdout, stderr = _run_cli("add", test_text)
     assert rc == 0, (
-        f"cognevra add exit code={rc}. "
+        f"levara add exit code={rc}. "
         f"#6: CLI add не работает. stderr: {stderr[:300]}"
     )
 
     # Search
     rc, stdout, stderr = _run_cli("search", "CLI text")
     assert rc == 0, (
-        f"cognevra search exit code={rc}. "
+        f"levara search exit code={rc}. "
         f"#6: CLI search не работает. stderr: {stderr[:300]}"
     )
     output = stdout + stderr
     assert len(output.strip()) > 0, (
-        f"cognevra search — пустой вывод. "
+        f"levara search — пустой вывод. "
         f"#6: search не вернул результатов"
     )
 
 
 def test_cli_cache_stats():
-    """DoD: cognevra cache stats → exit 0, output содержит "Size" или "Hits".
+    """DoD: levara cache stats → exit 0, output содержит "Size" или "Hits".
     Проверяет: CLI cache stats endpoint работает.
     Риски: #6 (binary missing), #7 (output format).
     """
     rc, stdout, stderr = _run_cli("cache", "stats")
     assert rc == 0, (
-        f"cognevra cache stats exit code={rc}. "
+        f"levara cache stats exit code={rc}. "
         f"#6: CLI не работает. stderr: {stderr[:300]}"
     )
     output = (stdout + stderr).lower()
     assert "size" in output or "hits" in output or "cache" in output, (
-        f"cognevra cache stats не содержит Size/Hits/Cache. "
+        f"levara cache stats не содержит Size/Hits/Cache. "
         f"#7: формат вывода изменился. stdout: {stdout[:300]}"
     )
 

--- a/tests/test_phase3_enterprise.py
+++ b/tests/test_phase3_enterprise.py
@@ -14,7 +14,7 @@
    Импакт: средний — ops не видит состояние sub-services.
    Тесты: test_health_details_format, test_storage_backend_info.
 
-3. /metrics не содержит cognevra_ prefix (#METRICS_EMPTY)
+3. /metrics не содержит levara_ prefix (#METRICS_EMPTY)
    Вероятность: низкая (Prometheus уже подключен по CLAUDE.md).
    Импакт: средний — Grafana dashboards не работают.
    Тесты: test_metrics_endpoint.
@@ -59,7 +59,7 @@ Integration (2):
   test_full_pipeline_all_phases       #7 add → cognify(session) → search(GRAPH)
   test_cache_stats_after_pipeline     #6 pipeline → cache/stats → size > 0
 
-Requires: Cognevra HTTP :8080, embed-server :9001.
+Requires: Levara HTTP :8080, embed-server :9001.
 НЕ используем pytest.skip() — если сервис упал, тест FAIL.
 """
 import asyncio
@@ -251,9 +251,9 @@ async def test_health_details_format():
 
 
 async def test_metrics_endpoint():
-    """DoD: GET /metrics → 200, содержит prometheus format (cognevra_ prefix).
+    """DoD: GET /metrics → 200, содержит prometheus format (levara_ prefix).
     Проверяет: Prometheus метрики доступны с правильным namespace.
-    Риски: #3 (metrics не содержит cognevra_ prefix).
+    Риски: #3 (metrics не содержит levara_ prefix).
     """
     async with aiohttp.ClientSession(timeout=TIMEOUT) as s:
         # /metrics обычно без авторизации (Prometheus scraping)
@@ -268,15 +268,15 @@ async def test_metrics_endpoint():
                 f"#3: prometheus exporter не настроен"
             )
             # Prometheus format: строки с # HELP, # TYPE, или metric_name{labels} value
-            assert "cognevra_" in text or "HELP" in text or "TYPE" in text, (
+            assert "levara_" in text or "HELP" in text or "TYPE" in text, (
                 f"GET /metrics не содержит prometheus format. "
                 f"Начало ответа: {text[:300]}. "
                 f"#3: формат метрик не Prometheus"
             )
-            # Предпочтительно — наличие cognevra_ prefix
-            if "cognevra_" not in text:
+            # Предпочтительно — наличие levara_ prefix
+            if "levara_" not in text:
                 # Не fatal, но warning: метрики без namespace
-                pass  # допускаем метрики без cognevra_ prefix
+                pass  # допускаем метрики без levara_ prefix
 
 
 async def test_server_logs_json():

--- a/tests/test_pi_deployment.py
+++ b/tests/test_pi_deployment.py
@@ -1,7 +1,7 @@
 """Тесты для Raspberry Pi deployment: SQLite, Git Analyzer, Memory, Chat History.
 
 Works with BOTH PostgreSQL and SQLite backends.
-Requires running Cognevra server (Go).
+Requires running Levara server (Go).
 """
 import subprocess
 import uuid
@@ -25,7 +25,7 @@ def _session():
 
 async def _register_and_token(session: aiohttp.ClientSession):
     """Register a fresh user and return (email, token)."""
-    email = f"pi_{uuid.uuid4().hex[:8]}@cognevra.dev"
+    email = f"pi_{uuid.uuid4().hex[:8]}@levara.dev"
     password = "pipass123456"
     await session.post(
         f"{BASE_URL}/auth/register",
@@ -84,7 +84,7 @@ class TestSQLite:
     async def test_sqlite_auth(self):
         """Register + login works on SQLite."""
         async with _session() as s:
-            email = f"sqlite_{uuid.uuid4().hex[:8]}@cognevra.dev"
+            email = f"sqlite_{uuid.uuid4().hex[:8]}@levara.dev"
             password = "sqlitepass123"
 
             # Register
@@ -192,10 +192,10 @@ class TestGitAnalyzer:
             assert not is_error
 
     async def test_git_analyze_cli(self):
-        """CLI `cognevra git analyze` exits with 0."""
+        """CLI `levara git analyze` exits with 0."""
         result = subprocess.run(
-            ["./cognevra", "git", "analyze", "--limit=3"],
-            cwd="/Users/stek0v/src/new_db/Cognevra",
+            ["./levara", "git", "analyze", "--limit=3"],
+            cwd="/Users/stek0v/src/new_db/Levara",
             capture_output=True,
             text=True,
             timeout=60,

--- a/tests/test_rag_cases.py
+++ b/tests/test_rag_cases.py
@@ -11,7 +11,7 @@ Tests here target vector DB layer (no LLM required):
 
 Requires:
   - embed-server on :9001 (pplx-embed-context-v1-0.6b, dim=1024)
-  - Cognevra on :8080 (dim=1024, 3 shards)
+  - Levara on :8080 (dim=1024, 3 shards)
 
 Run:
     pytest tests/test_rag_cases.py -v -s
@@ -43,7 +43,7 @@ import pytest
 
 BOOK_PATH = Path(__file__).parent.parent / "Edvards_Dzanet_Uragan_r4_P61XH.txt"
 EMBED_URL = "http://localhost:9001/v1/embeddings"
-COGNEVRA_URL = "http://localhost:8080"
+LEVARA_URL = "http://localhost:8080"
 EMBED_MODEL = "pplx-embed-context-v1-0.6b"
 DIM = 1024
 MIN_CHUNK_CHARS = 80
@@ -154,39 +154,39 @@ async def embed_texts(session: aiohttp.ClientSession,
     return all_vecs
 
 
-# ── Cognevra helpers ──────────────────────────────────────────────────────────
+# ── Levara helpers ──────────────────────────────────────────────────────────
 
 
-async def cognevra_insert(session: aiohttp.ClientSession,
+async def levara_insert(session: aiohttp.ClientSession,
                         records: List[Dict]) -> Dict:
     async with session.post(
-        f"{COGNEVRA_URL}/api/v1/batch_insert", json={"records": records}
+        f"{LEVARA_URL}/api/v1/batch_insert", json={"records": records}
     ) as r:
         r.raise_for_status()
         return await r.json()
 
 
-async def cognevra_search(session: aiohttp.ClientSession,
+async def levara_search(session: aiohttp.ClientSession,
                         vector: List[float], k: int = K) -> List[Dict]:
     async with session.post(
-        f"{COGNEVRA_URL}/api/v1/search", json={"vector": vector, "k": k}
+        f"{LEVARA_URL}/api/v1/search", json={"vector": vector, "k": k}
     ) as r:
         r.raise_for_status()
         data = await r.json()
     return data.get("results", [])
 
 
-async def cognevra_delete(session: aiohttp.ClientSession,
+async def levara_delete(session: aiohttp.ClientSession,
                         ids: List[str]) -> Dict:
     async with session.post(
-        f"{COGNEVRA_URL}/api/v1/delete", json={"ids": ids}
+        f"{LEVARA_URL}/api/v1/delete", json={"ids": ids}
     ) as r:
         r.raise_for_status()
         return await r.json()
 
 
 def _extract_text(result: Dict) -> str:
-    """Extract text from Cognevra or LanceDB result."""
+    """Extract text from Levara or LanceDB result."""
     meta = result.get("metadata", result.get("payload", {}))
     if isinstance(meta, str):
         try:
@@ -360,7 +360,7 @@ def _check(url):
 pytestmark = pytest.mark.skipif(
     not (_check("http://localhost:9001/health")
          and _check("http://localhost:8080/metrics")),
-    reason="Need embed-server:9001 + Cognevra:8080",
+    reason="Need embed-server:9001 + Levara:8080",
 )
 
 
@@ -391,7 +391,7 @@ def book_data():
 
 @pytest.fixture(scope="module")
 def inserted_data(book_data):
-    """Insert book data into Cognevra and LanceDB, return handles."""
+    """Insert book data into Levara and LanceDB, return handles."""
     chunks, vecs, q_vecs = book_data
     N = len(chunks)
 
@@ -404,7 +404,7 @@ def inserted_data(book_data):
                     "metadata": {"text": chunks[i]["text"][:500],
                                  "chapter": chunks[i]["chapter"]},
                 } for i in range(start, min(start + 50, N))]
-                await cognevra_insert(session, batch)
+                await levara_insert(session, batch)
         # Wait for HNSW indexer
         await asyncio.sleep(2)
 
@@ -438,7 +438,7 @@ def inserted_data(book_data):
 
     lance_tbl = asyncio.run(_insert_lance())
 
-    print(f"  Inserted {N} chunks into Cognevra and LanceDB")
+    print(f"  Inserted {N} chunks into Levara and LanceDB")
     return {
         "chunks": chunks,
         "vecs": vecs,
@@ -494,9 +494,9 @@ class TestRAGCases:
         v_full_hits, l_full_hits = 0, 0
 
         for q, qv in zip(MULTIHOP_QUERIES, mh_vecs):
-            # -- Cognevra --
+            # -- Levara --
             async with aiohttp.ClientSession() as session:
-                v_results = await cognevra_search(session, qv, k=K)
+                v_results = await levara_search(session, qv, k=K)
             v_text = " ".join(
                 _extract_text(r) for r in v_results
             ).lower()
@@ -532,7 +532,7 @@ class TestRAGCases:
 
         print(f"\n  {'Provider':<35} {'Full hits':>10} {'Rate':>8}")
         print(f"  {'-'*58}")
-        print(f"  {'Cognevra':<35} {v_full_hits:>5}/{n}    {v_rate:>7.0%}")
+        print(f"  {'Levara':<35} {v_full_hits:>5}/{n}    {v_rate:>7.0%}")
         print(f"  {'LanceDB':<35} {l_full_hits:>5}/{n}    {l_rate:>7.0%}")
 
         # At least some multi-hop queries should succeed
@@ -557,11 +557,11 @@ class TestRAGCases:
               f"({len(QUERIES)} queries, 500 noise chunks)")
         print("=" * 72)
 
-        # -- Baseline hit rate (Cognevra) --
+        # -- Baseline hit rate (Levara) --
         v_hits_clean = 0
         async with aiohttp.ClientSession() as session:
             for cq, qv in zip(QUERIES, q_vecs):
-                results = await cognevra_search(session, qv, k=K)
+                results = await levara_search(session, qv, k=K)
                 combined = " ".join(
                     _extract_text(r) for r in results
                 ).lower()
@@ -619,7 +619,7 @@ class TestRAGCases:
                             "chapter": -1,
                         },
                     })
-                await cognevra_insert(session, batch)
+                await levara_insert(session, batch)
 
         await asyncio.sleep(2)  # Let HNSW index
 
@@ -627,7 +627,7 @@ class TestRAGCases:
         v_hits_noisy = 0
         async with aiohttp.ClientSession() as session:
             for cq, qv in zip(QUERIES, q_vecs):
-                results = await cognevra_search(session, qv, k=K)
+                results = await levara_search(session, qv, k=K)
                 combined = " ".join(
                     _extract_text(r) for r in results
                 ).lower()
@@ -650,7 +650,7 @@ class TestRAGCases:
             for start in range(0, len(noise_ids), 50):
                 batch_ids = noise_ids[start:start + 50]
                 try:
-                    await cognevra_delete(session, batch_ids)
+                    await levara_delete(session, batch_ids)
                 except Exception:
                     pass  # Best-effort cleanup
 
@@ -708,12 +708,12 @@ class TestRAGCases:
                                 "chapter": chunks[i]["chapter"],
                             },
                         })
-                    await cognevra_insert(session, batch)
+                    await levara_insert(session, batch)
 
         # Insert needle
         needle_id = f"needle:{uuid.uuid4()}"
         async with aiohttp.ClientSession() as session:
-            await cognevra_insert(session, [{
+            await levara_insert(session, [{
                 "id": needle_id,
                 "vector": needle_vec,
                 "metadata": {"text": NEEDLE_TEXT, "chapter": 99},
@@ -725,9 +725,9 @@ class TestRAGCases:
 
         await asyncio.sleep(3)  # Let HNSW index all new vectors
 
-        # -- Search for needle (Cognevra) --
+        # -- Search for needle (Levara) --
         async with aiohttp.ClientSession() as session:
-            results = await cognevra_search(session, needle_query_vec, k=K)
+            results = await levara_search(session, needle_query_vec, k=K)
 
         found_positions = []
         for i, r in enumerate(results):
@@ -739,7 +739,7 @@ class TestRAGCases:
         in_top5 = any(p <= 5 for p in found_positions)
         in_top10 = any(p <= 10 for p in found_positions)
 
-        print(f"  Cognevra needle positions: "
+        print(f"  Levara needle positions: "
               f"{found_positions or 'NOT FOUND'}")
         print(f"  In top-1:  {'YES' if in_top1 else 'NO'}")
         print(f"  In top-5:  {'YES' if in_top5 else 'NO'}")
@@ -811,12 +811,12 @@ class TestRAGCases:
         print(f"\n  LanceDB needle positions: {l_found or 'NOT FOUND'}")
         print(f"  LanceDB in top-10: {'YES' if l_in_top10 else 'NO'}")
 
-        # -- Cleanup padding + needle from Cognevra --
+        # -- Cleanup padding + needle from Levara --
         async with aiohttp.ClientSession() as session:
             all_cleanup = padding_ids + [needle_id]
             for start in range(0, len(all_cleanup), 50):
                 try:
-                    await cognevra_delete(
+                    await levara_delete(
                         session, all_cleanup[start:start + 50]
                     )
                 except Exception:
@@ -858,8 +858,8 @@ class TestRAGCases:
             v_hits, l_hits = 0, 0
             async with aiohttp.ClientSession() as session:
                 for cq, qv in zip(queries, query_vecs):
-                    # Cognevra
-                    results = await cognevra_search(session, qv, k=K)
+                    # Levara
+                    results = await levara_search(session, qv, k=K)
                     v_text = " ".join(
                         _extract_text(r) for r in results
                     ).lower()
@@ -879,7 +879,7 @@ class TestRAGCases:
             n = len(queries)
             v_rate = v_hits / n if n else 0
             l_rate = l_hits / n if n else 0
-            print(f"  {label:<20} Cognevra: {v_hits}/{n} ({v_rate:.0%})  "
+            print(f"  {label:<20} Levara: {v_hits}/{n} ({v_rate:.0%})  "
                   f"LanceDB: {l_hits}/{n} ({l_rate:.0%})")
             return v_rate, l_rate
 
@@ -892,13 +892,13 @@ class TestRAGCases:
         # Cross-lingual gap
         if ru_v > 0:
             gap_v = (ru_v - en_v) / ru_v
-            print(f"\n  Cross-lingual gap (Cognevra): {gap_v:.0%}")
+            print(f"\n  Cross-lingual gap (Levara): {gap_v:.0%}")
         if ru_l > 0:
             gap_l = (ru_l - en_l) / ru_l
             print(f"  Cross-lingual gap (LanceDB):  {gap_l:.0%}")
 
         print(f"\n  Expected: RU > Mixed >= EN")
-        print(f"  Cognevra: {ru_v:.0%} > {mx_v:.0%} >= {en_v:.0%}")
+        print(f"  Levara: {ru_v:.0%} > {mx_v:.0%} >= {en_v:.0%}")
         print(f"  LanceDB:  {ru_l:.0%} > {mx_l:.0%} >= {en_l:.0%}")
 
         # RU baseline should be decent
@@ -928,7 +928,7 @@ class TestRAGCases:
         v_hits_clean, l_hits_clean = 0, 0
         async with aiohttp.ClientSession() as session:
             for cq, qv in zip(QUERIES, q_vecs):
-                results = await cognevra_search(session, qv, k=K)
+                results = await levara_search(session, qv, k=K)
                 combined = " ".join(
                     _extract_text(r) for r in results
                 ).lower()
@@ -957,7 +957,7 @@ class TestRAGCases:
         v_hits_typo, l_hits_typo = 0, 0
         async with aiohttp.ClientSession() as session:
             for cq, qv in zip(TYPO_QUERIES, typo_vecs):
-                results = await cognevra_search(session, qv, k=K)
+                results = await levara_search(session, qv, k=K)
                 combined = " ".join(
                     _extract_text(r) for r in results
                 ).lower()
@@ -986,7 +986,7 @@ class TestRAGCases:
         v_hits_tr, l_hits_tr = 0, 0
         async with aiohttp.ClientSession() as session:
             for cq, qv in zip(TRANSLIT_QUERIES, translit_vecs):
-                results = await cognevra_search(session, qv, k=K)
+                results = await levara_search(session, qv, k=K)
                 combined = " ".join(
                     _extract_text(r) for r in results
                 ).lower()
@@ -1020,7 +1020,7 @@ class TestRAGCases:
         else:
             typo_deg_l = translit_deg_l = 0
 
-        print(f"\n  {'Metric':<30} {'Cognevra':>10} {'LanceDB':>10}")
+        print(f"\n  {'Metric':<30} {'Levara':>10} {'LanceDB':>10}")
         print(f"  {'-'*55}")
         print(f"  {'Typo degradation':<30} "
               f"{typo_deg_v:>9.0%} {typo_deg_l:>9.0%}")

--- a/tests/test_rag_llm_cases.py
+++ b/tests/test_rag_llm_cases.py
@@ -10,7 +10,7 @@ Tests here use the full retrieval + generation + evaluation pipeline:
 
 Requires:
   - embed-server on :9001
-  - Cognevra on :8080
+  - Levara on :8080
   - Ollama with qwen3.5 on :11434
 
 Run:
@@ -34,7 +34,7 @@ import pytest
 
 BOOK_PATH = Path(__file__).parent.parent / "Edvards_Dzanet_Uragan_r4_P61XH.txt"
 EMBED_URL = "http://localhost:9001/v1/embeddings"
-COGNEVRA_URL = "http://localhost:8080"
+LEVARA_URL = "http://localhost:8080"
 OLLAMA_URL = "http://127.0.0.1:11434"
 EMBED_MODEL = "pplx-embed-context-v1-0.6b"
 LLM_MODEL = "qwen3.5:latest"
@@ -95,22 +95,22 @@ async def embed_texts(session: aiohttp.ClientSession,
     return all_vecs
 
 
-# ── Cognevra helpers ──────────────────────────────────────────────────────────
+# ── Levara helpers ──────────────────────────────────────────────────────────
 
 
-async def cognevra_insert(session: aiohttp.ClientSession,
+async def levara_insert(session: aiohttp.ClientSession,
                         records: List[Dict]) -> Dict:
     async with session.post(
-        f"{COGNEVRA_URL}/api/v1/batch_insert", json={"records": records}
+        f"{LEVARA_URL}/api/v1/batch_insert", json={"records": records}
     ) as r:
         r.raise_for_status()
         return await r.json()
 
 
-async def cognevra_search(session: aiohttp.ClientSession,
+async def levara_search(session: aiohttp.ClientSession,
                         vector: List[float], k: int = K) -> List[Dict]:
     async with session.post(
-        f"{COGNEVRA_URL}/api/v1/search", json={"vector": vector, "k": k}
+        f"{LEVARA_URL}/api/v1/search", json={"vector": vector, "k": k}
     ) as r:
         r.raise_for_status()
         data = await r.json()
@@ -218,13 +218,13 @@ async def llm_judge(session: aiohttp.ClientSession,
 
 async def rag_pipeline(session: aiohttp.ClientSession,
                        question: str) -> Dict:
-    """Full RAG pipeline: embed query -> search Cognevra -> generate answer."""
+    """Full RAG pipeline: embed query -> search Levara -> generate answer."""
     # 1. Embed query
     query_vecs = await embed_texts(session, [question])
     query_vec = query_vecs[0]
 
     # 2. Search
-    results = await cognevra_search(session, query_vec, k=K)
+    results = await levara_search(session, query_vec, k=K)
     context_chunks = [_extract_text(r) for r in results]
     context = "\n---\n".join(c for c in context_chunks if c)
 
@@ -311,7 +311,7 @@ pytestmark = pytest.mark.skipif(
         and _check("http://localhost:8080/metrics")
         and _check("http://127.0.0.1:11434/api/tags")
     ),
-    reason="Need embed-server:9001 + Cognevra:8080 + Ollama:11434",
+    reason="Need embed-server:9001 + Levara:8080 + Ollama:11434",
 )
 
 
@@ -320,7 +320,7 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture(scope="module")
 def book_inserted():
-    """Load book, chunk, embed, insert into Cognevra -- once for module."""
+    """Load book, chunk, embed, insert into Levara -- once for module."""
     if not BOOK_PATH.exists():
         pytest.skip(f"Book not found: {BOOK_PATH}")
 
@@ -340,7 +340,7 @@ def book_inserted():
                         "chapter": chunks[i]["chapter"],
                     },
                 } for i in range(start, min(start + 50, len(chunks)))]
-                await cognevra_insert(session, batch)
+                await levara_insert(session, batch)
 
             await asyncio.sleep(2)
         return vecs
@@ -364,7 +364,7 @@ class TestRAGLLMCases:
     async def test_01_grounded_answers(self, book_inserted):
         """Grounded answers: LLM generates answers based only on context.
 
-        Pipeline: query -> embed -> Cognevra search -> Qwen generate
+        Pipeline: query -> embed -> Levara search -> Qwen generate
         Check: answer contains expected keywords from context.
         """
         print("\n" + "=" * 72)

--- a/tests/test_rbac_isolation.py
+++ b/tests/test_rbac_isolation.py
@@ -84,7 +84,7 @@ Graph Search Isolation (2):
 
 Итого: 13 тестов.
 
-Requires: Cognevra HTTP :8080 с auth endpoints.
+Requires: Levara HTTP :8080 с auth endpoints.
 """
 import os
 import time
@@ -93,7 +93,7 @@ import asyncio
 import pytest
 import aiohttp
 
-BASE = os.getenv("COGNEVRA_HTTP_URL", "http://localhost:8080/api/v1")
+BASE = os.getenv("LEVARA_HTTP_URL", "http://localhost:8080/api/v1")
 BASE_ROOT = BASE.rsplit("/api/v1", 1)[0]  # http://localhost:8080
 
 pytestmark = pytest.mark.asyncio
@@ -668,7 +668,7 @@ async def test_rbac_superuser_bypass():
         assert ds_id, f"Не удалось создать dataset"
 
         # Пробуем получить superuser token через admin login
-        admin_email = "admin@cognevra.dev"
+        admin_email = "admin@levara.dev"
         admin_pw = "admin123456"
 
         h_admin = {}
@@ -692,7 +692,7 @@ async def test_rbac_superuser_bypass():
 
         if not h_admin:
             pytest.skip(
-                "Superuser login не доступен (admin@cognevra.dev)."
+                "Superuser login не доступен (admin@levara.dev)."
             )
 
         # Superuser должен видеть dataset юзера A

--- a/tests/test_scenarios_real.py
+++ b/tests/test_scenarios_real.py
@@ -79,7 +79,7 @@ async def test_s02_developer_knowledge_base():
     async with aiohttp.ClientSession() as s:
         h, _, _ = await _user(s, "dev")
         async with s.post(f"{BASE_URL}/add",
-            data="Cognevra uses HNSW for fast approximate nearest neighbor search. It supports WAL durability.",
+            data="Levara uses HNSW for fast approximate nearest neighbor search. It supports WAL durability.",
             headers={**h, "Content-Type": "text/plain"}) as r:
             assert (await r.json())["items"] >= 1
         async with s.post(f"{BASE_URL}/search/text", json={
@@ -97,7 +97,7 @@ async def test_s03_analyst_csv_upload():
     """Analyst: upload CSV → RAG search."""
     async with aiohttp.ClientSession() as s:
         h, _, _ = await _user(s, "analyst")
-        csv = b"name,type,speed\nCognevra,VectorDB,fast\nNeo4j,GraphDB,medium\nPostgres,RelationalDB,fast"
+        csv = b"name,type,speed\nLevara,VectorDB,fast\nNeo4j,GraphDB,medium\nPostgres,RelationalDB,fast"
         form = aiohttp.FormData()
         form.add_field("data", csv, filename="benchmarks.csv", content_type="text/csv")
         async with s.post(f"{BASE_URL}/add", data=form, headers=h) as r:
@@ -193,7 +193,7 @@ async def test_s07_mcp_agent_pipeline():
             "jsonrpc": "2.0", "id": "1", "method": "initialize", "params": {}
         }) as r:
             init = await r.json()
-            assert init["result"]["serverInfo"]["name"] == "Cognevra"
+            assert init["result"]["serverInfo"]["name"] == "Levara"
         # List tools
         async with s.post(f"{MCP_URL}/mcp", json={
             "jsonrpc": "2.0", "id": "2", "method": "tools/list", "params": {}

--- a/tests/test_scenarios_ui.py
+++ b/tests/test_scenarios_ui.py
@@ -18,7 +18,7 @@ from playwright.sync_api import Page, expect
 
 BASE_UI = "http://localhost:3000"
 BASE_API = "http://localhost:8080/api/v1"
-EMAIL = "admin@cognevra.dev"
+EMAIL = "admin@levara.dev"
 PASSWORD = "admin123456"
 
 

--- a/tests/test_stress_concurrent.py
+++ b/tests/test_stress_concurrent.py
@@ -1,6 +1,6 @@
 """Stress tests: concurrency — parallel operations must not crash or lose data.
 
-Requires: Cognevra gRPC:50051, embed-server:9001.
+Requires: Levara gRPC:50051, embed-server:9001.
 """
 import concurrent.futures
 import grpc
@@ -10,8 +10,8 @@ import time
 
 import pytest
 
-pb = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2")
-pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2_grpc")
+pb = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2")
+pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2_grpc")
 if pb is None or pb_grpc is None:
     pytest.skip("Proto stubs not loaded", allow_module_level=True)
 
@@ -23,8 +23,8 @@ def _stub():
     try:
         grpc.channel_ready_future(ch).result(timeout=3)
     except grpc.FutureTimeoutError:
-        pytest.skip("Cognevra not running")
-    return pb_grpc.CognevraServiceStub(ch), ch
+        pytest.skip("Levara not running")
+    return pb_grpc.LevaraServiceStub(ch), ch
 
 
 class TestConcurrentInsert:

--- a/tests/test_stress_edge_cases.py
+++ b/tests/test_stress_edge_cases.py
@@ -1,7 +1,7 @@
 """Stress tests: edge cases, error handling, boundary conditions.
 
 Tests that the system handles bad input gracefully without crashes.
-Requires: Cognevra gRPC:50051 only (no embed-server needed for most).
+Requires: Levara gRPC:50051 only (no embed-server needed for most).
 """
 import grpc
 import json
@@ -11,8 +11,8 @@ import io
 
 import pytest
 
-pb = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2")
-pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2_grpc")
+pb = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2")
+pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2_grpc")
 if pb is None or pb_grpc is None:
     pytest.skip("Proto stubs not loaded", allow_module_level=True)
 
@@ -24,8 +24,8 @@ def _stub():
     try:
         grpc.channel_ready_future(ch).result(timeout=3)
     except grpc.FutureTimeoutError:
-        pytest.skip("Cognevra not running")
-    return pb_grpc.CognevraServiceStub(ch), ch
+        pytest.skip("Levara not running")
+    return pb_grpc.LevaraServiceStub(ch), ch
 
 
 class TestVectorEdgeCases:

--- a/tests/test_stress_latency.py
+++ b/tests/test_stress_latency.py
@@ -1,7 +1,7 @@
 """Stress tests: performance targets and latency benchmarks.
 
 Verifies that all RPCs meet latency SLAs under load.
-Requires: Cognevra gRPC:50051, embed-server:9001.
+Requires: Levara gRPC:50051, embed-server:9001.
 """
 import grpc
 import json
@@ -12,8 +12,8 @@ from pathlib import Path
 
 import pytest
 
-pb = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2")
-pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2_grpc")
+pb = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2")
+pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2_grpc")
 if pb is None or pb_grpc is None:
     pytest.skip("Proto stubs not loaded", allow_module_level=True)
 
@@ -27,8 +27,8 @@ def _stub():
     try:
         grpc.channel_ready_future(ch).result(timeout=3)
     except grpc.FutureTimeoutError:
-        pytest.skip("Cognevra not running")
-    return pb_grpc.CognevraServiceStub(ch), ch
+        pytest.skip("Levara not running")
+    return pb_grpc.LevaraServiceStub(ch), ch
 
 
 def _check_embed():

--- a/tests/test_stress_volume.py
+++ b/tests/test_stress_volume.py
@@ -1,6 +1,6 @@
 """Stress tests: volume — large data sets, scale limits.
 
-Requires: Cognevra gRPC:50051, embed-server:9001 (for some).
+Requires: Levara gRPC:50051, embed-server:9001 (for some).
 """
 import grpc
 import json
@@ -10,8 +10,8 @@ from pathlib import Path
 
 import pytest
 
-pb = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2")
-pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2_grpc")
+pb = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2")
+pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2_grpc")
 if pb is None or pb_grpc is None:
     pytest.skip("Proto stubs not loaded", allow_module_level=True)
 
@@ -24,8 +24,8 @@ def _stub():
     try:
         grpc.channel_ready_future(ch).result(timeout=3)
     except grpc.FutureTimeoutError:
-        pytest.skip("Cognevra not running")
-    return pb_grpc.CognevraServiceStub(ch), ch
+        pytest.skip("Levara not running")
+    return pb_grpc.LevaraServiceStub(ch), ch
 
 
 class TestVolumeInsert:

--- a/tests/test_stub_fixes.py
+++ b/tests/test_stub_fixes.py
@@ -20,7 +20,7 @@ import asyncio
 import pytest
 import aiohttp
 
-BASE = os.getenv("COGNEVRA_HTTP_URL", "http://localhost:8080/api/v1")
+BASE = os.getenv("LEVARA_HTTP_URL", "http://localhost:8080/api/v1")
 BASE_ROOT = BASE.rsplit("/api/v1", 1)[0]  # http://localhost:8080
 
 pytestmark = pytest.mark.asyncio

--- a/tests/test_triplet_search_go.py
+++ b/tests/test_triplet_search_go.py
@@ -1,7 +1,7 @@
 """Integration test for Go-accelerated SearchTriplets gRPC RPC.
 
 Tests the in-memory graph scoring that replaces Python's brute_force_triplet_search.
-Requires Cognevra running on localhost:50051.
+Requires Levara running on localhost:50051.
 """
 import grpc
 import pytest
@@ -9,8 +9,8 @@ import sys
 import time
 
 # Proto stubs loaded by conftest.py from cognee tree
-pb = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2")
-pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.cognevra.generated.cognevra_pb2_grpc")
+pb = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2")
+pb_grpc = sys.modules.get("cognee.infrastructure.databases.vector.levara.generated.levara_pb2_grpc")
 if pb is None or pb_grpc is None:
     pytest.skip("Proto stubs not loaded (conftest issue)", allow_module_level=True)
 
@@ -20,7 +20,7 @@ def _channel():
     try:
         grpc.channel_ready_future(ch).result(timeout=3)
     except grpc.FutureTimeoutError:
-        pytest.skip("Cognevra not running on localhost:50051")
+        pytest.skip("Levara not running on localhost:50051")
     return ch
 
 
@@ -29,19 +29,19 @@ class TestSearchTriplets:
 
     def test_basic_triplet_search(self):
         ch = _channel()
-        stub = pb_grpc.CognevraServiceStub(ch)
+        stub = pb_grpc.LevaraServiceStub(ch)
 
         req = pb.SearchTripletsReq(
             nodes=[
-                pb.TripletNode(id="n1", name="Cognevra", description="Vector DB", type="Software"),
+                pb.TripletNode(id="n1", name="Levara", description="Vector DB", type="Software"),
                 pb.TripletNode(id="n2", name="HNSW", description="Graph index", type="Algorithm"),
                 pb.TripletNode(id="n3", name="WAL", description="Write-Ahead Log", type="Component"),
             ],
             edges=[
                 pb.TripletEdge(node1_id="n1", node2_id="n2", relationship_type="uses",
-                              edge_text="Cognevra uses HNSW", edge_type_id="et1"),
+                              edge_text="Levara uses HNSW", edge_type_id="et1"),
                 pb.TripletEdge(node1_id="n1", node2_id="n3", relationship_type="has",
-                              edge_text="Cognevra has WAL", edge_type_id="et2"),
+                              edge_text="Levara has WAL", edge_type_id="et2"),
             ],
             node_distances=[
                 pb.CollectionDistances(
@@ -74,7 +74,7 @@ class TestSearchTriplets:
         assert abs(second.score - 7.1) < 0.01, f"expected score ~7.1, got {second.score}"
 
         # Formatted context should contain node info
-        assert "Cognevra" in resp.formatted_context
+        assert "Levara" in resp.formatted_context
         assert "HNSW" in resp.formatted_context
         assert "Node1:" in resp.formatted_context
 
@@ -82,7 +82,7 @@ class TestSearchTriplets:
 
     def test_empty_graph(self):
         ch = _channel()
-        stub = pb_grpc.CognevraServiceStub(ch)
+        stub = pb_grpc.LevaraServiceStub(ch)
 
         resp = stub.SearchTriplets(pb.SearchTripletsReq(top_k=5))
         assert len(resp.triplets) == 0
@@ -91,7 +91,7 @@ class TestSearchTriplets:
 
     def test_missing_node_skipped(self):
         ch = _channel()
-        stub = pb_grpc.CognevraServiceStub(ch)
+        stub = pb_grpc.LevaraServiceStub(ch)
 
         req = pb.SearchTripletsReq(
             nodes=[pb.TripletNode(id="n1", name="A")],
@@ -106,7 +106,7 @@ class TestSearchTriplets:
 
     def test_lowest_distance_wins(self):
         ch = _channel()
-        stub = pb_grpc.CognevraServiceStub(ch)
+        stub = pb_grpc.LevaraServiceStub(ch)
 
         req = pb.SearchTripletsReq(
             nodes=[
@@ -135,7 +135,7 @@ class TestSearchTriplets:
     def test_performance_10k_edges(self):
         """SearchTriplets should handle 10K edges in <5ms."""
         ch = _channel()
-        stub = pb_grpc.CognevraServiceStub(ch)
+        stub = pb_grpc.LevaraServiceStub(ch)
 
         nodes = [pb.TripletNode(id=f"n{i}", name=f"Node{i}") for i in range(1000)]
         edges = [

--- a/tests/test_ui_full_screenshots.py
+++ b/tests/test_ui_full_screenshots.py
@@ -9,8 +9,8 @@ from playwright.sync_api import Page
 
 BASE = "http://localhost:3000"
 API = "http://localhost:8080/api/v1"
-DIR = "/tmp/cognevra_screenshots_full"
-EMAIL = "admin@cognevra.dev"
+DIR = "/tmp/levara_screenshots_full"
+EMAIL = "admin@levara.dev"
 PASSWORD = "admin123456"
 
 os.makedirs(DIR, exist_ok=True)

--- a/tests/test_ui_screenshots.py
+++ b/tests/test_ui_screenshots.py
@@ -1,6 +1,6 @@
 """
 UI SCREENSHOT TESTS — каждый шаг делает скриншот, Claude анализирует его.
-Скриншоты сохраняются в /tmp/cognevra_screenshots/.
+Скриншоты сохраняются в /tmp/levara_screenshots/.
 После прогона все скриншоты можно просмотреть для аудита.
 """
 import os
@@ -8,8 +8,8 @@ import pytest
 from playwright.sync_api import Page
 
 BASE = "http://localhost:3000"
-SCREENSHOTS_DIR = "/tmp/cognevra_screenshots"
-EMAIL = "admin@cognevra.dev"
+SCREENSHOTS_DIR = "/tmp/levara_screenshots"
+EMAIL = "admin@levara.dev"
 PASSWORD = "admin123456"
 
 os.makedirs(SCREENSHOTS_DIR, exist_ok=True)

--- a/tests/test_user_journey_full.py
+++ b/tests/test_user_journey_full.py
@@ -1,7 +1,7 @@
 """
 Full User Journey Test — от регистрации до визуализации графа.
 
-Описывает ПОЛНЫЙ путь нового пользователя в Cognevra:
+Описывает ПОЛНЫЙ путь нового пользователя в Levara:
 
 1. РЕГИСТРАЦИЯ → Пользователь создаёт аккаунт
 2. ЛОГИН → Получает JWT токен + cookie
@@ -54,7 +54,7 @@ _state = {}
 
 async def test_step01_register():
     """Пользователь регистрирует новый аккаунт."""
-    _state["email"] = f"journey_{unique_id()}@cognevra.dev"
+    _state["email"] = f"journey_{unique_id()}@levara.dev"
     _state["password"] = "JourneyPass123!"
 
     async with aiohttp.ClientSession() as s:
@@ -134,7 +134,7 @@ async def test_step04_check_settings():
             assert r.status == 200
             settings = await r.json()
             assert "vector_engine" in settings
-            assert settings["vector_engine"] == "cognevra"
+            assert settings["vector_engine"] == "levara"
             assert "embedding_model" in settings
             assert "llm_provider" in settings
             print(f"  ✓ Settings: embed={settings['embedding_model']}, "
@@ -197,11 +197,11 @@ async def test_step06_upload_text_file():
     async with aiohttp.ClientSession() as s:
         form = aiohttp.FormData()
         form.add_field("data",
-            b"Cognevra is a high-performance vector database written in Go. "
+            b"Levara is a high-performance vector database written in Go. "
             b"It uses HNSW (Hierarchical Navigable Small World) indexing for fast approximate nearest neighbor search. "
             b"The system combines WAL durability with memory-mapped arenas for efficient vector storage. "
-            b"Cognevra supports multiple embedding models and can store vectors of any dimension.",
-            filename="cognevra_intro.txt", content_type="text/plain")
+            b"Levara supports multiple embedding models and can store vectors of any dimension.",
+            filename="levara_intro.txt", content_type="text/plain")
         form.add_field("datasetId", _state["dataset_id"])
 
         async with s.post(f"{BASE_URL}/add", data=form, headers=_state["headers"]) as r:
@@ -210,7 +210,7 @@ async def test_step06_upload_text_file():
             assert data["status"] == "ok"
             assert data["items"] >= 1
             assert data["dataset_id"] == _state["dataset_id"]
-            print(f"  ✓ Uploaded: cognevra_intro.txt ({data['items']} items)")
+            print(f"  ✓ Uploaded: levara_intro.txt ({data['items']} items)")
 
 
 async def test_step06b_upload_markdown_file():
@@ -290,7 +290,7 @@ async def test_step08_cognify_dataset():
     async with aiohttp.ClientSession() as s:
         async with s.post(f"{BASE_URL}/cognify", json={
             "texts": [
-                "Cognevra uses HNSW for vector search. Neo4j stores the knowledge graph. "
+                "Levara uses HNSW for vector search. Neo4j stores the knowledge graph. "
                 "PostgreSQL stores metadata. The system was created by stek0v.",
             ]
         }, headers=_state["headers"]) as r:
@@ -423,7 +423,7 @@ async def test_step11e_search_rag():
     """Пользователь ищет по RAG_COMPLETION (chunks + LLM answer)."""
     async with aiohttp.ClientSession() as s:
         async with s.post(f"{BASE_URL}/search/text", json={
-            "query_text": "What is Cognevra?",
+            "query_text": "What is Levara?",
             "query_type": "RAG_COMPLETION",
             "top_k": 3,
         }, headers=_state["headers"]) as r:
@@ -463,7 +463,7 @@ async def test_step12b_add_markdown_cell():
     async with aiohttp.ClientSession() as s:
         async with s.post(f"{BASE_URL}/notebooks/{_state['notebook_id']}/cells", json={
             "type": "markdown",
-            "content": "# My Research\n\nAnalyzing Cognevra vector database architecture.",
+            "content": "# My Research\n\nAnalyzing Levara vector database architecture.",
         }, headers=_state["headers"]) as r:
             assert r.status == 201
             data = await r.json()
@@ -544,7 +544,7 @@ async def test_step13a_mcp_initialize():
         }) as r:
             assert r.status == 200
             data = await r.json()
-            assert data["result"]["serverInfo"]["name"] == "Cognevra"
+            assert data["result"]["serverInfo"]["name"] == "Levara"
             print(f"  ✓ MCP initialized: {data['result']['serverInfo']['name']} "
                   f"v{data['result']['serverInfo']['version']}")
 
@@ -589,7 +589,7 @@ async def test_step13c_health_details():
 
 async def test_step14a_create_colleague():
     """Создаём коллегу для шаринга."""
-    _state["colleague_email"] = f"colleague_{unique_id()}@cognevra.dev"
+    _state["colleague_email"] = f"colleague_{unique_id()}@levara.dev"
     async with aiohttp.ClientSession() as s:
         async with s.post(f"{BASE_URL}/auth/register", json={
             "email": _state["colleague_email"],
@@ -632,7 +632,7 @@ async def test_step14c_check_permissions():
 # STEP 15: COLLECTIONS — Vector collection metadata
 # Пользователь просматривает vector collections и их метаданные.
 # GET /collections → [{name, embedding_model, embedding_dim, distance_metric, record_count}]
-# Docs: — (Cognevra extension)
+# Docs: — (Levara extension)
 # ═══════════════════════════════════════════════════════════════════════
 
 async def test_step15_list_collections():

--- a/tests/test_whisper_audio.py
+++ b/tests/test_whisper_audio.py
@@ -51,7 +51,7 @@ Integration (2):
 
 Итого: 8 тестов.
 
-Requires: Cognevra HTTP :8080.
+Requires: Levara HTTP :8080.
 """
 import os
 import uuid
@@ -59,7 +59,7 @@ import asyncio
 import pytest
 import aiohttp
 
-BASE = os.getenv("COGNEVRA_HTTP_URL", "http://localhost:8080/api/v1")
+BASE = os.getenv("LEVARA_HTTP_URL", "http://localhost:8080/api/v1")
 BASE_ROOT = BASE.rsplit("/api/v1", 1)[0]  # http://localhost:8080
 
 pytestmark = pytest.mark.asyncio
@@ -138,7 +138,7 @@ async def test_audio_format_detection():
     Не должен вернуть ошибку "unknown format" или "unsupported file type"."""
     alive = await _check_server()
     if not alive:
-        assert False, "Cognevra HTTP сервер недоступен на " + BASE
+        assert False, "Levara HTTP сервер недоступен на " + BASE
 
     async with aiohttp.ClientSession(timeout=TIMEOUT) as s:
         h = await _register(s, "audio_det")
@@ -175,7 +175,7 @@ async def test_audio_classify():
     Проверяем через /add response или через /classify endpoint."""
     alive = await _check_server()
     if not alive:
-        assert False, "Cognevra HTTP сервер недоступен на " + BASE
+        assert False, "Levara HTTP сервер недоступен на " + BASE
 
     async with aiohttp.ClientSession(timeout=TIMEOUT) as s:
         h = await _register(s, "audio_cls")
@@ -224,7 +224,7 @@ async def test_audio_unsupported_format():
     Файл с неизвестным расширением НЕ должен уходить в Whisper pipeline."""
     alive = await _check_server()
     if not alive:
-        assert False, "Cognevra HTTP сервер недоступен на " + BASE
+        assert False, "Levara HTTP сервер недоступен на " + BASE
 
     async with aiohttp.ClientSession(timeout=TIMEOUT) as s:
         h = await _register(s, "audio_unk")
@@ -262,7 +262,7 @@ async def test_whisper_health_check():
     Допустимые значения: connected, not_configured, unreachable."""
     alive = await _check_server()
     if not alive:
-        assert False, "Cognevra HTTP сервер недоступен на " + BASE
+        assert False, "Levara HTTP сервер недоступен на " + BASE
 
     async with aiohttp.ClientSession(timeout=TIMEOUT) as s:
         # Пробуем /health/details
@@ -294,7 +294,7 @@ async def test_whisper_not_configured():
     Сервер должен вернуть 4xx с объяснением, или 200 с isError=true."""
     alive = await _check_server()
     if not alive:
-        assert False, "Cognevra HTTP сервер недоступен на " + BASE
+        assert False, "Levara HTTP сервер недоступен на " + BASE
 
     async with aiohttp.ClientSession(timeout=TIMEOUT) as s:
         h = await _register(s, "whisper_nc")
@@ -326,7 +326,7 @@ async def test_whisper_endpoint_format():
     Если настроен — проверяем что ответ содержит текст транскрипции."""
     alive = await _check_server()
     if not alive:
-        assert False, "Cognevra HTTP сервер недоступен на " + BASE
+        assert False, "Levara HTTP сервер недоступен на " + BASE
 
     async with aiohttp.ClientSession(timeout=TIMEOUT) as s:
         h = await _register(s, "whisper_fmt")
@@ -363,7 +363,7 @@ async def test_audio_pipeline_smoke():
     Если не настроен → проверяем что ошибка понятная."""
     alive = await _check_server()
     if not alive:
-        assert False, "Cognevra HTTP сервер недоступен на " + BASE
+        assert False, "Levara HTTP сервер недоступен на " + BASE
 
     async with aiohttp.ClientSession(timeout=TIMEOUT) as s:
         h = await _register(s, "audio_smoke")
@@ -445,7 +445,7 @@ async def test_all_format_support():
     Каждый формат должен вернуть "whisper not configured" или 200 — не generic ошибку."""
     alive = await _check_server()
     if not alive:
-        assert False, "Cognevra HTTP сервер недоступен на " + BASE
+        assert False, "Levara HTTP сервер недоступен на " + BASE
 
     async with aiohttp.ClientSession(timeout=TIMEOUT) as s:
         h = await _register(s, "audio_all")


### PR DESCRIPTION
## Summary

Phase 6 — final cleanup. The previous phases targeted specific cognevra patterns (CognevraAdapter import in P4, sys.modules.get / env var in P5). 37 test files mentioning cognevra in **other contexts** (mock stubs, docstrings, prometheus prefix, comments) slipped through.

This PR sed-renames cognevra → levara across all of them. No code logic changes.

## After this PR

The only remaining `cognevra` mentions in the repo are intentional:

| Where | Why |
|---|---|
| `Levara-legacy/` | Frozen legacy module (Phase 2) |
| `Levara/docs/testing-logs/*.txt` | Historical test snapshots |
| `Levara/tests/test-results-phase1.md` | 2026-04-10 test result snapshot |
| `test_reports/coverage_2026-04-21.*` | Coverage snapshot |
| `.gitignore` | Patterns for `Levara-legacy/cli` etc |
| `CHANGELOG.md` | Historical changelog |
| `Raspberry/README.md` | Migration block for existing Pi deployments |
| `cognee-plugin/levara_adapter/__init__.py` | `CognevraAdapter = LevaraAdapter` alias |

## Why this wasn't in P4/P5

P4 grep was scoped to "tests with `from cognee...vector.cognevra.CognevraAdapter import` pattern" — 10 files. P5 added 6 more (those using `sys.modules.get(...)` or `os.getenv("COGNEVRA_HTTP_URL")`). These 37 don't have those distinctive markers — they reference cognevra only in:

- Mock pb_grpc stubs: `pb_grpc.CognevraServiceStub(ch)`
- sys.modules paths via `.get(...)`: `sys.modules.get("cognee...cognevra.generated.cognevra_pb2")`
- Docstrings and `Requires:` headers
- Prometheus metric prefix tests: `assert "cognevra_" in metrics_text`

## Test plan

- [ ] `pytest --collect-only tests/` succeeds for all 37 renamed files
- [ ] `git grep -i cognevra` returns only the 8 intentional categories above