### PR TITLE
fix(devx): align stack-dev DB defaults + warn on silent ping failure

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -20,9 +20,13 @@ EMBEDDING_PROVIDER=openai
 # HUGGINGFACE_TOKENIZER=           # Required for Ollama embeddings
 
 # --- PostgreSQL ---
-POSTGRES_USER=cognee
-POSTGRES_PASSWORD=cognee
-POSTGRES_DB=cognee_db
+# Defaults align with Levara server defaults (cmd/server/main.go) so a fresh
+# `make stack-dev` reaches a working DB without edits. If you carry a
+# pre-existing postgres-data volume from a previous (Cognee-era) install, run
+# `make stack-dev-reset` to wipe it before bringing the stack back up.
+POSTGRES_USER=levara
+POSTGRES_PASSWORD=levara
+POSTGRES_DB=levara_db
 
 # --- Neo4j ---
 NEO4J_PASSWORD=pleaseletmein

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help up down full-stack full-stack-down build test benchmark proto clean install-hook qv-stack qv-stack-down qv-stack-logs stack-dev stack-dev-down stack-dev-logs
+.PHONY: help up down full-stack full-stack-down build test benchmark proto clean install-hook qv-stack qv-stack-down qv-stack-logs stack-dev stack-dev-down stack-dev-logs stack-dev-reset
 
 # Default
 help:
@@ -18,6 +18,7 @@ help:
 	@echo "  make stack-dev       One-command bootstrap: up + wait-for-health + pull embed model"
 	@echo "  make stack-dev-down  Stop the LevaraOS stack"
 	@echo "  make stack-dev-logs  Follow Levara logs"
+	@echo "  make stack-dev-reset Destroy volumes + reboot (use after Cognee-era upgrade)"
 	@echo ""
 	@echo "QV Mode (local llama-server + full stack):"
 	@echo "  make qv-stack        Start all services for qv mode (requires qv running on :9004)"
@@ -77,6 +78,16 @@ stack-dev-down:
 
 stack-dev-logs:
 	docker compose -f docker-compose.levaraos.yml logs -f levara
+
+# Wipe the LevaraOS postgres + levara volumes and bring the stack back up.
+# Use after upgrading from an older (Cognee-era) volume whose Postgres user
+# does not match the current credentials. DESTRUCTIVE — Postgres metadata
+# (memories, datasets, feedback) and Levara's persisted vectors are deleted.
+stack-dev-reset:
+	@echo "About to destroy LevaraOS volumes (postgres-data, levara-data, ...)."
+	@read -p "Type 'yes' to confirm: " ans && [ "$$ans" = "yes" ] || (echo "aborted"; exit 1)
+	docker compose -f docker-compose.levaraos.yml down -v
+	@bash tools/stack-dev-up.sh
 
 # --- QV Mode (local llama-server + full stack) ---
 

--- a/tools/stack-dev-up.sh
+++ b/tools/stack-dev-up.sh
@@ -49,6 +49,19 @@ until curl -sf "$LEVARA_URL/metrics" > /dev/null 2>&1; do
 done
 log "Levara healthy"
 
+# 3a. Detect silent DB-init failure. /metrics succeeds even when Levara
+#     could not reach Postgres — but memory tools, auth, and sync all
+#     return 5xx in that state. Surfacing this loudly here saves an hour
+#     of "why does save_memory return 'database not configured'".
+# `grep -q` exits early under pipefail and SIGPIPEs `docker logs`, masking
+# matches as failures — so use a full read with output suppressed instead.
+if docker logs levara 2>&1 | grep -E "running without DB|PostgreSQL ping warning" > /dev/null; then
+  warn "Levara is up but reports 'running without DB' — Postgres credentials"
+  warn "are likely out of sync (common after an upgrade from a Cognee-era"
+  warn "volume). Memory tools and auth will return 5xx until this is fixed."
+  warn "Quick fix: 'make stack-dev-reset' wipes the postgres volume and reboots."
+fi
+
 # 4. Pull embed model into Ollama if missing. Cheap when already present.
 if curl -sf "$OLLAMA_URL/api/tags" > /dev/null 2>&1; then
   if ! curl -sf "$OLLAMA_URL/api/tags" | grep -q "\"$EMBED_MODEL"; then


### PR DESCRIPTION
## Summary
Three small fixes that close a P0.4 bootstrap papercut where memory tools and auth returned 5xx after \`make stack-dev\` even though the success banner said "healthy":

1. **\`.env.template\` defaults** — switch to \`levara/levara/levara_db\` to match the server's built-in defaults. Fresh clones reach a working DB without edits.
2. **\`stack-dev-up.sh\` silent-failure detection** — grep Levara logs for \`running without DB\` / \`PostgreSQL ping warning\` after health-check; surface a loud yellow warning. \`/metrics\` succeeds even when Postgres is unreachable, so the previous output was a false green.
3. **\`make stack-dev-reset\`** — destructive volume-wipe + reboot, gated by typed-\`yes\` confirmation. Required for upgrading users whose \`postgres-data\` volume was initialized with the legacy cognee user.

Bonus: \`grep -q\` → \`grep > /dev/null\`. Under \`set -o pipefail\`, \`-q\` early-exits on first match, SIGPIPEs \`docker logs\`, and the pipeline returns non-zero — silently masking the warning. Classic gotcha; switched to a full-read.

## Test plan
- [x] Warn fires correctly against the existing broken stack (verified locally).
- [x] \`bash -n tools/stack-dev-up.sh\` passes.
- [x] \`make help\` shows new \`stack-dev-reset\` line.
- [ ] Manual: \`make stack-dev-reset\` on the existing local stack → Postgres credentials align → no warn → \`save_memory\` returns 200 instead of 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)