### PR TITLE
feat(metrics): RAG verify-stack observability

### DIFF
--- a/Levara/internal/http/api_search.go
+++ b/Levara/internal/http/api_search.go
@@ -793,6 +793,7 @@ func ragCompletionSearch(c *fiber.Ctx, cfg APIConfig, req UnifiedSearchRequest) 
 	} else if lowConfidence {
 		abstainReason = "low_confidence"
 	}
+	emitRAGMetrics("RAG_COMPLETION", confidence, abstained, abstainReason, verification)
 
 	// Step 2: LLM completion using retrieved chunks as context
 	llmEndpoint := os.Getenv("LLM_ENDPOINT")

--- a/Levara/internal/http/graph_search.go
+++ b/Levara/internal/http/graph_search.go
@@ -97,6 +97,7 @@ func graphCompletionSearch(c *fiber.Ctx, cfg APIConfig, req UnifiedSearchRequest
 	} else if lowConfidence {
 		abstainReason = "low_confidence"
 	}
+	emitRAGMetrics("GRAPH_COMPLETION", confidence, abstained, abstainReason, verification)
 
 	// Step 3: LLM completion
 	llmEndpoint := os.Getenv("LLM_ENDPOINT")
@@ -256,6 +257,7 @@ func contextExtensionSearch(c *fiber.Ctx, cfg APIConfig, req UnifiedSearchReques
 	} else if lowConfidence {
 		abstainReason = "low_confidence"
 	}
+	emitRAGMetrics("GRAPH_COMPLETION_CONTEXT_EXTENSION", confidence, abstained, abstainReason, verification)
 
 	// Step 4: LLM completion with extended context
 	llmEndpoint := os.Getenv("LLM_ENDPOINT")

--- a/Levara/internal/http/verify.go
+++ b/Levara/internal/http/verify.go
@@ -5,7 +5,25 @@ import (
 	"math"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/stek0v/levara/internal/metrics"
 )
+
+// emitRAGMetrics records confidence distribution, abstain counts, and
+// verify-stage drops for a single RAG completion. Default thresholds keep
+// abstain/verify behavior off; these metrics let an operator observe live
+// distributions before opting in.
+func emitRAGMetrics(searchType string, confidence float64, abstained bool, abstainReason string, v resultVerification) {
+	metrics.RAGConfidence.WithLabelValues(searchType).Observe(confidence)
+	if abstained && abstainReason != "" {
+		metrics.RAGAbstainTotal.WithLabelValues(searchType, abstainReason).Inc()
+	}
+	if v.DroppedLowScore > 0 {
+		metrics.RAGVerifyDroppedTotal.WithLabelValues(searchType, "low_score").Add(float64(v.DroppedLowScore))
+	}
+	if v.DroppedBadMeta > 0 {
+		metrics.RAGVerifyDroppedTotal.WithLabelValues(searchType, "bad_metadata").Add(float64(v.DroppedBadMeta))
+	}
+}
 
 type resultVerification struct {
 	Total             int `json:"total"`

--- a/Levara/internal/metrics/telemetry.go
+++ b/Levara/internal/metrics/telemetry.go
@@ -148,6 +148,25 @@ var (
 		Name: "levara_wal_recoveries_total",
 		Help: "WAL recovery passes by result (ok|fail), summed across shards",
 	}, []string{"result"})
+
+	// 14. RAG verify-stack observability. Default thresholds are 0 (disabled)
+	// so these metrics let an operator observe live confidence distributions
+	// before opting in to abstain/verify behavior.
+	RAGConfidence = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "levara_rag_confidence",
+		Help:    "Distribution of combined RAG confidence scores by search type",
+		Buckets: []float64{.05, .1, .2, .3, .4, .5, .6, .7, .8, .9, .95},
+	}, []string{"search_type"})
+
+	RAGAbstainTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "levara_rag_abstain_total",
+		Help: "RAG completions that abstained, by search type and reason (low_confidence|no_evidence)",
+	}, []string{"search_type", "reason"})
+
+	RAGVerifyDroppedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "levara_rag_verify_dropped_total",
+		Help: "Result rows dropped by verify stage, by search type and reason (low_score|bad_metadata)",
+	}, []string{"search_type", "reason"})
 )
 
 func init() {
@@ -155,4 +174,14 @@ func init() {
 	// hides them just because no recovery has happened in this process.
 	WALRecoveriesTotal.WithLabelValues("ok")
 	WALRecoveriesTotal.WithLabelValues("fail")
+
+	// Eagerly materialize RAG verify-stack series at 0 across the known
+	// search types and reasons so dashboards/alerts can reference a stable
+	// label set instead of waiting for a real abstain/drop to appear.
+	for _, st := range []string{"RAG_COMPLETION", "GRAPH_COMPLETION", "GRAPH_COMPLETION_CONTEXT_EXTENSION"} {
+		RAGAbstainTotal.WithLabelValues(st, "low_confidence")
+		RAGAbstainTotal.WithLabelValues(st, "strict_grounded_no_evidence")
+		RAGVerifyDroppedTotal.WithLabelValues(st, "low_score")
+		RAGVerifyDroppedTotal.WithLabelValues(st, "bad_metadata")
+	}
 }


### PR DESCRIPTION
## Summary
- Adds three Prometheus metrics (`levara_rag_confidence`, `levara_rag_abstain_total`, `levara_rag_verify_dropped_total`) so operators can observe live confidence distributions and verify-stage drops before tuning abstain thresholds (still disabled by default at 0).
- Wires `emitRAGMetrics()` at all three RAG completion callsites: `RAG_COMPLETION`, `GRAPH_COMPLETION`, `GRAPH_COMPLETION_CONTEXT_EXTENSION`.
- Eagerly materializes known label combinations at 0 on startup so dashboards and alerts can reference a stable label set.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/http/... ./internal/metrics/...`
- [ ] Deploy to stage and verify the three series appear in `/metrics` at 0 on a clean start
- [ ] Send a few RAG queries and confirm `levara_rag_confidence` populates per `search_type`

🤖 Generated with [Claude Code](https://claude.com/claude-code)