### PR TITLE
feat(mcp): levara_instructions versioned agent contract tool

### DIFF
--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -440,6 +440,7 @@ func (h *mcpHandler) handleRPC(c *fiber.Ctx) error {
 					"name":    "levara",
 					"version": "1.0.0",
 				},
+				"instructions": "Call the `levara_instructions` tool for the versioned agent contract (memory model, when-to-save rules, observability toolkit, anti-patterns). Contract revision: " + mcp.AgentContractVersion + ".",
 			},
 		})
 
@@ -621,6 +622,8 @@ func (h *mcpHandler) executeToolInner(ctx context.Context, sess *mcpSession, nam
 		return h.toolRecentErrors(ctx, args)
 	case "sync_status":
 		return h.toolSyncStatus(ctx, args)
+	case "levara_instructions":
+		return mcp.ToolLevaraInstructions(ctx, h, args)
 	default:
 		return mcpToolResult{
 			Content: []mcpContent{{Type: "text", Text: fmt.Sprintf("Unknown tool: %s", name)}},

--- a/Levara/pkg/mcp/agent_contract.md
+++ b/Levara/pkg/mcp/agent_contract.md
@@ -1,0 +1,95 @@
+# Levara Agent Contract — v1
+
+Authoritative guidance for agents using Levara MCP tools. This document is
+embedded in the binary; the `levara_instructions` tool returns it verbatim
+plus a content hash for client-side caching.
+
+## 1. Memory Model: room × hall
+
+Every memory has two independent axes. **Always set both** when saving —
+empty fields drop recall quality sharply.
+
+| Axis | Meaning | Vocabulary |
+|---|---|---|
+| `room` | What the memory is *about* (free-form subject/subsystem) | e.g. `auth`, `deploy`, `mcp`, `kg-temporal` |
+| `hall` | What *kind* of memory it is (controlled enum) | see below |
+
+Hall vocabulary (server rejects unknown values):
+
+- `fact` — objective characteristic: version, dim, IP, path, number.
+- `event` — something happened at a specific time. Always include an
+  absolute date in the value.
+- `decision` — architectural/project choice; record the *why*, not just
+  the *what*.
+- `preference` — user preference: style, tone, tools, flags.
+- `advice` — reusable rule: "before X, do Y."
+- `discovery` — non-obvious insight or bug; symptom + cause + fix.
+
+## 2. When to Save (without being asked)
+
+Trigger an immediate `save_memory` when any of these happens:
+
+| Trigger | Hall |
+|---|---|
+| User picks an architectural option ("we'll use X, not Y") | `decision` |
+| Root cause of a bug found after investigation | `discovery` |
+| User corrects your approach or sets a style rule | `preference` |
+| New endpoint / IP / port / version appears | `fact` |
+| Significant milestone shipped | `event` (with absolute date) |
+| Reusable rule emerges in conversation | `advice` |
+| Deadline or freeze window mentioned | `event` (with absolute date) |
+
+## 3. What NOT to Save
+
+- File paths, function names, code snippets — these are in git/grep and
+  rot under refactors.
+- Git history, who-changed-what — `git log` is authoritative.
+- Intermediate steps of the current task — use TaskCreate, not memory.
+- Anything already in CLAUDE.md or the MCP initialize hints.
+- Duplicates — search first; supersede instead of overwriting.
+
+## 4. Recall Patterns
+
+| Question | Call |
+|---|---|
+| "What did we decide about auth?" | `recall_memory(query="auth", hall="decision")` |
+| "All my style preferences" | `list_memories(hall="preference")` |
+| "Bugs we hit in migrations" | `recall_memory(query="migration", hall="discovery")` |
+| "Everything tagged deploy" | `list_memories(room="deploy")` |
+| "Across multiple projects" | `cross_search(collections=[...])` |
+
+## 5. Pin Policy
+
+Use `pin_memory(key, priority)` sparingly. Pinned entries always surface
+in `wake_up`, which has a token budget.
+
+| priority | when |
+|---|---|
+| 10 | global user preferences (style, language, hard rules) |
+| 8 | critical infra (endpoints, IPs, ports, versions) |
+| 5 | active decisions for major subsystems |
+| 1-3 | optional context |
+
+## 6. Observability Toolkit
+
+These tools answer "what is this instance doing right now?" without
+parsing `/metrics`:
+
+- `runtime_stats` — collections, embed/llm/rerank config, process state.
+- `ingestion_status` — in-flight + recent cognify/codify/analyze runs.
+- `recent_errors` — failed runs + doctor checks reporting `fail`.
+- `sync_status` — last sync per direction (push/pull) from heartbeats.
+- `doctor` — full health check across dependencies.
+- `heartbeat` — recent system events log.
+
+## 7. Anti-patterns
+
+- **Recommending in a vacuum.** Before any architectural suggestion for
+  this project, call `recall_memory` on the topic — a prior decision may
+  already exist.
+- **Overwriting decisions.** Use `supersede` semantics, not blind
+  `save_memory` on the same key. Audit trail matters.
+- **Saving file/function names.** They rot. Save the *concept* and let
+  the agent locate the symbol via grep when needed.
+- **Skipping the `why`.** A decision without a reason can't survive an
+  edge case re-evaluation six months later.

--- a/Levara/pkg/mcp/tool_instructions.go
+++ b/Levara/pkg/mcp/tool_instructions.go
@@ -1,0 +1,47 @@
+// tool_instructions.go — Versioned agent contract served via MCP.
+//
+// The contract markdown (agent_contract.md) is embedded in the binary so
+// the document ships with the server and cannot drift from the runtime
+// it describes. Clients receive the markdown plus a content hash so they
+// can cache and detect changes across deploys.
+package mcp
+
+import (
+	"context"
+	_ "embed"
+	"encoding/hex"
+	"encoding/json"
+	"crypto/sha256"
+)
+
+//go:embed agent_contract.md
+var agentContractMD string
+
+// AgentContractVersion is the human-readable contract revision. Bump
+// whenever the embedded markdown changes meaningfully (not for typos).
+const AgentContractVersion = "v1"
+
+// AgentContractMarkdown returns the embedded contract verbatim. Exposed
+// for callers (e.g. the HTTP `initialize` handler) that want to hint at
+// the contract without going through tools/call.
+func AgentContractMarkdown() string { return agentContractMD }
+
+// AgentContractSHA returns the hex-encoded SHA-256 of the contract
+// markdown. Stable across builds with identical content; clients use it
+// as a cache key.
+func AgentContractSHA() string {
+	sum := sha256.Sum256([]byte(agentContractMD))
+	return hex.EncodeToString(sum[:])
+}
+
+// ToolLevaraInstructions returns the embedded agent contract. No
+// dependencies, no DB access — pure read of the binary's own bytes.
+func ToolLevaraInstructions(ctx context.Context, deps Deps, args map[string]any) ToolResult {
+	out := map[string]any{
+		"version":          AgentContractVersion,
+		"content_sha":      AgentContractSHA(),
+		"content_markdown": agentContractMD,
+	}
+	data, _ := json.MarshalIndent(out, "", "  ")
+	return ToolResult{Content: []Content{{Type: "text", Text: string(data)}}}
+}

--- a/Levara/pkg/mcp/tool_instructions_test.go
+++ b/Levara/pkg/mcp/tool_instructions_test.go
@@ -1,0 +1,52 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAgentContractEmbeddedAndNonEmpty(t *testing.T) {
+	if len(agentContractMD) < 200 {
+		t.Fatalf("agent contract markdown looks too short (%d bytes) — embed likely failed", len(agentContractMD))
+	}
+	if !strings.Contains(agentContractMD, "Levara Agent Contract") {
+		t.Errorf("contract missing expected title")
+	}
+}
+
+func TestAgentContractSHAStable(t *testing.T) {
+	a := AgentContractSHA()
+	b := AgentContractSHA()
+	if a != b {
+		t.Errorf("SHA not stable: %s vs %s", a, b)
+	}
+	if len(a) != 64 {
+		t.Errorf("expected 64-char hex SHA, got %d chars", len(a))
+	}
+}
+
+func TestToolLevaraInstructionsReturnsValidJSON(t *testing.T) {
+	res := ToolLevaraInstructions(context.Background(), nil, nil)
+	if res.IsError {
+		t.Fatalf("unexpected IsError: %+v", res.Content)
+	}
+	if len(res.Content) != 1 {
+		t.Fatalf("expected 1 content block, got %d", len(res.Content))
+	}
+	var parsed struct {
+		Version         string `json:"version"`
+		ContentSHA      string `json:"content_sha"`
+		ContentMarkdown string `json:"content_markdown"`
+	}
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if parsed.Version == "" || parsed.ContentSHA == "" || parsed.ContentMarkdown == "" {
+		t.Errorf("missing required fields: %+v", parsed)
+	}
+	if parsed.ContentSHA != AgentContractSHA() {
+		t.Errorf("returned SHA mismatch")
+	}
+}

--- a/Levara/pkg/mcp/tools.go
+++ b/Levara/pkg/mcp/tools.go
@@ -611,6 +611,19 @@ func ToolDescriptors() []Tool {
 		},
 	},
 	{
+		Name:        "levara_instructions",
+		Description: "Versioned agent contract: memory model (room × hall), when-to-save rules, what-not-to-save, recall patterns, pin policy, observability toolkit, anti-patterns. Returns the embedded markdown plus a content hash for client-side caching. Call once per session and follow what it says — overrides any conflicting hint in the initialize response.",
+		OutputSchema: objectSchema(map[string]any{
+			"version":          stringProp("Contract revision string (bumped on meaningful changes)."),
+			"content_sha":      stringProp("SHA-256 of the markdown body, hex-encoded."),
+			"content_markdown": stringProp("Full agent contract as markdown."),
+		}),
+		InputSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+	},
+	{
 		Name:        "runtime_stats",
 		Description: "Snapshot of live runtime state: per-collection record counts and embedding model, dependency configuration (embed/llm/rerank/neo4j), goroutine and heap stats. Use to answer 'what is this instance running right now?' without parsing /metrics.",
 		OutputSchema: objectSchema(map[string]any{


### PR DESCRIPTION
## Summary
- New `levara_instructions` MCP tool returning `{version, content_sha, content_markdown}` for the embedded agent contract (`agent_contract.md`, v1).
- MCP `initialize` response now advertises the tool + current contract revision so fresh agents have a single canonical entrypoint.
- Contract is shipped via `go:embed` — cannot drift from the runtime that describes it. SHA-256 lets clients cache and invalidate across deploys.

InsForge roadmap P0.2: replaces per-client CLAUDE.md drift with one server-authoritative document covering memory model (room × hall), save triggers, recall patterns, pin policy, observability toolkit, and anti-patterns.

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./pkg/mcp/... ./internal/http/...`
- [ ] Manual: `tools/call` `levara_instructions` returns valid JSON with non-empty markdown and 64-char SHA.
- [ ] Manual: `initialize` response carries `instructions` field referencing the tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)