### PR TITLE
fix(dockerfile): build whole ./cmd/server/ package instead of just main.go

### DIFF
--- a/Levara/Dockerfile
+++ b/Levara/Dockerfile
@@ -11,7 +11,7 @@ RUN go mod download
 COPY . .
 
 # CGO disabled keeps the image static; ldflags strip debug info.
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o levara ./cmd/server/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o levara ./cmd/server/
 
 FROM alpine:latest
 


### PR DESCRIPTION
`go build ./cmd/server/main.go` compiles ONLY that one file, skipping siblings (`bootstrap.go`, `rerank_config.go`, `neo4j_bootstrap.go`). main.go calls `startEmbedKeepAlive` defined in `bootstrap.go` → build fails with `cmd/server/main.go:613:2: undefined: startEmbedKeepAlive`.

Single-character fix: drop the `main.go` suffix to build the whole package.

Verified locally: `docker compose up -d --build levara` succeeds with this change.