### PR TITLE
feat(memories): SSE memory events stream (P1.5)

### DIFF
--- a/Levara/internal/http/memories.go
+++ b/Levara/internal/http/memories.go
@@ -2,7 +2,10 @@
 package http
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -13,6 +16,7 @@ import (
 func RegisterMemoryAPI(app fiber.Router, cfg APIConfig) {
 	app.Post("/memories", saveMemoryHandler(cfg))
 	app.Get("/memories", listMemoriesHandler(cfg))
+	app.Get("/memories/stream", memoryEventsStreamHandler())
 	app.Get("/memories/:key", getMemoryHandler(cfg))
 	app.Delete("/memories/:key", deleteMemoryHandler(cfg))
 }
@@ -75,6 +79,15 @@ func saveMemoryHandler(cfg APIConfig) fiber.Handler {
 		if err != nil {
 			return c.Status(500).JSON(fiber.Map{"detail": "save failed: " + err.Error()})
 		}
+
+		memoryEvents.Publish(MemoryEvent{
+			Kind:      "memory.saved",
+			Key:       req.Key,
+			Value:     req.Value,
+			Type:      req.Type,
+			OwnerID:   req.OwnerID,
+			Timestamp: now,
+		})
 
 		return c.Status(201).JSON(fiber.Map{
 			"id": id, "key": req.Key, "saved": true,
@@ -188,7 +201,98 @@ func deleteMemoryHandler(cfg APIConfig) fiber.Handler {
 			return c.Status(500).JSON(fiber.Map{"detail": "delete failed: " + err.Error()})
 		}
 
+		memoryEvents.Publish(MemoryEvent{
+			Kind:      "memory.deleted",
+			Key:       key,
+			OwnerID:   ownerID,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+		})
+
 		return c.JSON(fiber.Map{"deleted": true, "key": key})
+	}
+}
+
+// memoryEventsStreamHandler — GET /memories/stream. Streams memory
+// mutations as Server-Sent Events. Optional ?owner_id=&type=&key_prefix=
+// filters narrow the stream to the caller's interest. Connection holds
+// open until the client disconnects or the request ctx is cancelled.
+//
+// Event format: `event: <kind>\ndata: <json>\n\n` plus a periodic
+// `: keepalive\n\n` comment to keep proxies happy.
+//
+// @Summary     Subscribe to memory mutation events (SSE)
+// @Description Push-based replacement for polling /memories. Emits memory.saved and memory.deleted events for the authenticated owner. Filters: owner_id, type, key_prefix. Keepalive comment every 25s.
+// @Tags        memories
+// @Produce     text/event-stream
+// @Security    BearerAuth
+// @Param       owner_id   query string false "Filter by owner_id (defaults to caller)"
+// @Param       type       query string false "Filter by memory type"
+// @Param       key_prefix query string false "Filter to keys starting with this prefix"
+// @Success     200 {string} string "SSE stream"
+// @Router      /memories/stream [get]
+func memoryEventsStreamHandler() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		callerID, _ := c.Locals("user_id").(string)
+		ownerFilter := c.Query("owner_id", callerID)
+		typeFilter := c.Query("type", "")
+		keyPrefix := c.Query("key_prefix", "")
+
+		c.Set("Content-Type", "text/event-stream")
+		c.Set("Cache-Control", "no-cache")
+		c.Set("Connection", "keep-alive")
+		c.Set("X-Accel-Buffering", "no")
+
+		ch, cancel := memoryEvents.Subscribe()
+		ctx := c.Context()
+
+		c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
+			defer cancel()
+
+			// Send a hello frame so clients know the subscription is live
+			// even before the first mutation arrives.
+			fmt.Fprintf(w, "event: ready\ndata: {\"subscribed\":true}\n\n")
+			_ = w.Flush()
+
+			keepalive := time.NewTicker(25 * time.Second)
+			defer keepalive.Stop()
+
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-keepalive.C:
+					if _, err := w.WriteString(": keepalive\n\n"); err != nil {
+						return
+					}
+					if err := w.Flush(); err != nil {
+						return
+					}
+				case ev, ok := <-ch:
+					if !ok {
+						return
+					}
+					if ownerFilter != "" && ev.OwnerID != "" && ev.OwnerID != ownerFilter {
+						continue
+					}
+					if typeFilter != "" && ev.Type != typeFilter {
+						continue
+					}
+					if keyPrefix != "" {
+						if len(ev.Key) < len(keyPrefix) || ev.Key[:len(keyPrefix)] != keyPrefix {
+							continue
+						}
+					}
+					data, _ := json.Marshal(ev)
+					if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Kind, data); err != nil {
+						return
+					}
+					if err := w.Flush(); err != nil {
+						return
+					}
+				}
+			}
+		})
+		return nil
 	}
 }
 

--- a/Levara/internal/http/memory_events.go
+++ b/Levara/internal/http/memory_events.go
@@ -1,0 +1,83 @@
+// memory_events.go — in-process pub/sub for memory mutations, consumed by
+// the SSE endpoint at GET /memories/stream so agents can subscribe instead
+// of polling /memories.
+package http
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// MemoryEvent is a single mutation observed on /memories. Kind is one of
+// "memory.saved" or "memory.deleted". Fields not relevant to the kind
+// (Value on delete, Type on delete) are left empty.
+type MemoryEvent struct {
+	Kind      string `json:"kind"`
+	Key       string `json:"key"`
+	Value     string `json:"value,omitempty"`
+	Type      string `json:"type,omitempty"`
+	OwnerID   string `json:"owner_id,omitempty"`
+	Timestamp string `json:"timestamp"`
+}
+
+// memoryBus is the package-level broadcaster. Subscribers are channels
+// fanned out from Publish under a read lock. Bounded per-subscriber buffer
+// — slow consumers drop events rather than blocking the writer.
+type memoryBus struct {
+	mu      sync.RWMutex
+	subs    map[uint64]chan MemoryEvent
+	nextID  uint64
+	dropped uint64
+}
+
+const memoryBusBuffer = 64
+
+var memoryEvents = &memoryBus{subs: make(map[uint64]chan MemoryEvent)}
+
+// Subscribe registers a new channel. The returned cancel function MUST be
+// called to remove the subscriber and close its channel.
+func (b *memoryBus) Subscribe() (<-chan MemoryEvent, func()) {
+	ch := make(chan MemoryEvent, memoryBusBuffer)
+	b.mu.Lock()
+	id := b.nextID
+	b.nextID++
+	b.subs[id] = ch
+	b.mu.Unlock()
+	return ch, func() {
+		b.mu.Lock()
+		if existing, ok := b.subs[id]; ok {
+			delete(b.subs, id)
+			close(existing)
+		}
+		b.mu.Unlock()
+	}
+}
+
+// Publish fans out the event to all current subscribers with a non-blocking
+// send. If a subscriber's buffer is full the event is dropped for that
+// subscriber and the global drop counter is incremented.
+func (b *memoryBus) Publish(ev MemoryEvent) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for _, ch := range b.subs {
+		select {
+		case ch <- ev:
+		default:
+			atomic.AddUint64(&b.dropped, 1)
+		}
+	}
+}
+
+// Dropped returns the cumulative count of events dropped because a
+// subscriber's buffer was full. Exposed for the metrics middleware.
+func (b *memoryBus) Dropped() uint64 {
+	return atomic.LoadUint64(&b.dropped)
+}
+
+// Subscribers returns the current subscriber count. Used by tests and
+// debug endpoints.
+func (b *memoryBus) Subscribers() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.subs)
+}

--- a/Levara/internal/http/memory_events_test.go
+++ b/Levara/internal/http/memory_events_test.go
@@ -1,0 +1,101 @@
+package http
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMemoryBus_SubscribePublishReceive(t *testing.T) {
+	bus := &memoryBus{subs: make(map[uint64]chan MemoryEvent)}
+	ch, cancel := bus.Subscribe()
+	defer cancel()
+
+	if got := bus.Subscribers(); got != 1 {
+		t.Fatalf("subscribers = %d, want 1", got)
+	}
+
+	want := MemoryEvent{Kind: "memory.saved", Key: "k", Value: "v", OwnerID: "u1", Timestamp: "t"}
+	bus.Publish(want)
+
+	select {
+	case got := <-ch:
+		if got != want {
+			t.Fatalf("got %+v, want %+v", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("did not receive event within 1s")
+	}
+}
+
+func TestMemoryBus_FanOutToMultipleSubscribers(t *testing.T) {
+	bus := &memoryBus{subs: make(map[uint64]chan MemoryEvent)}
+	const n = 5
+	chans := make([]<-chan MemoryEvent, n)
+	cancels := make([]func(), n)
+	for i := 0; i < n; i++ {
+		chans[i], cancels[i] = bus.Subscribe()
+	}
+	defer func() {
+		for _, c := range cancels {
+			c()
+		}
+	}()
+
+	bus.Publish(MemoryEvent{Kind: "memory.saved", Key: "k"})
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			select {
+			case ev := <-chans[i]:
+				if ev.Key != "k" {
+					t.Errorf("subscriber %d: key = %q, want k", i, ev.Key)
+				}
+			case <-time.After(time.Second):
+				t.Errorf("subscriber %d did not receive within 1s", i)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestMemoryBus_CancelRemovesSubscriber(t *testing.T) {
+	bus := &memoryBus{subs: make(map[uint64]chan MemoryEvent)}
+	_, cancel := bus.Subscribe()
+	if got := bus.Subscribers(); got != 1 {
+		t.Fatalf("subscribers = %d, want 1", got)
+	}
+	cancel()
+	if got := bus.Subscribers(); got != 0 {
+		t.Fatalf("after cancel subscribers = %d, want 0", got)
+	}
+	// cancel must be idempotent — second call should not panic.
+	cancel()
+}
+
+func TestMemoryBus_SlowSubscriberDrops(t *testing.T) {
+	bus := &memoryBus{subs: make(map[uint64]chan MemoryEvent)}
+	_, cancel := bus.Subscribe()
+	defer cancel()
+
+	// Fill the buffer + 5 extra publishes that have nowhere to go.
+	for i := 0; i < memoryBusBuffer+5; i++ {
+		bus.Publish(MemoryEvent{Kind: "memory.saved"})
+	}
+
+	if got := bus.Dropped(); got < 5 {
+		t.Fatalf("Dropped() = %d, want >= 5", got)
+	}
+}
+
+func TestMemoryBus_PublishWithNoSubscribersIsNoop(t *testing.T) {
+	bus := &memoryBus{subs: make(map[uint64]chan MemoryEvent)}
+	bus.Publish(MemoryEvent{Kind: "memory.saved", Key: "k"})
+	if got := bus.Dropped(); got != 0 {
+		t.Fatalf("Dropped() = %d, want 0 (no subs ≠ drop)", got)
+	}
+}


### PR DESCRIPTION
## Summary
- New endpoint **GET /memories/stream** — Server-Sent Events push of memory.saved / memory.deleted as they happen.
- In-process broadcaster (\`memoryBus\`) with bounded buffer (64) and non-blocking publish — slow subscribers drop events; drop count is observable.
- \`saveMemoryHandler\` and \`deleteMemoryHandler\` now publish on success.
- Filters: \`?owner_id=&type=&key_prefix=\`. \`owner_id\` defaults to the authenticated caller, so tenant isolation is the default behaviour.
- 25s keepalive comment for idle-proxy survivability.

## Why
Closes the last identified InsForge-roadmap item: agents currently poll \`/memories\` to detect new context. Push semantics let MCP clients subscribe once and react to memory mutations instantly. Same SSE shape we already use for \`/cognify/:runId/stream\` and \`/memify/:runId/stream\`.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test -race -count=1 ./...\` — all green
- [x] Unit tests cover: subscribe/publish/receive, fan-out to multiple subs, cancel-idempotency, slow-consumer drop, no-subscribers-no-drop
- [ ] Manual smoke: \`curl -N http://localhost:8080/api/v1/memories/stream\` while \`POST /memories\` runs in another shell — verify \`event: memory.saved\` arrives <1s
- [ ] Verify keepalive comment after 25s idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)