### PR TITLE
ci: lint verify-stack Prometheus rules with promtool (G-5)

### DIFF
--- a/.github/workflows/lint-prom-rules.yml
+++ b/.github/workflows/lint-prom-rules.yml
@@ -1,0 +1,29 @@
+name: lint-prom-rules
+
+on:
+  pull_request:
+    paths:
+      - 'Levara/docs/prometheus-verify.rules.yml'
+      - '.github/workflows/lint-prom-rules.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'Levara/docs/prometheus-verify.rules.yml'
+      - '.github/workflows/lint-prom-rules.yml'
+
+jobs:
+  promtool:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install promtool
+        run: |
+          set -euo pipefail
+          PROM_VERSION=2.55.1
+          curl -sSL "https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/prometheus-${PROM_VERSION}.linux-amd64.tar.gz" \
+            | tar -xz --strip-components=1 -C /usr/local/bin "prometheus-${PROM_VERSION}.linux-amd64/promtool"
+          promtool --version
+
+      - name: Validate verify-stack rules
+        run: promtool check rules Levara/docs/prometheus-verify.rules.yml


### PR DESCRIPTION
## Summary
- New workflow `lint-prom-rules.yml` runs `promtool check rules` on PRs/pushes that touch `Levara/docs/prometheus-verify.rules.yml` or the workflow itself.
- Pinned to Prometheus 2.55.1 (downloaded once per run; small file, no caching needed).
- Closes G-5 from `docs/last100-test-analysis.md` — the rules shipped in #61 had no automated syntax validation.

## Test plan
- [x] Local `promtool check rules Levara/docs/prometheus-verify.rules.yml` → SUCCESS, 7 rules found
- [ ] CI run on this PR's `lint-prom-rules` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)