### PR TITLE
fix(store): close Insert/Clear race that crashed indexer with stale arena idx

### DIFF
--- a/Levara/internal/store/arena.go
+++ b/Levara/internal/store/arena.go
@@ -169,8 +169,19 @@ func (a *VectorArena) GetUnsafe(index uint32) ([]float32, error) {
 func (a *VectorArena) GetNoLock(index uint32) []float32 {
 	pageIdx := int(index) / a.vectorsPerPage
 	vecIdxInPage := int(index) % a.vectorsPerPage
+	// Defensive bounds check: if the arena was swapped out from under us
+	// (e.g. Clear() during a Raft snapshot restore) a stale idx would index
+	// past a.pages and panic. Returning nil lets HNSW callsites skip the
+	// stale node — they already tolerate nil from nodeByOffset.
+	if pageIdx < 0 || pageIdx >= len(a.pages) {
+		return nil
+	}
 	offset := vecIdxInPage * a.dim * 4
-	rawbytes := a.pages[pageIdx][offset : offset+(a.dim*4)]
+	page := a.pages[pageIdx]
+	if offset < 0 || offset+(a.dim*4) > len(page) {
+		return nil
+	}
+	rawbytes := page[offset : offset+(a.dim*4)]
 	return unsafe.Slice((*float32)(unsafe.Pointer(&rawbytes[0])), a.dim)
 }
 

--- a/Levara/internal/store/clear_pending_race_test.go
+++ b/Levara/internal/store/clear_pending_race_test.go
@@ -1,0 +1,101 @@
+package store
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestClear_DrainsPendingVecs_NoIndexerPanic regresses a flaky panic seen in
+// internal/cluster's snapshot/restore tests under `go test -race ./...`:
+//
+//	panic: runtime error: index out of range [N] with length M
+//	  goroutine running indexerLoop → HNSWIndex.Add → searchLayerTopK
+//	  → Arena.GetNoLock (db.go:207, hnsw.go:361)
+//
+// Root cause: Insert releases db.mu *before* appending to db.pendingVecs under
+// db.pendingMu. A concurrent Clear() (e.g. from FSM.Restore) takes db.mu,
+// swaps in a fresh empty arena+hnsw, and returns — but never touches
+// pendingVecs. The indexer goroutine then drains a stale idx against the new
+// (empty) arena, and Arena.GetNoLock indexes past len(a.pages).
+//
+// Fix: Clear() resets pendingVecs under pendingMu after the arena swap; and
+// GetNoLock has a defensive bounds check. This test forces the window with
+// runtime.Gosched() pressure: many writers issue Inserts while a single
+// goroutine repeatedly Clears. Without the fix this panics within seconds.
+func TestClear_DrainsPendingVecs_NoIndexerPanic(t *testing.T) {
+	dir := t.TempDir()
+	db, err := NewLevara(16, dir+"/meta.bin")
+	if err != nil {
+		t.Fatalf("NewLevara: %v", err)
+	}
+	defer db.Close()
+
+	const (
+		writers  = 8
+		duration = 500 * time.Millisecond
+	)
+
+	stop := make(chan struct{})
+	var inserts, clears atomic.Int64
+
+	var wg sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			vec := make([]float32, 16)
+			for j := range vec {
+				vec[j] = float32(id+j) * 0.01
+			}
+			i := 0
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				key := fmt.Sprintf("w%d-i%d", id, i)
+				_ = db.Insert(key, vec, map[string]any{"k": key})
+				inserts.Add(1)
+				i++
+				runtime.Gosched()
+			}
+		}(w)
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			db.Clear()
+			clears.Add(1)
+			runtime.Gosched()
+			time.Sleep(time.Microsecond * 200)
+		}
+	}()
+
+	time.Sleep(duration)
+	close(stop)
+	wg.Wait()
+
+	// Give the indexer a moment to drain the final post-Clear batch.
+	time.Sleep(50 * time.Millisecond)
+
+	if inserts.Load() == 0 {
+		t.Fatal("no inserts ran — timing issue")
+	}
+	if clears.Load() == 0 {
+		t.Fatal("no clears ran — timing issue")
+	}
+	t.Logf("survived %d inserts / %d clears with no indexer panic",
+		inserts.Load(), clears.Load())
+}

--- a/Levara/internal/store/db.go
+++ b/Levara/internal/store/db.go
@@ -275,6 +275,15 @@ func (db *Levara) Insert(id string, vector []float32, data any) error {
 	db.revIndex[idx] = id
 	db.metaLocs[idx] = loc
 
+	// Append to the indexer queue under db.mu so the (idx, arena) pairing is
+	// atomic with the arena.Add above. If we released db.mu first, a
+	// concurrent Clear() could swap the arena before we appended, leaving a
+	// stale idx pointing past the new arena's bounds — which the indexer
+	// would later try to dereference and panic on.
+	db.pendingMu.Lock()
+	db.pendingVecs = append(db.pendingVecs, pendingItem{vector: vector, id: id, idx: idx})
+	db.pendingMu.Unlock()
+
 	// Release db.mu before fsync — group commit coalesces across goroutines.
 	db.mu.Unlock()
 
@@ -283,9 +292,6 @@ func (db *Levara) Insert(id string, vector []float32, data any) error {
 		return fmt.Errorf("wal flush: %w", err)
 	}
 
-	db.pendingMu.Lock()
-	db.pendingVecs = append(db.pendingVecs, pendingItem{vector: vector, id: id, idx: idx})
-	db.pendingMu.Unlock()
 	db.signalIndexer()
 
 	return nil
@@ -374,6 +380,15 @@ func (db *Levara) BatchInsert(records []BatchItem) []error {
 		db.metaLocs[idx] = d.loc
 		toIndex = append(toIndex, pendingItem{vector: d.rec.Vector, id: d.rec.ID, idx: idx})
 	}
+
+	// Enqueue under db.mu so the (idx, arena) pairing is atomic with arena.Add
+	// — see the matching note in Insert. A concurrent Clear() must observe
+	// either an empty pending queue or the items already drained.
+	if len(toIndex) > 0 {
+		db.pendingMu.Lock()
+		db.pendingVecs = append(db.pendingVecs, toIndex...)
+		db.pendingMu.Unlock()
+	}
 	db.mu.Unlock()
 
 	// Group commit: fsync outside db.mu lock
@@ -381,11 +396,7 @@ func (db *Levara) BatchInsert(records []BatchItem) []error {
 		errs = append(errs, fmt.Errorf("wal flush: %w", err))
 	}
 
-	// Phase 2: enqueue for async HNSW indexing.
 	if len(toIndex) > 0 {
-		db.pendingMu.Lock()
-		db.pendingVecs = append(db.pendingVecs, toIndex...)
-		db.pendingMu.Unlock()
 		db.signalIndexer()
 	}
 
@@ -578,6 +589,12 @@ func (db *Levara) Clear() {
 	db.metaLocs = make(map[uint32]FileLocation)
 	db.arena = NewVectorArena(db.dim)
 	db.hnsw = NewHNSWIndex(db.arena, db.hnswCfg)
+	// Drain any pending indexer items — their idx values reference the
+	// previous arena and would panic GetNoLock once the indexer drains them
+	// against the freshly-allocated empty arena.
+	db.pendingMu.Lock()
+	db.pendingVecs = nil
+	db.pendingMu.Unlock()
 }
 
 func (db *Levara) Close() error {

--- a/Levara/internal/store/hnsw.go
+++ b/Levara/internal/store/hnsw.go
@@ -181,7 +181,11 @@ func (h *HNSWIndex) vecUnsafe(offset uint32) []float32 {
 // searchLayer finds the closest node to query in a specific layer (greedy)
 func (h *HNSWIndex) searchLayer(query []float32, entryPoint *HNSWNode, layer int, getVec vecFn) *HNSWNode {
 	curr := entryPoint
-	minDist := dist(query, getVec(curr.ArenaOffset))
+	currVec := getVec(curr.ArenaOffset)
+	if currVec == nil {
+		return curr
+	}
+	minDist := dist(query, currVec)
 
 	for {
 		changed := false
@@ -194,7 +198,11 @@ func (h *HNSWIndex) searchLayer(query []float32, entryPoint *HNSWNode, layer int
 			if friendNode == nil {
 				continue
 			}
-			d := dist(query, getVec(friendNode.ArenaOffset))
+			fVec := getVec(friendNode.ArenaOffset)
+			if fVec == nil {
+				continue
+			}
+			d := dist(query, fVec)
 			if d < minDist {
 				minDist = d
 				curr = friendNode
@@ -246,6 +254,13 @@ func (h *HNSWIndex) Add(vector []float32, id string, idx uint32) {
 
 	getVec := h.vecNoLock
 	curr := h.Nodes[h.EntryNodeID]
+	// If the entry node's vector is no longer reachable in the current arena
+	// (e.g. arena was swapped by Clear() before we got the write lock), abort
+	// the topology stitching — the new node remains as an orphan that the
+	// next Add will pick up as the entry point.
+	if curr == nil || getVec(curr.ArenaOffset) == nil {
+		return
+	}
 
 	// Zoom Phase: greedy search from top layer down to node's level
 	for l := h.MaxLayer; l > level; l-- {
@@ -296,6 +311,9 @@ func (h *HNSWIndex) pruneConnections(node *HNSWNode, layer, maxConn int, getVec 
 	}
 
 	nodeVec := getVec(node.ArenaOffset)
+	if nodeVec == nil {
+		return
+	}
 
 	type scored struct {
 		offset uint32
@@ -307,7 +325,11 @@ func (h *HNSWIndex) pruneConnections(node *HNSWNode, layer, maxConn int, getVec 
 		if cn == nil {
 			continue
 		}
-		items = append(items, scored{offset, dist(nodeVec, getVec(cn.ArenaOffset))})
+		cnVec := getVec(cn.ArenaOffset)
+		if cnVec == nil {
+			continue
+		}
+		items = append(items, scored{offset, dist(nodeVec, cnVec)})
 	}
 
 	if len(items) <= maxConn {
@@ -345,7 +367,11 @@ func (h *HNSWIndex) searchLayerTopK(query []float32, entry *HNSWNode, layer, ef 
 
 	visited[entry.ArenaOffset] = struct{}{}
 
-	entryDist := dist(query, getVec(entry.ArenaOffset))
+	entryVec := getVec(entry.ArenaOffset)
+	if entryVec == nil {
+		return nil
+	}
+	entryDist := dist(query, entryVec)
 
 	candidates := srMinHeap{{entry, entryDist}}
 	results := srMaxHeap{{entry, entryDist}}
@@ -370,7 +396,11 @@ func (h *HNSWIndex) searchLayerTopK(query []float32, entry *HNSWNode, layer, ef 
 			if fNode == nil {
 				continue
 			}
-			fDist := dist(query, getVec(fNode.ArenaOffset))
+			fVec := getVec(fNode.ArenaOffset)
+			if fVec == nil {
+				continue
+			}
+			fDist := dist(query, fVec)
 
 			if results.Len() < ef {
 				results.Push(searchResult{fNode, fDist})


### PR DESCRIPTION
## Summary

- Closes an intermittent race in `internal/store` where a concurrent `Clear()` during in-flight `Insert()` calls left the async indexer with stale arena offsets, panicking next drain with `runtime error: index out of range` inside `Arena.GetNoLock`.
- Fix is layered: append to `pendingVecs` under `db.mu` so the (idx, arena) pairing is atomic; drain pending in `Clear()` as a safety net; bounds-check `Arena.GetNoLock` and skip nil at HNSW callsites.
- Adds `TestClear_DrainsPendingVecs_NoIndexerPanic` — reliably panicked pre-fix, passes under `-race -count=3`.

## Root cause

`Insert()` released `db.mu` before taking `pendingMu` to append the new vec. A concurrent `Clear()` (e.g. from Raft `FSM.Restore`) could slip into that window, swap arena + hnsw, and return. The pending append then enqueued an idx pointing past the fresh empty arena. The next `indexerLoop` drain hit `Arena.GetNoLock` with a stale idx → page index OOB → panic. Originally surfaced as the flaky failure in `internal/cluster.TestFSM_SnapshotRestore_Roundtrip` under `go test -race ./...`.

## Test plan

- [x] `go test -race -count=3 ./internal/store/... ./internal/cluster/...` — passes
- [x] `go test -race -count=1 ./...` — full sweep green
- [x] New regression panics pre-fix, clean post-fix
- [ ] Reviewer: confirm append-under-db.mu doesn't measurably regress single-writer Insert latency (it adds one uncontended `pendingMu` Lock/Unlock inside the existing `db.mu` critical section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)