### PR TITLE
feat(mcp): runtime_stats + ingestion_status observability tools

### DIFF
--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -613,6 +613,10 @@ func (h *mcpHandler) executeToolInner(ctx context.Context, sess *mcpSession, nam
 		return h.toolDoctor(ctx, args)
 	case "heartbeat":
 		return h.toolHeartbeat(ctx, args)
+	case "runtime_stats":
+		return h.toolRuntimeStats(ctx, args)
+	case "ingestion_status":
+		return h.toolIngestionStatus(ctx, args)
 	default:
 		return mcpToolResult{
 			Content: []mcpContent{{Type: "text", Text: fmt.Sprintf("Unknown tool: %s", name)}},

--- a/Levara/internal/http/mcp_observability.go
+++ b/Levara/internal/http/mcp_observability.go
@@ -1,0 +1,142 @@
+// mcp_observability.go — Agent-facing runtime observability MCP tools.
+//
+// `doctor` and `heartbeat` already cover health checks and recent event
+// history. These tools fill the gap between them: a single snapshot of
+// live runtime state (`runtime_stats`) and a queryable view of in-flight
+// + recent ingestion runs (`ingestion_status`).
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"runtime"
+	"time"
+)
+
+// toolRuntimeStats returns a compact snapshot of the running instance:
+// per-collection record counts and embedding model, dependency
+// configuration (embed/llm/rerank/neo4j endpoints + flags), and basic
+// process metrics. Read-only and safe to call frequently.
+func (h *mcpHandler) toolRuntimeStats(ctx context.Context, args map[string]any) mcpToolResult {
+	type collectionEntry struct {
+		Name           string `json:"name"`
+		Records        int    `json:"records"`
+		Dim            int    `json:"dim"`
+		Metric         string `json:"metric"`
+		EmbeddingModel string `json:"embedding_model"`
+		Domain         string `json:"domain,omitempty"`
+	}
+
+	var collections []collectionEntry
+	totalRecords := 0
+	if h.cfg.Collections != nil {
+		for _, m := range h.cfg.Collections.ListWithMeta() {
+			collections = append(collections, collectionEntry{
+				Name:           m.Name,
+				Records:        m.RecordCount,
+				Dim:            m.EmbeddingDim,
+				Metric:         m.DistanceMetric,
+				EmbeddingModel: m.EmbeddingModel,
+				Domain:         m.Domain,
+			})
+			totalRecords += m.RecordCount
+		}
+	}
+
+	llmModel := ""
+	llmProvider := ""
+	if h.cfg.LLMProvider != nil {
+		llmProvider = "configured"
+		llmModel = os.Getenv("LLM_MODEL")
+	}
+
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	out := map[string]any{
+		"collections":       collections,
+		"collection_count":  len(collections),
+		"total_records":     totalRecords,
+		"embed_endpoint":    h.cfg.EmbedEndpoint,
+		"embed_model":       h.cfg.EmbedModel,
+		"llm_provider":      llmProvider,
+		"llm_model":         llmModel,
+		"rerank_enabled":    h.cfg.RerankEndpoint != "",
+		"rerank_model":      h.cfg.RerankModel,
+		"neo4j_enabled":     h.cfg.Neo4jCfg.Neo4jURL != "",
+		"goroutines":        runtime.NumGoroutine(),
+		"heap_alloc_bytes":  ms.HeapAlloc,
+		"heap_sys_bytes":    ms.HeapSys,
+		"num_gc":            ms.NumGC,
+		"snapshot_taken_at": time.Now().UTC().Format(time.RFC3339),
+	}
+
+	data, _ := json.MarshalIndent(out, "", "  ")
+	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(data)}}}
+}
+
+// toolIngestionStatus surfaces in-flight and recently completed
+// background pipeline runs (cognify, codify, analyze_commits) from the
+// in-memory run registry. Filter by status (RUNNING|COMPLETED|FAILED) or
+// limit the result set.
+func (h *mcpHandler) toolIngestionStatus(ctx context.Context, args map[string]any) mcpToolResult {
+	if h.cfg.Runs == nil {
+		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: `{"error":"run registry unavailable"}`}}, IsError: true}
+	}
+
+	statusFilter, _ := args["status"].(string)
+	limit := 20
+	if v, ok := args["limit"].(float64); ok && v > 0 {
+		limit = int(v)
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	all := h.cfg.Runs.Snapshot()
+	running := 0
+	completed := 0
+	failed := 0
+	filtered := make([]any, 0, len(all))
+	for _, s := range all {
+		switch s.Status {
+		case "RUNNING":
+			running++
+		case "COMPLETED":
+			completed++
+		case "FAILED":
+			failed++
+		}
+		if statusFilter != "" && s.Status != statusFilter {
+			continue
+		}
+		if len(filtered) >= limit {
+			continue
+		}
+		filtered = append(filtered, map[string]any{
+			"pipeline_run_id":    s.RunID,
+			"status":             s.Status,
+			"stage":              s.Stage,
+			"message":            s.Message,
+			"chunks_created":     s.Chunks,
+			"entities_extracted": s.Entities,
+			"edges_extracted":    s.Edges,
+			"elapsed_ms":         s.ElapsedMs,
+			"started_at":         s.StartedAt.UTC().Format(time.RFC3339),
+		})
+	}
+
+	out := map[string]any{
+		"summary": map[string]any{
+			"total":     len(all),
+			"running":   running,
+			"completed": completed,
+			"failed":    failed,
+		},
+		"runs": filtered,
+	}
+	data, _ := json.MarshalIndent(out, "", "  ")
+	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(data)}}}
+}
+

--- a/Levara/pkg/mcp/tools.go
+++ b/Levara/pkg/mcp/tools.go
@@ -611,6 +611,68 @@ func ToolDescriptors() []Tool {
 		},
 	},
 	{
+		Name:        "runtime_stats",
+		Description: "Snapshot of live runtime state: per-collection record counts and embedding model, dependency configuration (embed/llm/rerank/neo4j), goroutine and heap stats. Use to answer 'what is this instance running right now?' without parsing /metrics.",
+		OutputSchema: objectSchema(map[string]any{
+			"collections": arrayOfObjectsProp(objectSchema(map[string]any{
+				"name":            stringProp("Collection name."),
+				"records":         integerProp("Vector count."),
+				"dim":             integerProp("Embedding dimension."),
+				"metric":          stringProp("cosine|l2|dot"),
+				"embedding_model": stringProp("Model used to embed this collection."),
+				"domain":          stringProp("Optional domain tag."),
+			}), "Per-collection state."),
+			"collection_count":  integerProp("Number of collections."),
+			"total_records":     integerProp("Sum of records across all collections."),
+			"embed_endpoint":    stringProp("Embedding service URL."),
+			"embed_model":       stringProp("Default embedding model."),
+			"llm_provider":      stringProp("'configured' when an LLM provider is wired, '' otherwise."),
+			"llm_model":         stringProp("LLM model name."),
+			"rerank_enabled":    map[string]any{"type": "boolean", "description": "Whether a reranker is wired."},
+			"rerank_model":      stringProp("Reranker model name."),
+			"neo4j_enabled":     map[string]any{"type": "boolean", "description": "Whether Neo4j graph backend is configured."},
+			"goroutines":        integerProp("Live goroutine count."),
+			"heap_alloc_bytes":  integerProp("Currently allocated heap bytes."),
+			"heap_sys_bytes":    integerProp("Heap memory obtained from OS."),
+			"num_gc":            integerProp("Completed GC cycles since start."),
+			"snapshot_taken_at": stringProp("RFC3339 timestamp."),
+		}),
+		InputSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+	},
+	{
+		Name:        "ingestion_status",
+		Description: "List in-flight and recently completed background pipeline runs (cognify, codify, analyze_commits) from the run registry, sorted newest-first. Use to debug stuck ingestion or confirm a long-running cognify finished.",
+		OutputSchema: objectSchema(map[string]any{
+			"summary": objectSchema(map[string]any{
+				"total":     integerProp("Total runs currently retained."),
+				"running":   integerProp("Runs in RUNNING state."),
+				"completed": integerProp("Runs in COMPLETED state."),
+				"failed":    integerProp("Runs in FAILED state."),
+			}),
+			"runs": arrayOfObjectsProp(objectSchema(map[string]any{
+				"pipeline_run_id":    stringProp("Run UUID."),
+				"status":             stringProp("RUNNING|COMPLETED|FAILED"),
+				"stage":              stringProp("Current/last stage name."),
+				"message":            stringProp("Free-form status message."),
+				"chunks_created":     integerProp(""),
+				"entities_extracted": integerProp(""),
+				"edges_extracted":    integerProp(""),
+				"elapsed_ms":         integerProp("Wall-clock duration."),
+				"started_at":         stringProp("RFC3339."),
+			}), "Filtered run list (newest first)."),
+		}),
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"status": map[string]any{"type": "string", "description": "Filter by RUNNING|COMPLETED|FAILED. Empty = all."},
+				"limit":  map[string]any{"type": "integer", "default": 20, "description": "Max runs to return (1-100)."},
+			},
+		},
+	},
+	{
 		Name:        "heartbeat",
 		Description: "Query recent system heartbeat events (doctor runs, sync, cognify completions, prune). Useful to understand system activity history and detect degradation patterns.",
 		OutputSchema: objectSchema(map[string]any{

--- a/Levara/pkg/runreg/runreg.go
+++ b/Levara/pkg/runreg/runreg.go
@@ -11,6 +11,7 @@
 package runreg
 
 import (
+	"sort"
 	"sync"
 	"time"
 )
@@ -95,6 +96,24 @@ func (r *Registry) PruneTerminalOlderThan(age time.Duration) int {
 		return true
 	})
 	return evicted
+}
+
+// Snapshot returns a copy of every run currently tracked, sorted by
+// StartedAt descending (newest first). Callers may safely mutate the
+// returned slice; the *Status pointers themselves are shared but the
+// registry treats stored entries as immutable after Store.
+func (r *Registry) Snapshot() []*Status {
+	var out []*Status
+	r.runs.Range(func(_, v any) bool {
+		if s, ok := v.(*Status); ok && s != nil {
+			out = append(out, s)
+		}
+		return true
+	})
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].StartedAt.After(out[j].StartedAt)
+	})
+	return out
 }
 
 // StartJanitor launches a goroutine that periodically calls

--- a/Levara/pkg/runreg/runreg_test.go
+++ b/Levara/pkg/runreg/runreg_test.go
@@ -8,6 +8,29 @@ import (
 	"time"
 )
 
+func TestRegistry_SnapshotSortsNewestFirst(t *testing.T) {
+	r := New()
+	now := time.Now()
+	r.Store("old", &Status{RunID: "old", Status: "COMPLETED", StartedAt: now.Add(-2 * time.Hour)})
+	r.Store("new", &Status{RunID: "new", Status: "RUNNING", StartedAt: now})
+	r.Store("mid", &Status{RunID: "mid", Status: "FAILED", StartedAt: now.Add(-1 * time.Hour)})
+
+	snap := r.Snapshot()
+	if len(snap) != 3 {
+		t.Fatalf("Snapshot len = %d, want 3", len(snap))
+	}
+	if snap[0].RunID != "new" || snap[1].RunID != "mid" || snap[2].RunID != "old" {
+		t.Errorf("unexpected order: %s, %s, %s", snap[0].RunID, snap[1].RunID, snap[2].RunID)
+	}
+}
+
+func TestRegistry_SnapshotEmpty(t *testing.T) {
+	r := New()
+	if got := r.Snapshot(); len(got) != 0 {
+		t.Errorf("empty registry Snapshot returned %d entries", len(got))
+	}
+}
+
 func TestRegistry_StoreLoadRoundTrip(t *testing.T) {
 	r := New()
 	s := &Status{


### PR DESCRIPTION
## Summary
- Two new MCP tools fill the gap between `doctor` (health checks) and `heartbeat` (event log).
- `runtime_stats`: live snapshot of per-collection records, embedding config, dependency wiring (embed/llm/rerank/neo4j), and process metrics (goroutines, heap, GC). Answers "what is this instance running right now?" without parsing /metrics.
- `ingestion_status`: in-flight + recently completed background runs (cognify, codify, analyze_commits) from the run registry, sorted newest-first with optional status filter.
- Adds `pkg/runreg.Registry.Snapshot()` for safe enumeration; the registry previously only exposed Load/Store/Delete.

Motivation: agent DX gap identified in the InsForge analysis — agents currently have to guess at runtime state. These tools make it queryable in one call.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/http/... ./pkg/mcp/... ./pkg/runreg/...`
- [x] New unit tests for `Snapshot` ordering + empty registry
- [ ] Smoke: call `runtime_stats` and `ingestion_status` from MCP client against a running stack
- [ ] Verify tool descriptors appear in `tools/list` MCP response

🤖 Generated with [Claude Code](https://claude.com/claude-code)