### PR TITLE
fix(store): unskip WAL recovery + Clear race tests

### DIFF
--- a/Levara/internal/store/arena.go
+++ b/Levara/internal/store/arena.go
@@ -70,7 +70,11 @@ func (a *VectorArena) Add(vector []float32) (uint32, error) {
 	}
 
 	// L2-normalize so dot product == cosine similarity (required by HNSW dist).
-	if mag2 > 0 {
+	// Skip when the input is already unit length within float32 epsilon: a
+	// second normalization would produce slightly different bits, which breaks
+	// bit-exact WAL recovery comparisons (the WAL stores the post-normalize
+	// vector, so replay re-feeds an already-unit vector through this path).
+	if mag2 > 0 && math.Abs(mag2-1.0) > 1e-6 {
 		invNorm := float32(1.0 / math.Sqrt(mag2))
 		for i := range vector {
 			vector[i] *= invNorm
@@ -162,11 +166,17 @@ func (a *VectorArena) GetUnsafe(index uint32) ([]float32, error) {
 	return unsafe.Slice((*float32)(unsafe.Pointer(&rawbytes[0])), a.dim), nil
 }
 
-// GetNoLock returns a zero-copy slice WITHOUT acquiring any lock.
-// Use ONLY when the caller guarantees no concurrent writes to the arena
-// (e.g., inside HNSW.Add which holds the HNSW write lock, preventing
-// concurrent inserts that could modify pages).
+// GetNoLock returns a copy of the vector at index. The name is historical: it
+// originally returned a zero-copy view assuming the caller held a mutually
+// exclusive lock against arena.Add, but that invariant did not hold — HNSW.Add
+// takes only the HNSW lock, while concurrent db.Insert callers take arena.mu
+// and append pages without coordinating with HNSW. The race detector flagged
+// this as a write-vs-read on page bytes (arena.go:109 vs vek32.Dot reads).
+// Now we acquire arena.mu.RLock and copy the slot bytes, so callers can hold
+// the result safely with no further synchronization.
 func (a *VectorArena) GetNoLock(index uint32) []float32 {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
 	pageIdx := int(index) / a.vectorsPerPage
 	vecIdxInPage := int(index) % a.vectorsPerPage
 	// Defensive bounds check: if the arena was swapped out from under us
@@ -176,13 +186,15 @@ func (a *VectorArena) GetNoLock(index uint32) []float32 {
 	if pageIdx < 0 || pageIdx >= len(a.pages) {
 		return nil
 	}
-	offset := vecIdxInPage * a.dim * 4
 	page := a.pages[pageIdx]
+	offset := vecIdxInPage * a.dim * 4
 	if offset < 0 || offset+(a.dim*4) > len(page) {
 		return nil
 	}
-	rawbytes := page[offset : offset+(a.dim*4)]
-	return unsafe.Slice((*float32)(unsafe.Pointer(&rawbytes[0])), a.dim)
+	out := make([]float32, a.dim)
+	src := unsafe.Slice((*float32)(unsafe.Pointer(&page[offset])), a.dim)
+	copy(out, src)
+	return out
 }
 
 // Returns the total number of vectors stored

--- a/Levara/internal/store/clear_pending_race_test.go
+++ b/Levara/internal/store/clear_pending_race_test.go
@@ -27,12 +27,6 @@ import (
 // runtime.Gosched() pressure: many writers issue Inserts while a single
 // goroutine repeatedly Clears. Without the fix this panics within seconds.
 func TestClear_DrainsPendingVecs_NoIndexerPanic(t *testing.T) {
-	if raceEnabled {
-		// TODO(ci): pre-existing data race between Insert (arena.Add line 76,
-		// in-place L2-normalize) and indexerLoop reads via GetNoLock zero-copy
-		// view. Tracked separately; skip under -race so the new CI gate is green.
-		t.Skip("known pre-existing race (arena.Add in-place mutation vs indexer GetNoLock view)")
-	}
 	dir := t.TempDir()
 	db, err := NewLevara(16, dir+"/meta.bin")
 	if err != nil {

--- a/Levara/internal/store/db.go
+++ b/Levara/internal/store/db.go
@@ -280,8 +280,14 @@ func (db *Levara) Insert(id string, vector []float32, data any) error {
 	// concurrent Clear() could swap the arena before we appended, leaving a
 	// stale idx pointing past the new arena's bounds — which the indexer
 	// would later try to dereference and panic on.
+	// Copy vector for the indexer: the caller may reuse its slice for a
+	// subsequent Insert, and arena.Add is allowed to mutate it (in-place
+	// L2-normalization). Sharing the slice would race with hnsw.Add reading it
+	// later as the search query.
+	vecCopy := make([]float32, len(vector))
+	copy(vecCopy, vector)
 	db.pendingMu.Lock()
-	db.pendingVecs = append(db.pendingVecs, pendingItem{vector: vector, id: id, idx: idx})
+	db.pendingVecs = append(db.pendingVecs, pendingItem{vector: vecCopy, id: id, idx: idx})
 	db.pendingMu.Unlock()
 
 	// Release db.mu before fsync — group commit coalesces across goroutines.
@@ -378,7 +384,11 @@ func (db *Levara) BatchInsert(records []BatchItem) []error {
 		}
 		db.revIndex[idx] = d.rec.ID
 		db.metaLocs[idx] = d.loc
-		toIndex = append(toIndex, pendingItem{vector: d.rec.Vector, id: d.rec.ID, idx: idx})
+		// Copy: caller may reuse the input slice; arena.Add may have mutated it
+		// in-place. See the matching note in Insert.
+		vecCopy := make([]float32, len(d.rec.Vector))
+		copy(vecCopy, d.rec.Vector)
+		toIndex = append(toIndex, pendingItem{vector: vecCopy, id: d.rec.ID, idx: idx})
 	}
 
 	// Enqueue under db.mu so the (idx, arena) pairing is atomic with arena.Add

--- a/Levara/internal/store/db_test.go
+++ b/Levara/internal/store/db_test.go
@@ -96,13 +96,6 @@ func TestDeleteWALRecovery(t *testing.T) {
 // same ID survives WAL recovery. The buggy 2-pass recovery (pre-T16) would collect
 // all deleted IDs first, then skip any Insert that matches — losing the final Insert.
 func TestInsertDeleteInsertWALRecovery(t *testing.T) {
-	// TODO(ci): pre-existing flake (~15% locally, ~100% on Linux CI). Suspected
-	// cause: arena.Add re-normalizes the vector in-place during WAL replay; the
-	// second normalization of an already-near-unit vector produces a slightly
-	// different float32 bit pattern, breaking the bit-exact vecEqual check.
-	// Fix belongs in a focused PR (either skip re-normalization when ||v|| is
-	// already 1.0±eps, or relax the test to use cosine-similarity tolerance).
-	t.Skip("known pre-existing flake — re-normalization vs bit-exact compare")
 	dir, _ := os.MkdirTemp("", "levara-wal-ridi-test-*")
 	defer os.RemoveAll(dir)
 	dbPath := dir + "/meta.bin"

--- a/Levara/internal/store/hnsw.go
+++ b/Levara/internal/store/hnsw.go
@@ -190,7 +190,14 @@ func (h *HNSWIndex) searchLayer(query []float32, entryPoint *HNSWNode, layer int
 	for {
 		changed := false
 		curr.RLock()
-		friends := curr.Connections[layer]
+		// Defensive bounds check: under concurrent Clear() the captured hnsw may
+		// briefly carry an entry-node pointer whose Layer (and thus
+		// len(Connections)) is smaller than the layer we are searching at.
+		// Treat that as "no friends here" and let the caller fall through.
+		var friends []uint32
+		if layer < len(curr.Connections) {
+			friends = curr.Connections[layer]
+		}
 		curr.RUnlock()
 
 		for _, fOffset := range friends {
@@ -384,7 +391,10 @@ func (h *HNSWIndex) searchLayerTopK(query []float32, entry *HNSWNode, layer, ef 
 		}
 
 		best.node.RLock()
-		friends := best.node.Connections[layer]
+		var friends []uint32
+		if layer < len(best.node.Connections) {
+			friends = best.node.Connections[layer]
+		}
 		best.node.RUnlock()
 
 		for _, fOffset := range friends {

--- a/Levara/internal/store/race_off_test.go
+++ b/Levara/internal/store/race_off_test.go
@@ -1,5 +1,0 @@
-//go:build !race
-
-package store
-
-const raceEnabled = false

--- a/Levara/internal/store/race_on_test.go
+++ b/Levara/internal/store/race_on_test.go
@@ -1,5 +1,0 @@
-//go:build race
-
-package store
-
-const raceEnabled = true


### PR DESCRIPTION
## Summary

Two pre-existing tests in `internal/store/` were under `t.Skip` — each hiding a real bug. Removed the skips and fixed the underlying issues.

### TestInsertDeleteInsertWALRecovery — flake
`arena.Add` re-normalized already-unit vectors during WAL replay, producing slightly different float32 bits each pass and breaking the bit-exact `vecEqual` check (~15% local, ~100% CI). Fix: skip normalization when \`||v|| ≈ 1.0\` within float32 epsilon, so replay yields bit-identical page bytes.

### TestClear_DrainsPendingVecs_NoIndexerPanic under -race
Three concurrency hazards stacked:

- **`arena.GetNoLock` returned a zero-copy view with no lock**, racing `arena.Add` (which holds `arena.mu.Lock` while appending pages and writing slot bytes). The doc claimed callers held an HNSW write lock that prevented concurrent arena writes — but `db.Insert` doesn't take that lock. Now takes RLock and returns a copy.
- **`db.Insert` pushed the caller's vector slice into `pendingVecs`.** Caller reuse of the slice mutated it in-place via `arena.Add`'s normalization while `indexerLoop`'s `hnsw.Add` was still reading it as the search query. Now copies before queuing (also fixed `BatchInsert`).
- **`hnsw.searchLayer` / `searchLayerTopK` indexed `Connections[layer]` without bounds-checking against the node's own `Layer`**, panicking when a stale entry node had a smaller layer than `h.MaxLayer`. Defensive bounds check returns no friends in that case.

Removed the now-unused `raceEnabled` build-tag pair in `internal/store/` (its only consumer was the unskipped race test).

## Test plan
- [x] `golangci-lint run ./...` → 0 issues
- [x] `go vet ./... && go build ./...` clean
- [x] `go test -race ./...` × 5 full repo, all green
- [x] `TestInsertDeleteInsertWALRecovery` -count=100 -race → green
- [x] `TestClear_DrainsPendingVecs_NoIndexerPanic` -count=100 -race → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)