### PR TITLE
fix(cognify): repair name→ID resolution, timestamp cast, ollama endpoint

### DIFF
--- a/Levara/pkg/mcp/tool_query_entity.go
+++ b/Levara/pkg/mcp/tool_query_entity.go
@@ -134,9 +134,13 @@ func queryEntityEdges(ctx context.Context, db *sql.DB, rewrite func(string) stri
 		pos += 2
 	}
 
+	// Scan timestamp columns as NullString so the driver returns "" for NULL
+	// without forcing a Postgres-specific COALESCE(..::text, ''). SQLite (used
+	// by tests) and Postgres both accept this — earlier `COALESCE(col, '')`
+	// failed under PG because '' isn't a valid timestamptz.
 	sqlStr := fmt.Sprintf(`
 		SELECT id, source_id, target_id, relationship_name, properties,
-			COALESCE(valid_from, ''), COALESCE(valid_until, ''), superseded_by, confidence
+			valid_from, valid_until, superseded_by, confidence
 		FROM graph_edges
 		WHERE (source_id IN (%s) OR target_id IN (%s))%s
 		ORDER BY updated_at DESC LIMIT $%d
@@ -151,7 +155,8 @@ func queryEntityEdges(ctx context.Context, db *sql.DB, rewrite func(string) stri
 
 	var edges []map[string]any
 	for rows.Next() {
-		var id, src, tgt, rel, props, vf, vu, sb string
+		var id, src, tgt, rel, props, sb string
+		var vf, vu sql.NullString
 		var conf float64
 		if err := rows.Scan(&id, &src, &tgt, &rel, &props, &vf, &vu, &sb, &conf); err != nil {
 			continue
@@ -162,8 +167,8 @@ func queryEntityEdges(ctx context.Context, db *sql.DB, rewrite func(string) stri
 			"target_id":     tgt,
 			"relationship":  rel,
 			"properties":    json.RawMessage(props),
-			"valid_from":    vf,
-			"valid_until":   vu,
+			"valid_from":    vf.String,
+			"valid_until":   vu.String,
 			"superseded_by": sb,
 			"confidence":    conf,
 		})

--- a/Levara/pkg/orchestrator/extract.go
+++ b/Levara/pkg/orchestrator/extract.go
@@ -202,6 +202,25 @@ func parseEntities(content string) ([]graph.DedupNode, []graph.DedupEdge, error)
 		}
 	}
 
+	// Map entity names → node IDs so we can translate LLM-emitted edges
+	// (which reference entities by name) into the UUID-keyed graph schema.
+	// Without this, query_entity resolves names to UUIDs and finds nothing
+	// because graph_edges stored the raw names as source_id/target_id.
+	nameToID := make(map[string]string, len(nodes))
+	for _, n := range nodes {
+		nameToID[n.Name] = n.ID
+	}
+	resolveID := func(ref string) string {
+		if id, ok := nameToID[ref]; ok {
+			return id
+		}
+		// Fall back to the LLM-supplied ref so we don't drop edges that
+		// mention an entity not in the nodes list (e.g. "board" in
+		// "Alice reports_to board"). The dedup stage handles these as
+		// loose references.
+		return ref
+	}
+
 	edges := make([]graph.DedupEdge, len(kg.Edges))
 	for i, e := range kg.Edges {
 		relName := e.Relationship
@@ -209,8 +228,8 @@ func parseEntities(content string) ([]graph.DedupNode, []graph.DedupEdge, error)
 			relName = e.RelationshipName
 		}
 		edges[i] = graph.DedupEdge{
-			SourceID:         e.Source,
-			TargetID:         e.Target,
+			SourceID:         resolveID(e.Source),
+			TargetID:         resolveID(e.Target),
 			RelationshipName: relName,
 			EdgeText:         e.EdgeText,
 		}

--- a/docker-compose.levaraos.yml
+++ b/docker-compose.levaraos.yml
@@ -39,7 +39,10 @@ services:
       # LLM defaults to a small fast model so mem0's infer=True path is usable
       # on CPU. Override LLM_MODEL/LLM_PROVIDER for richer extraction.
       LLM_PROVIDER: ${LLM_PROVIDER:-ollama}
-      LLM_ENDPOINT: ${LLM_ENDPOINT:-http://ollama:11434}
+      # Ollama's OpenAI-compatible surface lives under /v1 — without this suffix
+      # the provider hits /chat/completions on bare 11434 and gets 404, which
+      # silently disables entity extraction during cognify.
+      LLM_ENDPOINT: ${LLM_ENDPOINT:-http://ollama:11434/v1}
       LLM_MODEL: ${LLM_MODEL:-qwen2.5:1.5b}
       LLM_API_KEY: ${LLM_API_KEY:-no-key}
       # The MemoryFS indexer makes one batch_insert per .md file from a single


### PR DESCRIPTION
## Summary

Three orthogonal bugs broke the cognify → query_entity end-to-end flow on the LevaraOS local stack. All three surfaced while building the second example template (rag-with-temporal-kg). Fix all together so the template can run.

- **`extract.go`** — edges stored LLM-emitted entity *names* as source_id/target_id, but nodes were keyed by UUID. `query_entity` resolved name→UUID and then found nothing. Build a name→ID map and rewrite edge endpoints. Unknown refs fall through unchanged.
- **`tool_query_entity.go`** — `COALESCE(valid_from, '')` crashed under Postgres timestamptz (SQLSTATE 22007). Switched to `sql.NullString` scan so the driver returns "" for NULL — portable across PG and the SQLite test harness.
- **`docker-compose.levaraos.yml`** — `LLM_ENDPOINT` defaulted to bare `http://ollama:11434`. Ollama's OpenAI-compat surface lives at `/v1`; without the suffix the provider hit `/chat/completions` and got 404, silently disabling extraction. Added `/v1`.

## Test plan

- [x] `go test ./pkg/mcp/...` — query_entity tests pass with NullString scan
- [x] `go test ./pkg/orchestrator/...` — extract tests pass with name→ID map
- [x] Live smoke: cognify a sentence → 3 nodes, 3 edges with UUID source_id where the LLM emitted a name → query_entity returns those edges resolved through node IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)