### PR TITLE
docs(verify): rollout playbook + prometheus rules + compose env

### DIFF
--- a/Levara/docs/prometheus-verify.rules.yml
+++ b/Levara/docs/prometheus-verify.rules.yml
@@ -1,0 +1,65 @@
+# Prometheus recording + alerting rules for the Levara verify-stack.
+# Drop into a rule_files entry alongside prometheus.yml:
+#
+#   rule_files:
+#     - /etc/prometheus/prometheus-verify.rules.yml
+#
+# Reload Prometheus after copying. The recording rules feed the suggested
+# Grafana panels; the alerts are the operator-actionable subset.
+
+groups:
+  - name: levara-verify-recording
+    interval: 30s
+    rules:
+      # Median + tail quantiles per search type — the input to threshold tuning.
+      - record: levara:rag_confidence:p50
+        expr: histogram_quantile(0.50, sum by (search_type, le) (rate(levara_rag_confidence_bucket[5m])))
+      - record: levara:rag_confidence:p10
+        expr: histogram_quantile(0.10, sum by (search_type, le) (rate(levara_rag_confidence_bucket[5m])))
+
+      # Abstain rate as a fraction of completions, by reason.
+      - record: levara:rag_abstain:rate5m
+        expr: sum by (search_type, reason) (rate(levara_rag_abstain_total[5m]))
+
+      # Verify-drop rate — `bad_metadata` is a write-path regression signal.
+      - record: levara:rag_verify_dropped:rate5m
+        expr: sum by (search_type, reason) (rate(levara_rag_verify_dropped_total[5m]))
+
+  - name: levara-verify-alerts
+    rules:
+      - alert: HighRAGAbstainRate
+        # Trips when >20% of completions abstain over 10 minutes. Most often
+        # means the threshold is too tight for the corpus, or a collection
+        # silently went empty. Check `levara:rag_confidence:p10` first.
+        expr: |
+          sum by (search_type) (rate(levara_rag_abstain_total[10m]))
+            /
+          (sum by (search_type) (rate(levara_rag_confidence_count[10m])) > 0)
+            > 0.20
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Levara RAG abstain rate > 20% on {{ $labels.search_type }}"
+          description: "Either thresholds are too aggressive or upstream retrieval has regressed."
+
+      - alert: VerifyDropBadMetadataSpike
+        # `bad_metadata` drops imply non-JSON metadata reaching the read path
+        # — a write-side regression (chunker, ingest, or migration).
+        expr: sum(rate(levara_rag_verify_dropped_total{reason="bad_metadata"}[5m])) > 0.5
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Levara verify-stack dropping rows with malformed metadata"
+          description: "Ingest pipeline likely wrote non-JSON metadata. Inspect recent inserts and the embed/chunker code path."
+
+      - alert: WALRecoveryFailure
+        # Pairs with the verify-stack's reliability story — fast surface for
+        # restart-time WAL replay regressions.
+        expr: increase(levara_wal_recoveries_total{result="fail"}[15m]) > 0
+        labels:
+          severity: critical
+        annotations:
+          summary: "Levara WAL recovery failed at startup"
+          description: "Investigate /version + recent restart logs; data may be inconsistent."

--- a/Levara/docs/verify-stack-rollout.md
+++ b/Levara/docs/verify-stack-rollout.md
@@ -1,0 +1,75 @@
+# Verify-stack rollout playbook
+
+The verify-stack adds three orthogonal quality gates to RAG completions:
+
+1. **Confidence** (`confidence.go`) — `retrieval × 0.7 + routing × 0.3`. Retrieval is `top × 0.6 + gap × 0.25 + coverage × 0.15`; routing pulls from the smart-router decision. Combined value lands in `[0,1]` and is the input to abstain.
+2. **Verification** (`verify.go`) — drops result rows whose score is below `min_score` or whose metadata fails JSON validation. Runs **before** the LLM is asked to ground.
+3. **Evidence + abstain** (`evidence.go`, `api_search.go`) — collects up-to-10 unique chunk IDs as `evidence_ids`. With `strict_grounded=true`, an empty list short-circuits to `abstain_reason=strict_grounded_no_evidence`. With non-zero confidence threshold, low-confidence completions abstain with `abstain_reason=low_confidence`.
+
+**All three default to off** (threshold `0`, no `verify_results`, no `strict_grounded`). The rollout in this repo is *opt-in via env or per-request flags*; this doc explains how to flip them on safely.
+
+## Phase 1 — Observe-only (production-safe, do this first)
+
+Goal: ship the feature without changing user-visible behaviour. Watch real traffic, learn the shape of `levara_rag_confidence`, then choose thresholds.
+
+No code or env change is needed — the metrics are emitted on every RAG completion regardless of threshold setting. Add the Prometheus recording rules from [`prometheus-verify.rules.yml`](./prometheus-verify.rules.yml) and the dashboard panel below.
+
+Check the percentile distribution per search type:
+
+```promql
+histogram_quantile(0.50, sum by (search_type, le) (rate(levara_rag_confidence_bucket[1h])))
+histogram_quantile(0.10, sum by (search_type, le) (rate(levara_rag_confidence_bucket[1h])))
+```
+
+Pick `LEVARA_RAG_ABSTAIN_THRESHOLD_<TYPE>` slightly below the 10th percentile of *good* completions for that type. Per-type tuning matters: `RAG_COMPLETION` and `GRAPH_COMPLETION` have very different score scales.
+
+## Phase 2 — Per-request opt-in (canary)
+
+Let downstream callers (agent, dashboard, API consumers) flip the gates on a per-request basis without changing the server config. The Cognevra MCP/HTTP API already accepts these fields on RAG endpoints:
+
+```json
+{
+  "query": "...",
+  "verify_results": true,
+  "min_score": 0.5,
+  "strict_grounded": true,
+  "include_debug": true
+}
+```
+
+`include_debug=true` switches list responses (CHUNKS/HYBRID/BM25) from a bare array to the envelope `{ results, debug: { confidence, verification, evidence_ids } }` so callers can see what the gates did without changing logging.
+
+## Phase 3 — Server-wide thresholds
+
+Once Phase 1 has produced 1–2 weeks of live confidence data and Phase 2 has shaken out client-visible regressions, set thresholds in `docker-compose.levaraos.yml`:
+
+```yaml
+environment:
+  # Conservative starting points — adjust per-type from the histogram.
+  LEVARA_RAG_ABSTAIN_THRESHOLD: "0.30"                       # global floor
+  LEVARA_RAG_ABSTAIN_THRESHOLD_RAG_COMPLETION: "0.35"        # tighter for prose
+  LEVARA_RAG_ABSTAIN_THRESHOLD_GRAPH_COMPLETION: "0.25"      # graph paths score lower
+```
+
+Per-type keys override the global; an unset/invalid key falls back. Anything outside `[0, 1]` is silently ignored — see `parseThreshold` in `internal/http/confidence.go`.
+
+## Alerts
+
+Suggested rules ship in `prometheus-verify.rules.yml`. Two are load-bearing:
+
+- **HighRAGAbstainRate** — fires when `>20%` of completions abstain over 10 min. Indicates either a real quality drop, a bad threshold, or a missing collection.
+- **VerifyDropAnomaly** — fires when `levara_rag_verify_dropped_total{reason="bad_metadata"}` rate spikes. This is almost always a write-path regression; the embed-side or upstream chunker started emitting non-JSON metadata.
+
+## Rollback
+
+The kill-switch is environment-only — unset the threshold variables and restart Levara. The verify-stack code itself stays compiled in but is inert at threshold `0`.
+
+Per-request flags (`verify_results`, `strict_grounded`) are caller-controlled, so individual clients can disable them without a server change.
+
+## Related code
+
+- `Levara/internal/http/confidence.go` — score blend, env parsing.
+- `Levara/internal/http/verify.go` — `min_score` + metadata filter, metrics emit.
+- `Levara/internal/http/evidence.go` — top-10 unique evidence IDs.
+- `Levara/internal/http/response_meta.go` — debug envelope toggle.
+- `Levara/internal/metrics/telemetry.go` (search for `RAGConfidence`) — series + eager init.

--- a/docker-compose.levaraos.yml
+++ b/docker-compose.levaraos.yml
@@ -50,6 +50,12 @@ services:
       # batch of memories — bump it for the integrated stack.
       RATE_LIMIT_USER_MAX: ${RATE_LIMIT_USER_MAX:-10000}
       RATE_LIMIT_USER_WINDOW_SECONDS: ${RATE_LIMIT_USER_WINDOW_SECONDS:-60}
+      # Verify-stack thresholds (see Levara/docs/verify-stack-rollout.md).
+      # Defaults to 0 (disabled) — observability metrics emit either way.
+      # Uncomment after Phase 1 observation to enable server-wide abstain.
+      LEVARA_RAG_ABSTAIN_THRESHOLD: ${LEVARA_RAG_ABSTAIN_THRESHOLD:-0}
+      LEVARA_RAG_ABSTAIN_THRESHOLD_RAG_COMPLETION: ${LEVARA_RAG_ABSTAIN_THRESHOLD_RAG_COMPLETION:-}
+      LEVARA_RAG_ABSTAIN_THRESHOLD_GRAPH_COMPLETION: ${LEVARA_RAG_ABSTAIN_THRESHOLD_GRAPH_COMPLETION:-}
     command:
       - "./levara"
       - "-standalone=true"
@@ -260,6 +266,9 @@ services:
       - "9090:9090"
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      # Verify-stack recording + alerting rules. Mount-only; rules are
+      # loaded lazily on Prometheus reload, so absent file = no rules.
+      - ./Levara/docs/prometheus-verify.rules.yml:/etc/prometheus/rules/verify.rules.yml:ro
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -2,6 +2,9 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+rule_files:
+  - /etc/prometheus/rules/*.rules.yml
+
 scrape_configs:
   - job_name: levara
     static_configs:


### PR DESCRIPTION
## Summary
- Adds `Levara/docs/verify-stack-rollout.md` — 3-phase playbook (observe-only → per-request opt-in → server-wide thresholds) with PromQL for picking per-search-type thresholds.
- Adds `Levara/docs/prometheus-verify.rules.yml` — recording rules (`levara:rag_confidence:p50/p10`, abstain/verify-drop rates) plus three alerts: `HighRAGAbstainRate`, `VerifyDropBadMetadataSpike`, `WALRecoveryFailure`.
- Wires `LEVARA_RAG_ABSTAIN_THRESHOLD[_RAG_COMPLETION|_GRAPH_COMPLETION]` into `docker-compose.levaraos.yml` (default `0`, i.e. off) and mounts the rules file under prometheus.
- Adds `rule_files: /etc/prometheus/rules/*.rules.yml` glob so any future `*.rules.yml` is picked up on reload.

Defaults are no-op: threshold `0` keeps the verify-stack inert; metrics already emit unconditionally so phase-1 data starts flowing the moment this lands.

## Test plan
- [ ] `docker compose -f docker-compose.levaraos.yml config` parses
- [ ] After deploy: `curl localhost:9090/api/v1/rules` lists `levara-verify-recording` + `levara-verify-alerts`
- [ ] `histogram_quantile(0.10, sum by (search_type, le) (rate(levara_rag_confidence_bucket[5m])))` returns data once traffic hits the stack
- [ ] Unsetting the env vars + restart returns to legacy behaviour (verified by reading `parseThreshold` fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)