### PR TITLE
feat(mcp): recent_errors + sync_status observability tools (iter 2)

### DIFF
--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -617,6 +617,10 @@ func (h *mcpHandler) executeToolInner(ctx context.Context, sess *mcpSession, nam
 		return h.toolRuntimeStats(ctx, args)
 	case "ingestion_status":
 		return h.toolIngestionStatus(ctx, args)
+	case "recent_errors":
+		return h.toolRecentErrors(ctx, args)
+	case "sync_status":
+		return h.toolSyncStatus(ctx, args)
 	default:
 		return mcpToolResult{
 			Content: []mcpContent{{Type: "text", Text: fmt.Sprintf("Unknown tool: %s", name)}},

--- a/Levara/internal/http/mcp_observability.go
+++ b/Levara/internal/http/mcp_observability.go
@@ -140,3 +140,172 @@ func (h *mcpHandler) toolIngestionStatus(ctx context.Context, args map[string]an
 	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(data)}}}
 }
 
+
+// toolRecentErrors aggregates recent error signals from two sources:
+// FAILED background runs in the registry, and doctor heartbeats whose
+// payload reported any check with status=fail. Designed to answer
+// "what's been going wrong lately?" without grepping logs.
+func (h *mcpHandler) toolRecentErrors(ctx context.Context, args map[string]any) mcpToolResult {
+	limit := 20
+	if v, ok := args["limit"].(float64); ok && v > 0 {
+		limit = int(v)
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	type errorEntry struct {
+		Source    string `json:"source"` // "pipeline_run" | "doctor"
+		Stage     string `json:"stage,omitempty"`
+		Message   string `json:"message"`
+		Reference string `json:"reference,omitempty"` // run_id or heartbeat_id
+		At        string `json:"at"`
+	}
+
+	var entries []errorEntry
+
+	if h.cfg.Runs != nil {
+		for _, s := range h.cfg.Runs.Snapshot() {
+			if s.Status != "FAILED" {
+				continue
+			}
+			entries = append(entries, errorEntry{
+				Source:    "pipeline_run",
+				Stage:     s.Stage,
+				Message:   s.Message,
+				Reference: s.RunID,
+				At:        s.StartedAt.UTC().Format(time.RFC3339),
+			})
+		}
+	}
+
+	if h.cfg.DB != nil {
+		rows, err := h.cfg.DB.QueryContext(ctx,
+			Q(`SELECT id, payload, created_at FROM heartbeats
+			   WHERE event_type = 'doctor' ORDER BY created_at DESC LIMIT $1`), 50)
+		if err == nil {
+			defer rows.Close()
+			for rows.Next() {
+				var id, payload, createdAt string
+				if err := rows.Scan(&id, &payload, &createdAt); err != nil {
+					continue
+				}
+				var report struct {
+					Status string `json:"status"`
+					Checks []struct {
+						Name    string `json:"name"`
+						Status  string `json:"status"`
+						Message string `json:"message"`
+					} `json:"checks"`
+				}
+				if json.Unmarshal([]byte(payload), &report) != nil {
+					continue
+				}
+				for _, ch := range report.Checks {
+					if ch.Status != "fail" {
+						continue
+					}
+					entries = append(entries, errorEntry{
+						Source:    "doctor",
+						Stage:     ch.Name,
+						Message:   ch.Message,
+						Reference: id,
+						At:        createdAt,
+					})
+				}
+			}
+		}
+	}
+
+	// Already mostly-sorted (registry first, then doctor desc); cap.
+	if len(entries) > limit {
+		entries = entries[:limit]
+	}
+
+	data, _ := json.MarshalIndent(map[string]any{
+		"count":  len(entries),
+		"errors": entries,
+	}, "", "  ")
+	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(data)}}}
+}
+
+// toolSyncStatus summarizes recent sync events per direction (push|pull)
+// from the heartbeats table. Returns last-seen-at and count for each
+// direction plus the most recent N events. Sync only emits a heartbeat
+// on success today, so this view answers "did sync run lately?" rather
+// than "did sync fail?".
+func (h *mcpHandler) toolSyncStatus(ctx context.Context, args map[string]any) mcpToolResult {
+	if h.cfg.DB == nil {
+		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: `{"error":"no database configured"}`}}, IsError: true}
+	}
+
+	limit := 10
+	if v, ok := args["limit"].(float64); ok && v > 0 {
+		limit = int(v)
+	}
+	if limit > 50 {
+		limit = 50
+	}
+
+	rows, err := h.cfg.DB.QueryContext(ctx,
+		Q(`SELECT id, payload, created_at FROM heartbeats
+		   WHERE event_type = 'sync' ORDER BY created_at DESC LIMIT $1`), limit)
+	if err != nil {
+		return mcpToolResult{Content: []mcpContent{{Type: "text", Text: `{"error":"sync heartbeats query failed"}`}}, IsError: true}
+	}
+	defer rows.Close()
+
+	type perDirection struct {
+		Count      int    `json:"count"`
+		LastAt     string `json:"last_at"`
+		LastRemote string `json:"last_remote"`
+	}
+	byDir := map[string]*perDirection{}
+	type evt struct {
+		ID        string          `json:"id"`
+		Direction string          `json:"direction"`
+		Remote    string          `json:"remote"`
+		Types     json.RawMessage `json:"types,omitempty"`
+		At        string          `json:"at"`
+	}
+	var events []evt
+
+	for rows.Next() {
+		var id, payload, createdAt string
+		if err := rows.Scan(&id, &payload, &createdAt); err != nil {
+			continue
+		}
+		var p struct {
+			Direction string          `json:"direction"`
+			Remote    string          `json:"remote"`
+			Types     json.RawMessage `json:"types"`
+		}
+		if json.Unmarshal([]byte(payload), &p) != nil {
+			continue
+		}
+		dir := p.Direction
+		if dir == "" {
+			dir = "unknown"
+		}
+		entry := byDir[dir]
+		if entry == nil {
+			entry = &perDirection{LastAt: createdAt, LastRemote: p.Remote}
+			byDir[dir] = entry
+		}
+		entry.Count++
+		events = append(events, evt{
+			ID:        id,
+			Direction: dir,
+			Remote:    p.Remote,
+			Types:     p.Types,
+			At:        createdAt,
+		})
+	}
+
+	data, _ := json.MarshalIndent(map[string]any{
+		"by_direction": byDir,
+		"events":       events,
+	}, "", "  ")
+	return mcpToolResult{Content: []mcpContent{{Type: "text", Text: string(data)}}}
+}
+

--- a/Levara/pkg/mcp/tools.go
+++ b/Levara/pkg/mcp/tools.go
@@ -673,6 +673,49 @@ func ToolDescriptors() []Tool {
 		},
 	},
 	{
+		Name:        "recent_errors",
+		Description: "Aggregated recent error signals: FAILED background runs (cognify/codify/analyze_commits) plus doctor heartbeats whose checks reported status=fail. Use as a single 'what's been going wrong lately?' query without grepping logs.",
+		OutputSchema: objectSchema(map[string]any{
+			"count": integerProp("Total entries returned."),
+			"errors": arrayOfObjectsProp(objectSchema(map[string]any{
+				"source":    stringProp("'pipeline_run' or 'doctor'."),
+				"stage":     stringProp("Run stage or doctor check name."),
+				"message":   stringProp("Free-form error message."),
+				"reference": stringProp("run_id or heartbeat_id."),
+				"at":        stringProp("RFC3339 timestamp."),
+			}), "Error entries, newest-ish first."),
+		}),
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"limit": map[string]any{"type": "integer", "default": 20, "description": "Max entries (1-100)."},
+			},
+		},
+	},
+	{
+		Name:        "sync_status",
+		Description: "Summarize recent sync events per direction (push|pull) from heartbeats: count, last-seen-at, last remote URL, and the most recent N events. Sync emits a heartbeat on success only — answers 'did sync run lately?' rather than 'did sync fail?'.",
+		OutputSchema: objectSchema(map[string]any{
+			"by_direction": map[string]any{
+				"type":        "object",
+				"description": "Per-direction summary: count, last_at, last_remote.",
+			},
+			"events": arrayOfObjectsProp(objectSchema(map[string]any{
+				"id":        stringProp("Heartbeat UUID."),
+				"direction": stringProp("push|pull|unknown."),
+				"remote":    stringProp("Remote URL."),
+				"types":     map[string]any{"description": "Sync types payload as recorded."},
+				"at":        stringProp("RFC3339."),
+			}), "Recent sync events, newest first."),
+		}),
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"limit": map[string]any{"type": "integer", "default": 10, "description": "Max events (1-50)."},
+			},
+		},
+	},
+	{
 		Name:        "heartbeat",
 		Description: "Query recent system heartbeat events (doctor runs, sync, cognify completions, prune). Useful to understand system activity history and detect degradation patterns.",
 		OutputSchema: objectSchema(map[string]any{


### PR DESCRIPTION
## Summary
- Iteration 2 of agent-facing observability, complementing PR #51's `runtime_stats` and `ingestion_status`.
- `recent_errors`: aggregates FAILED runs from the registry + doctor-heartbeat checks reporting status=fail. Single "what's been going wrong lately?" query.
- `sync_status`: per-direction summary (count, last_at, last_remote) + last N sync events from heartbeats. Sync emits on success only today, so this answers "did sync run lately?".

## Test plan
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 -timeout=300s ./...` clean across all 40+ packages
- [ ] Smoke: call `recent_errors` and `sync_status` against a running stack
- [ ] Verify both tools appear in `tools/list` and have valid schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)