### PR TITLE
feat(graph): scope nodes/edges by dataset_id column

### DIFF
--- a/Levara/internal/http/memify.go
+++ b/Levara/internal/http/memify.go
@@ -216,7 +216,7 @@ func memifyHandler(cfg APIConfig) fiber.Handler {
 						RelationshipName: e.RelationshipType,
 					}
 				}
-				orchestrator.UpsertGraphToPostgres(ctx, cfg.DB, dedupNodes, dedupEdges)
+				orchestrator.UpsertGraphToPostgres(ctx, cfg.DB, req.Dataset, dedupNodes, dedupEdges)
 			}
 
 			status.Status = "COMPLETED"

--- a/Levara/internal/http/schema.go
+++ b/Levara/internal/http/schema.go
@@ -144,12 +144,14 @@ var schemaStatements = []string{
 	)`,
 
 	// Graph nodes (PostgreSQL mirror of Neo4j for SQL queries)
+	// dataset_id scopes nodes to a tenant/project; '' means legacy/global.
 	`CREATE TABLE IF NOT EXISTS graph_nodes (
 		id TEXT PRIMARY KEY,
 		name TEXT NOT NULL DEFAULT '',
 		type TEXT NOT NULL DEFAULT '',
 		description TEXT NOT NULL DEFAULT '',
 		properties JSONB NOT NULL DEFAULT '{}',
+		dataset_id TEXT NOT NULL DEFAULT '',
 		created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 		updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 	)`,
@@ -158,6 +160,7 @@ var schemaStatements = []string{
 	// Temporal validity: valid_from/valid_until track when an edge was true.
 	// superseded_by stores edge ID that replaced this one (for non-overlapping
 	// exclusive relationships like assigned_to, role_is, status_is).
+	// dataset_id scopes edges to a tenant/project; '' means legacy/global.
 	`CREATE TABLE IF NOT EXISTS graph_edges (
 		id TEXT PRIMARY KEY,
 		source_id TEXT NOT NULL,
@@ -168,6 +171,7 @@ var schemaStatements = []string{
 		valid_until TIMESTAMPTZ,
 		superseded_by TEXT NOT NULL DEFAULT '',
 		confidence REAL NOT NULL DEFAULT 1.0,
+		dataset_id TEXT NOT NULL DEFAULT '',
 		created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 		updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 	)`,
@@ -285,11 +289,18 @@ var schemaStatements = []string{
 	`ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS valid_until TIMESTAMPTZ`,
 	`ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS superseded_by TEXT NOT NULL DEFAULT ''`,
 	`ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS confidence REAL NOT NULL DEFAULT 1.0`,
+	// Tenant/project scoping — promotes dataset_id from JSON property to a
+	// first-class column so query_entity and graph reads can filter without
+	// JSON extraction. Empty string preserves legacy/global rows.
+	`ALTER TABLE graph_nodes ADD COLUMN IF NOT EXISTS dataset_id TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS dataset_id TEXT NOT NULL DEFAULT ''`,
 	// Indexes that depend on the columns added by the ALTERs above.
 	`CREATE INDEX IF NOT EXISTS idx_memories_room ON memories(collection_name, room)`,
 	`CREATE INDEX IF NOT EXISTS idx_memories_hall ON memories(hall)`,
 	`CREATE INDEX IF NOT EXISTS idx_memories_pinned ON memories(is_pinned, pin_priority DESC)`,
 	`CREATE INDEX IF NOT EXISTS idx_graph_edges_validity ON graph_edges(source_id, relationship_name, valid_until)`,
+	`CREATE INDEX IF NOT EXISTS idx_graph_nodes_dataset ON graph_nodes(dataset_id)`,
+	`CREATE INDEX IF NOT EXISTS idx_graph_edges_dataset ON graph_edges(dataset_id)`,
 
 	`CREATE INDEX IF NOT EXISTS idx_acl_principal ON acl(principal_id)`,
 	`CREATE INDEX IF NOT EXISTS idx_acl_dataset ON acl(dataset_id)`,
@@ -476,6 +487,7 @@ var schemaSQLiteStatements = []string{
 		type TEXT NOT NULL DEFAULT '',
 		description TEXT NOT NULL DEFAULT '',
 		properties TEXT NOT NULL DEFAULT '{}',
+		dataset_id TEXT NOT NULL DEFAULT '',
 		created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 	)`,
@@ -490,6 +502,7 @@ var schemaSQLiteStatements = []string{
 		valid_until TEXT,
 		superseded_by TEXT NOT NULL DEFAULT '',
 		confidence REAL NOT NULL DEFAULT 1.0,
+		dataset_id TEXT NOT NULL DEFAULT '',
 		created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 		updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 	)`,
@@ -628,11 +641,15 @@ var schemaSQLiteStatements = []string{
 	`ALTER TABLE graph_edges ADD COLUMN valid_until TEXT`,
 	`ALTER TABLE graph_edges ADD COLUMN superseded_by TEXT NOT NULL DEFAULT ''`,
 	`ALTER TABLE graph_edges ADD COLUMN confidence REAL NOT NULL DEFAULT 1.0`,
+	`ALTER TABLE graph_nodes ADD COLUMN dataset_id TEXT NOT NULL DEFAULT ''`,
+	`ALTER TABLE graph_edges ADD COLUMN dataset_id TEXT NOT NULL DEFAULT ''`,
 	// Indexes that depend on the columns added above.
 	`CREATE INDEX IF NOT EXISTS idx_memories_room ON memories(collection_name, room)`,
 	`CREATE INDEX IF NOT EXISTS idx_memories_hall ON memories(hall)`,
 	`CREATE INDEX IF NOT EXISTS idx_memories_pinned ON memories(is_pinned, pin_priority DESC)`,
 	`CREATE INDEX IF NOT EXISTS idx_graph_edges_validity ON graph_edges(source_id, relationship_name, valid_until)`,
+	`CREATE INDEX IF NOT EXISTS idx_graph_nodes_dataset ON graph_nodes(dataset_id)`,
+	`CREATE INDEX IF NOT EXISTS idx_graph_edges_dataset ON graph_edges(dataset_id)`,
 
 	// Graph communities (Louvain multi-level) — SQLite
 	`CREATE TABLE IF NOT EXISTS graph_communities (

--- a/Levara/pkg/mcp/tool_query_entity.go
+++ b/Levara/pkg/mcp/tool_query_entity.go
@@ -49,12 +49,13 @@ func ToolQueryEntity(ctx context.Context, deps Deps, args map[string]any) ToolRe
 		}
 	}
 	asOf, _ := args["as_of"].(string)
+	datasetID, _ := args["dataset_id"].(string)
 	limit := queryEntityEdgeLimit
 	if l, ok := args["limit"].(float64); ok && l > 0 {
 		limit = int(l)
 	}
 
-	nodeIDs := resolveEntityNodes(ctx, db, deps.Q, name)
+	nodeIDs := resolveEntityNodes(ctx, db, deps.Q, name, datasetID)
 	if len(nodeIDs) == 0 {
 		return ToolResult{Content: []Content{{
 			Type: "text",
@@ -62,7 +63,7 @@ func ToolQueryEntity(ctx context.Context, deps Deps, args map[string]any) ToolRe
 		}}}
 	}
 
-	edges, err := queryEntityEdges(ctx, db, deps.Q, nodeIDs, asOf, limit)
+	edges, err := queryEntityEdges(ctx, db, deps.Q, nodeIDs, asOf, datasetID, limit)
 	if err != nil {
 		return ToolResult{
 			Content: []Content{{Type: "text", Text: "Error: " + err.Error()}},
@@ -71,22 +72,34 @@ func ToolQueryEntity(ctx context.Context, deps Deps, args map[string]any) ToolRe
 	}
 
 	resp := map[string]any{
-		"entity":   name,
-		"as_of":    asOf,
-		"node_ids": nodeIDs,
-		"edges":    edges,
+		"entity":     name,
+		"as_of":      asOf,
+		"dataset_id": datasetID,
+		"node_ids":   nodeIDs,
+		"edges":      edges,
 	}
 	out, _ := json.MarshalIndent(resp, "", "  ")
 	return ToolResult{Content: []Content{{Type: "text", Text: string(out)}}}
 }
 
 // resolveEntityNodes returns the graph node IDs that share the given
-// entity name. Capped at queryEntityNodeResolveLimit; silent failure
-// returns an empty slice (callers surface "No entity found").
-func resolveEntityNodes(ctx context.Context, db *sql.DB, rewrite func(string) string, name string) []string {
-	rows, err := db.QueryContext(ctx, rewrite(fmt.Sprintf(
-		"SELECT id FROM graph_nodes WHERE name = $1 LIMIT %d", queryEntityNodeResolveLimit,
-	)), name)
+// entity name. When datasetID is non-empty, results are scoped to that
+// dataset; an empty datasetID matches all rows (legacy/global behaviour).
+// Capped at queryEntityNodeResolveLimit; silent failure returns an empty
+// slice (callers surface "No entity found").
+func resolveEntityNodes(ctx context.Context, db *sql.DB, rewrite func(string) string, name, datasetID string) []string {
+	var (
+		query string
+		args  []any
+	)
+	if datasetID == "" {
+		query = fmt.Sprintf("SELECT id FROM graph_nodes WHERE name = $1 LIMIT %d", queryEntityNodeResolveLimit)
+		args = []any{name}
+	} else {
+		query = fmt.Sprintf("SELECT id FROM graph_nodes WHERE name = $1 AND dataset_id = $2 LIMIT %d", queryEntityNodeResolveLimit)
+		args = []any{name, datasetID}
+	}
+	rows, err := db.QueryContext(ctx, rewrite(query), args...)
 	if err != nil {
 		return nil
 	}
@@ -106,7 +119,7 @@ func resolveEntityNodes(ctx context.Context, db *sql.DB, rewrite func(string) st
 // or target), applying the active-now or as_of-based validity filter.
 // Returns SQL errors to the caller since a malformed query here is a
 // real fault, not a not-found.
-func queryEntityEdges(ctx context.Context, db *sql.DB, rewrite func(string) string, nodeIDs []string, asOf string, limit int) ([]map[string]any, error) {
+func queryEntityEdges(ctx context.Context, db *sql.DB, rewrite func(string) string, nodeIDs []string, asOf, datasetID string, limit int) ([]map[string]any, error) {
 	srcPlaceholders := make([]string, 0, len(nodeIDs))
 	tgtPlaceholders := make([]string, 0, len(nodeIDs))
 	qargs := make([]any, 0, len(nodeIDs)*2+2)
@@ -134,6 +147,15 @@ func queryEntityEdges(ctx context.Context, db *sql.DB, rewrite func(string) stri
 		pos += 2
 	}
 
+	// Tenant scope: when caller supplies dataset_id, drop edges from other
+	// datasets. Empty dataset_id keeps the legacy/global view.
+	var datasetClause string
+	if datasetID != "" {
+		datasetClause = fmt.Sprintf(" AND dataset_id = $%d", pos)
+		qargs = append(qargs, datasetID)
+		pos++
+	}
+
 	// Scan timestamp columns as NullString so the driver returns "" for NULL
 	// without forcing a Postgres-specific COALESCE(..::text, ''). SQLite (used
 	// by tests) and Postgres both accept this — earlier `COALESCE(col, '')`
@@ -142,9 +164,9 @@ func queryEntityEdges(ctx context.Context, db *sql.DB, rewrite func(string) stri
 		SELECT id, source_id, target_id, relationship_name, properties,
 			valid_from, valid_until, superseded_by, confidence
 		FROM graph_edges
-		WHERE (source_id IN (%s) OR target_id IN (%s))%s
+		WHERE (source_id IN (%s) OR target_id IN (%s))%s%s
 		ORDER BY updated_at DESC LIMIT $%d
-	`, strings.Join(srcPlaceholders, ","), strings.Join(tgtPlaceholders, ","), validityClause, pos)
+	`, strings.Join(srcPlaceholders, ","), strings.Join(tgtPlaceholders, ","), validityClause, datasetClause, pos)
 	qargs = append(qargs, limit)
 
 	rows, err := db.QueryContext(ctx, rewrite(sqlStr), qargs...)

--- a/Levara/pkg/mcp/tools.go
+++ b/Levara/pkg/mcp/tools.go
@@ -353,9 +353,10 @@ func ToolDescriptors() []Tool {
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
-				"name":  map[string]any{"type": "string", "description": "Entity name to query"},
-				"as_of": map[string]any{"type": "string", "description": "RFC3339 timestamp. If omitted, returns currently-valid edges."},
-				"limit": map[string]any{"type": "integer", "description": "Max edges to return. Default 50."},
+				"name":       map[string]any{"type": "string", "description": "Entity name to query"},
+				"as_of":      map[string]any{"type": "string", "description": "RFC3339 timestamp. If omitted, returns currently-valid edges."},
+				"dataset_id": map[string]any{"type": "string", "description": "Optional tenant/project scope. When set, only edges from this dataset are returned."},
+				"limit":      map[string]any{"type": "integer", "description": "Max edges to return. Default 50."},
 			},
 			"required": []string{"name"},
 		},

--- a/Levara/pkg/orchestrator/pgupsert.go
+++ b/Levara/pkg/orchestrator/pgupsert.go
@@ -49,8 +49,11 @@ func IsExclusiveRelationship(rel string) bool {
 }
 
 // UpsertGraphToPostgres writes deduped nodes and edges to PostgreSQL in a single transaction.
+// datasetID scopes the rows to a tenant/project; pass "" for legacy/global.
+// Auto-supersession is also dataset-scoped — exclusive edges in dataset A
+// never collide with the same source+relation in dataset B.
 // Returns (nodesWritten, edgesWritten, error).
-func UpsertGraphToPostgres(ctx context.Context, db *sql.DB, nodes []graph.DedupNode, edges []graph.DedupEdge) (int, int, error) {
+func UpsertGraphToPostgres(ctx context.Context, db *sql.DB, datasetID string, nodes []graph.DedupNode, edges []graph.DedupEdge) (int, int, error) {
 	if db == nil || (len(nodes) == 0 && len(edges) == 0) {
 		return 0, 0, nil
 	}
@@ -71,15 +74,16 @@ func UpsertGraphToPostgres(ctx context.Context, db *sql.DB, nodes []graph.DedupN
 			"name": n.Name, "type": n.Type, "description": n.Description,
 		})
 		_, err := tx.ExecContext(ctx,
-			`INSERT INTO graph_nodes (id, name, type, description, properties, created_at, updated_at)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7)
+			`INSERT INTO graph_nodes (id, name, type, description, properties, dataset_id, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 			 ON CONFLICT (id) DO UPDATE SET
 				name = EXCLUDED.name,
 				type = EXCLUDED.type,
 				description = EXCLUDED.description,
 				properties = EXCLUDED.properties,
+				dataset_id = EXCLUDED.dataset_id,
 				updated_at = EXCLUDED.updated_at`,
-			n.ID, n.Name, n.Type, n.Description, string(props), now, now)
+			n.ID, n.Name, n.Type, n.Description, string(props), datasetID, now, now)
 		if err != nil {
 			return nodesWritten, edgesWritten, fmt.Errorf("upsert node %s: %w", n.ID, err)
 		}
@@ -91,24 +95,25 @@ func UpsertGraphToPostgres(ctx context.Context, db *sql.DB, nodes []graph.DedupN
 		edgeID := fmt.Sprintf("%s_%s_%s", e.SourceID, e.RelationshipName, e.TargetID)
 		props, _ := json.Marshal(map[string]string{"edge_text": e.EdgeText})
 		_, err := tx.ExecContext(ctx,
-			`INSERT INTO graph_edges (id, source_id, target_id, relationship_name, properties, valid_from, created_at, updated_at)
-			 VALUES ($1, $2, $3, $4, $5, $6, $6, $6)
+			`INSERT INTO graph_edges (id, source_id, target_id, relationship_name, properties, valid_from, dataset_id, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $6, $6)
 			 ON CONFLICT (id) DO UPDATE SET
 				source_id = EXCLUDED.source_id,
 				target_id = EXCLUDED.target_id,
 				relationship_name = EXCLUDED.relationship_name,
 				properties = EXCLUDED.properties,
+				dataset_id = EXCLUDED.dataset_id,
 				updated_at = EXCLUDED.updated_at`,
-			edgeID, e.SourceID, e.TargetID, e.RelationshipName, string(props), now)
+			edgeID, e.SourceID, e.TargetID, e.RelationshipName, string(props), now, datasetID)
 		if err != nil {
 			return nodesWritten, edgesWritten, fmt.Errorf("upsert edge %s: %w", edgeID, err)
 		}
 		edgesWritten++
 
-		// Auto-supersession for exclusive relationships:
+		// Auto-supersession for exclusive relationships, scoped to dataset:
 		// when a single source can have only one current target, mark
-		// prior valid edges (different target, same source+rel) as
-		// superseded by this new edge.
+		// prior valid edges (different target, same source+rel, same
+		// dataset) as superseded by this new edge.
 		if IsExclusiveRelationship(e.RelationshipName) {
 			_, err := tx.ExecContext(ctx,
 				`UPDATE graph_edges
@@ -116,8 +121,9 @@ func UpsertGraphToPostgres(ctx context.Context, db *sql.DB, nodes []graph.DedupN
 				 WHERE source_id = $4
 				   AND relationship_name = $5
 				   AND id <> $6
+				   AND dataset_id = $7
 				   AND (valid_until IS NULL)`,
-				now, edgeID, now, e.SourceID, e.RelationshipName, edgeID)
+				now, edgeID, now, e.SourceID, e.RelationshipName, edgeID, datasetID)
 			if err != nil {
 				return nodesWritten, edgesWritten, fmt.Errorf("supersede edges for %s: %w", edgeID, err)
 			}

--- a/Levara/pkg/orchestrator/pipeline.go
+++ b/Levara/pkg/orchestrator/pipeline.go
@@ -801,7 +801,7 @@ func Run(ctx context.Context, texts []string, cfg Config, progressCh chan<- Prog
 		writeWg.Add(1)
 		go func() {
 			defer writeWg.Done()
-			nw, ew, err := UpsertGraphToPostgres(ctx, cfg.DB, dedupResult.Nodes, dedupResult.Edges)
+			nw, ew, err := UpsertGraphToPostgres(ctx, cfg.DB, cfg.DatasetID, dedupResult.Nodes, dedupResult.Edges)
 			if err != nil {
 				log.Printf("[pipeline] pg upsert: %v", err)
 			} else {


### PR DESCRIPTION
## Summary
- Promote `dataset_id` from JSON property to first-class column on `graph_nodes` / `graph_edges` (PG + SQLite migrations + indexes).
- `UpsertGraphToPostgres` takes a `datasetID` parameter; pipeline passes `cfg.DatasetID`, memify passes `req.Dataset`. Auto-supersession of exclusive relationships is now scoped to the dataset.
- `query_entity` MCP tool accepts an optional `dataset_id` arg and filters node resolution + edge fetch by it. Empty value preserves the legacy/global view.

## Why
Without column-level scoping, two projects/tenants could collide on the same exclusive relationship (e.g. `works_at` on a name shared between datasets), and `query_entity` returned cross-project edges. Promoting `dataset_id` to a real column also lets the SQL planner use an index instead of JSONB extraction.

## Test plan
- [x] `go test ./pkg/orchestrator/... ./pkg/mcp/... ./internal/http/...` — all green.
- [ ] Live smoke after merge: cognify with two distinct dataset_ids, `query_entity` with each, verify isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)