### PR TITLE
Post-contract cleanup: workspace + mcp + server refactors + docs

### DIFF
--- a/Levara/cmd/server/bootstrap.go
+++ b/Levara/cmd/server/bootstrap.go
@@ -7,32 +7,319 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/adaptor"
+	"github.com/gofiber/fiber/v2/middleware/cors"
+	"github.com/gofiber/fiber/v2/middleware/logger"
+	"github.com/gofiber/swagger"
+	"github.com/hashicorp/raft"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
 
 	"github.com/stek0v/levara/internal/cluster"
 	vectorGrpc "github.com/stek0v/levara/internal/grpc"
+	vectorHttp "github.com/stek0v/levara/internal/http"
 	"github.com/stek0v/levara/internal/store"
 	"github.com/stek0v/levara/pkg/embed"
 	"github.com/stek0v/levara/pkg/graphdb"
+	"github.com/stek0v/levara/pkg/ingest"
 	"github.com/stek0v/levara/pkg/llm"
 	"github.com/stek0v/levara/pkg/llmcache"
 	"github.com/stek0v/levara/pkg/llmproxy"
 	"github.com/stek0v/levara/pkg/observe"
+	"github.com/stek0v/levara/pkg/storage"
 	pb "github.com/stek0v/levara/proto/pb"
 	pbv2 "github.com/stek0v/levara/proto/pb/v2"
 )
+
+func initStorageBackend(dataDir string, srvLog *observe.Logger) (storage.Storage, string, string) {
+	storagePath := dataDir + "/uploads"
+	fileStore, err := storage.NewFromEnv(storagePath)
+	if err != nil {
+		log.Fatalf("storage init: %v", err)
+	}
+	storageBackend := strings.ToLower(os.Getenv("STORAGE_BACKEND"))
+	if srvLog != nil {
+		srvLog.Info("storage backend ready", map[string]any{"backend": storageBackend, "path": storagePath})
+		if storageBackend == "s3" {
+			srvLog.Info("S3 storage enabled for upload hot-path", map[string]any{
+				"hot_path":     "/api/v1/add -> ingest + mirror to cfg.FileStorage",
+				"location_uri": "storage://<key> for non-local backend",
+				"storage_path": storagePath,
+			})
+		}
+	}
+	return fileStore, storageBackend, storagePath
+}
+
+type sqlRuntime struct {
+	DSN string
+	DB  *sql.DB
+}
+
+func initSQLRuntime(dataDir string) sqlRuntime {
+	dbProvider := os.Getenv("DB_PROVIDER")
+	if dbProvider == "sqlite" {
+		return initSQLiteRuntime(dataDir)
+	}
+	if os.Getenv("DB_HOST") != "" {
+		return initPostgresRuntime()
+	}
+	return sqlRuntime{}
+}
+
+type vectorRuntime struct {
+	Shards      []store.ShardHandler
+	Cluster     *store.Cluster
+	Replication *cluster.ReplicationServer
+}
+
+type vectorRuntimeConfig struct {
+	Dim        int
+	DataDir    string
+	NodeID     string
+	NumShards  int
+	Standalone bool
+	Bootstrap  bool
+	RaftAddr   string
+	RaftPort   int
+	JoinAddr   string
+	HNSW       store.HNSWConfig
+}
+
+func initVectorRuntime(cfg vectorRuntimeConfig) vectorRuntime {
+	var shards []store.ShardHandler
+	for i := range cfg.NumShards {
+		dbPath := fmt.Sprintf("%s/%s/shard_%d/meta.bin", cfg.DataDir, cfg.NodeID, i)
+		db, err := store.NewLevara(cfg.Dim, dbPath, cfg.HNSW)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if cfg.Standalone {
+			shards = append(shards, &cluster.DirectNode{DB: db})
+			continue
+		}
+		raftNode, err := cluster.NewRaftNode(i, cfg.NodeID, cfg.DataDir+"/"+cfg.NodeID, cfg.RaftPort+i, db,
+			cluster.WithBindAddr(cfg.RaftAddr))
+		if err != nil {
+			log.Fatal(err)
+		}
+		if cfg.Bootstrap {
+			configuration := raft.Configuration{
+				Servers: []raft.Server{{
+					ID:      raft.ServerID(fmt.Sprintf("%s-shard-%d", cfg.NodeID, i)),
+					Address: raft.ServerAddress(fmt.Sprintf("%s:%d", cfg.RaftAddr, cfg.RaftPort+i)),
+				}},
+			}
+			raftNode.Raft.BootstrapCluster(configuration)
+		}
+		shards = append(shards, raftNode)
+	}
+
+	replServer := initReplicationServer(cfg.NodeID, cfg.JoinAddr, shards)
+	return vectorRuntime{
+		Shards:      shards,
+		Cluster:     store.NewCluster(shards),
+		Replication: replServer,
+	}
+}
+
+func initReplicationServer(nodeID, joinAddr string, shards []store.ShardHandler) *cluster.ReplicationServer {
+	replDB := replicationDB(shards)
+	if replDB == nil {
+		return nil
+	}
+	replServer := cluster.NewReplicationServer(nodeID, nil, replDB)
+	if joinAddr != "" {
+		replServer.SetRole("replica")
+		replServer.SetPrimaryAddr(joinAddr)
+		log.Printf("Levara replica mode — joining primary at %s", joinAddr)
+	} else {
+		replServer.SetRole("primary")
+		log.Printf("Levara primary mode — accepting replicas")
+	}
+	for _, shard := range shards {
+		if dn, ok := shard.(*cluster.DirectNode); ok {
+			dn.Repl = replServer
+		}
+	}
+	return replServer
+}
+
+func replicationDB(shards []store.ShardHandler) *store.Levara {
+	if len(shards) == 0 {
+		return nil
+	}
+	switch s := shards[0].(type) {
+	case *cluster.DirectNode:
+		return s.DB
+	case *cluster.RaftNode:
+		return s.DB
+	default:
+		return nil
+	}
+}
+
+type httpRuntime struct {
+	App            *fiber.App
+	API            fiber.Router
+	VectorHandler  *vectorHttp.Handler
+	VersionHandler fiber.Handler
+}
+
+func initHTTPRuntime(clusterStore *store.Cluster, dim int, replServer *cluster.ReplicationServer, errTracker *observe.ErrorTracker) httpRuntime {
+	app := fiber.New()
+	app.Use(cors.New(cors.Config{
+		AllowOrigins:     "http://localhost:3000,http://localhost:3001,http://127.0.0.1:3000,http://127.0.0.1:3001,http://localhost:8080,http://localhost:8081",
+		AllowMethods:     "GET,POST,PUT,DELETE,PATCH,OPTIONS",
+		AllowHeaders:     "Origin,Content-Type,Accept,Authorization,X-Api-Key",
+		AllowCredentials: true,
+	}))
+	app.Use(logger.New())
+
+	handler := vectorHttp.NewHandler(clusterStore, dim)
+	app.Get("/metrics", adaptor.HTTPHandler(promhttp.Handler()))
+	if strings.EqualFold(os.Getenv("ENV"), "dev") || os.Getenv("ENV") == "" {
+		app.Get("/swagger/*", swagger.HandlerDefault)
+	}
+	app.Get("/health", func(c *fiber.Ctx) error {
+		return c.JSON(fiber.Map{"status": "ready", "health": "healthy", "version": "levara-go"})
+	})
+	versionHandler := func(c *fiber.Ctx) error { return c.JSON(versionPayload()) }
+	app.Get("/version", versionHandler)
+
+	if replServer != nil {
+		app.Get("/cluster/wal/stream", adaptor.HTTPHandlerFunc(replServer.HandleStreamWAL))
+		app.Get("/cluster/snapshot", adaptor.HTTPHandlerFunc(replServer.HandleSnapshot))
+		app.Get("/cluster/state", adaptor.HTTPHandlerFunc(replServer.HandleClusterState))
+	}
+
+	cloudApi := app.Group("/api")
+	cloudApi.Get("/datasets", func(c *fiber.Ctx) error {
+		return c.Redirect("/api/v1/datasets", 307)
+	})
+	cloudApi.Get("/datasets/:id/data", func(c *fiber.Ctx) error {
+		return c.Redirect("/api/v1/datasets/"+c.Params("id")+"/data", 307)
+	})
+	cloudApi.Get("/health", func(c *fiber.Ctx) error {
+		return c.JSON(fiber.Map{"status": "ready", "health": "healthy", "version": "levara-go"})
+	})
+
+	api := app.Group("/api/v1")
+	api.Get("/info", handler.Info)
+	api.Get("/health", func(c *fiber.Ctx) error {
+		return c.JSON(fiber.Map{"status": "ready", "health": "healthy", "version": "levara-go"})
+	})
+	api.Get("/version", versionHandler)
+	api.Post("/checks/connection", func(c *fiber.Ctx) error {
+		return c.JSON(fiber.Map{"status": "connected"})
+	})
+	api.Get("/errors", func(c *fiber.Ctx) error {
+		limit := c.QueryInt("limit", 50)
+		return c.JSON(fiber.Map{
+			"errors": errTracker.Recent(limit),
+			"total":  errTracker.Count(),
+		})
+	})
+	api.Delete("/errors", func(c *fiber.Ctx) error {
+		errTracker.Clear()
+		return c.JSON(fiber.Map{"cleared": true})
+	})
+
+	return httpRuntime{
+		App:            app,
+		API:            api,
+		VectorHandler:  handler,
+		VersionHandler: versionHandler,
+	}
+}
+
+func initSQLiteRuntime(dataDir string) sqlRuntime {
+	vectorHttp.SetDBProvider(vectorHttp.DBSQLite)
+	ingest.SetSQLiteMode(true)
+	dbPath := os.Getenv("DB_PATH")
+	if dbPath == "" {
+		dbPath = filepath.Join(dataDir, "levara.db")
+	}
+	_ = os.MkdirAll(filepath.Dir(dbPath), 0755)
+
+	dsn := "file:" + dbPath + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)"
+	db, err := sql.Open("sqlite3", dsn)
+	log.Printf("SQLite DSN: %s", dsn)
+	if err != nil {
+		log.Printf("SQLite init warning: %v (running without DB)", err)
+		return sqlRuntime{}
+	}
+	db.SetMaxOpenConns(4)
+	db.SetMaxIdleConns(4)
+	db.SetConnMaxLifetime(0)
+	db.SetConnMaxIdleTime(0)
+	if err := db.Ping(); err != nil {
+		log.Printf("SQLite ping warning: %v (running without DB)", err)
+		db.Close()
+		return sqlRuntime{}
+	}
+	log.Printf("SQLite database ready: %s", dbPath)
+	if err := vectorHttp.MigrateSchema(db); err != nil {
+		log.Printf("Schema migration warning: %v", err)
+	}
+	return sqlRuntime{DB: db}
+}
+
+func initPostgresRuntime() sqlRuntime {
+	vectorHttp.SetDBProvider(vectorHttp.DBPostgres)
+	dbUser := os.Getenv("DB_USERNAME")
+	if dbUser == "" {
+		dbUser = "levara"
+	}
+	dbPass := os.Getenv("DB_PASSWORD")
+	if dbPass == "" {
+		dbPass = "levara"
+	}
+	dbName := os.Getenv("DB_NAME")
+	if dbName == "" {
+		dbName = "levara_db"
+	}
+	dbPort := os.Getenv("DB_PORT")
+	if dbPort == "" {
+		dbPort = "5432"
+	}
+	dbHost := os.Getenv("DB_HOST")
+	dsn := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", dbUser, dbPass, dbHost, dbPort, dbName)
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		log.Printf("PostgreSQL pool init warning: %v (running without DB)", err)
+		return sqlRuntime{DSN: dsn}
+	}
+	db.SetMaxOpenConns(25)
+	db.SetMaxIdleConns(10)
+	db.SetConnMaxLifetime(5 * time.Minute)
+	if err := db.Ping(); err != nil {
+		log.Printf("PostgreSQL ping warning: %v (running without DB)", err)
+		db.Close()
+		return sqlRuntime{DSN: dsn}
+	}
+	log.Printf("PostgreSQL connection pool ready (max_open=25, max_idle=10)")
+	if err := vectorHttp.MigrateSchema(db); err != nil {
+		log.Printf("Schema migration warning: %v", err)
+	}
+	return sqlRuntime{DSN: dsn, DB: db}
+}
 
 // initLLMProvider wires the multi-provider abstraction from env vars
 // (LLM_PROVIDER, LLM_ENDPOINT, LLM_API_KEY) and optionally wraps it with
@@ -303,18 +590,18 @@ func registerHealthDetails(app *fiber.App, deps healthDeps) {
 // needs. Defined here so the registration site is one parameter rather
 // than a long positional list.
 type healthDeps struct {
-	port           int
-	grpcPort       int
-	dim            int
-	pgDB           interface{ Ping() error }
-	neo4jURL       string
-	neo4jUser      string
-	neo4jPassword  string
-	neo4jDatabase  string
-	embedEndpoint  string
-	embedModel     string
-	llmProvider    llm.Provider
-	colManager     *store.CollectionManager
+	port          int
+	grpcPort      int
+	dim           int
+	pgDB          interface{ Ping() error }
+	neo4jURL      string
+	neo4jUser     string
+	neo4jPassword string
+	neo4jDatabase string
+	embedEndpoint string
+	embedModel    string
+	llmProvider   llm.Provider
+	colManager    *store.CollectionManager
 }
 
 // probeEmbedService tries a handful of well-known health paths under the

--- a/Levara/cmd/server/main.go
+++ b/Levara/cmd/server/main.go
@@ -52,7 +52,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"flag"
 	"fmt"
 	"log"
@@ -62,13 +61,8 @@ import (
 	"strings"
 	"time"
 
-	"path/filepath"
-
-	"github.com/gofiber/swagger"
-	"github.com/hashicorp/raft"
 	_ "github.com/jackc/pgx/v5/stdlib"       // pgx via database/sql (binary protocol, prepared stmts)
 	_ "github.com/ncruces/go-sqlite3/driver" // pure-Go SQLite driver (no CGO, ARM64 ready)
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/stek0v/levara/internal/cluster"
 	vectorGrpc "github.com/stek0v/levara/internal/grpc"
 	"github.com/stek0v/levara/internal/metrics"
@@ -77,17 +71,12 @@ import (
 	_ "github.com/stek0v/levara/docs" // swaggo-generated OpenAPI spec (T13)
 	"github.com/stek0v/levara/pkg/embed"
 	"github.com/stek0v/levara/pkg/graphdb"
-	"github.com/stek0v/levara/pkg/ingest"
 	"github.com/stek0v/levara/pkg/llmcache"
 	"github.com/stek0v/levara/pkg/observe"
 	"github.com/stek0v/levara/pkg/router"
 	"github.com/stek0v/levara/pkg/runreg"
-	"github.com/stek0v/levara/pkg/storage"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/middleware/adaptor"
-	"github.com/gofiber/fiber/v2/middleware/cors"
-	"github.com/gofiber/fiber/v2/middleware/logger"
 
 	vectorHttp "github.com/stek0v/levara/internal/http"
 )
@@ -196,20 +185,7 @@ func main() {
 	// ---------------------------------------------------------------
 	// Storage backend (P3.5): STORAGE_BACKEND=local|s3
 	// ---------------------------------------------------------------
-	storagePath := *dataDir + "/uploads"
-	fileStore, storeErr := storage.NewFromEnv(storagePath)
-	if storeErr != nil {
-		log.Fatalf("storage init: %v", storeErr)
-	}
-	storageBackend := strings.ToLower(os.Getenv("STORAGE_BACKEND"))
-	srvLog.Info("storage backend ready", map[string]any{"backend": storageBackend, "path": storagePath})
-	if storageBackend == "s3" {
-		srvLog.Info("S3 storage enabled for upload hot-path", map[string]any{
-			"hot_path":     "/api/v1/add -> ingest + mirror to cfg.FileStorage",
-			"location_uri": "storage://<key> for non-local backend",
-			"storage_path": storagePath,
-		})
-	}
+	fileStore, storageBackend, _ := initStorageBackend(*dataDir, srvLog)
 
 	hnswCfg := store.HNSWConfig{
 		M:            *hnswM,
@@ -236,126 +212,27 @@ func main() {
 		log.Printf("Levara Raft consensus mode")
 	}
 
-	var shards []store.ShardHandler
-
-	for i := range numShards {
-		dbPath := fmt.Sprintf("%s/%s/shard_%d/meta.bin", *dataDir, nodeID, i)
-		db, err := store.NewLevara(*dim, dbPath, hnswCfg)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		if *standalone {
-			shards = append(shards, &cluster.DirectNode{DB: db}) // Repl set after replServer created
-		} else {
-			raftNode, err := cluster.NewRaftNode(i, nodeID, *dataDir+"/"+nodeID, basePort+i, db,
-				cluster.WithBindAddr(*raftAddr))
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			if *bootstrap {
-				configuration := raft.Configuration{
-					Servers: []raft.Server{
-						{
-							ID:      raft.ServerID(fmt.Sprintf("%s-shard-%d", nodeID, i)),
-							Address: raft.ServerAddress(fmt.Sprintf("%s:%d", *raftAddr, basePort+i)),
-						},
-					},
-				}
-				raftNode.Raft.BootstrapCluster(configuration)
-			}
-			shards = append(shards, raftNode)
-		}
-	}
-
-	c := store.NewCluster(shards)
-
-	// ---------------------------------------------------------------
-	// Replication setup
-	// ---------------------------------------------------------------
-	// Get a reference DB for replication (shard 0's underlying DB)
-	var replDB *store.Levara
-	if len(shards) > 0 {
-		switch s := shards[0].(type) {
-		case *cluster.DirectNode:
-			replDB = s.DB
-		case *cluster.RaftNode:
-			replDB = s.DB
-		}
-	}
-
-	var replServer *cluster.ReplicationServer
-	if replDB != nil {
-		replServer = cluster.NewReplicationServer(nodeID, nil, replDB)
-		if *joinAddr != "" {
-			replServer.SetRole("replica")
-			replServer.SetPrimaryAddr(*joinAddr)
-			log.Printf("Levara replica mode — joining primary at %s", *joinAddr)
-		} else {
-			replServer.SetRole("primary")
-			log.Printf("Levara primary mode — accepting replicas")
-		}
-		// Wire replication to all DirectNode shards
-		for _, shard := range shards {
-			if dn, ok := shard.(*cluster.DirectNode); ok {
-				dn.Repl = replServer
-			}
-		}
-	}
-
-	app := fiber.New()
-	app.Use(cors.New(cors.Config{
-		AllowOrigins:     "http://localhost:3000,http://localhost:3001,http://127.0.0.1:3000,http://127.0.0.1:3001,http://localhost:8080,http://localhost:8081",
-		AllowMethods:     "GET,POST,PUT,DELETE,PATCH,OPTIONS",
-		AllowHeaders:     "Origin,Content-Type,Accept,Authorization,X-Api-Key",
-		AllowCredentials: true,
-	}))
-	app.Use(logger.New())
-
-	handler := vectorHttp.NewHandler(c, *dim)
-	app.Get("/metrics", adaptor.HTTPHandler(promhttp.Handler()))
-
-	// Swagger UI (T13). Public in dev so anyone can explore; in prod we
-	// could gate behind a JWT admin middleware, but for now we let
-	// operators flip it off entirely by not setting ENV=dev. Regenerate
-	// docs/swagger.{json,yaml} via `make swag`.
-	if strings.EqualFold(os.Getenv("ENV"), "dev") || os.Getenv("ENV") == "" {
-		app.Get("/swagger/*", swagger.HandlerDefault)
-	}
-
-	// Root-level health for frontend compatibility
-	app.Get("/health", func(c *fiber.Ctx) error {
-		return c.JSON(fiber.Map{"status": "ready", "health": "healthy", "version": "levara-go"})
+	vectorRuntime := initVectorRuntime(vectorRuntimeConfig{
+		Dim:        *dim,
+		DataDir:    *dataDir,
+		NodeID:     nodeID,
+		NumShards:  numShards,
+		Standalone: *standalone,
+		Bootstrap:  *bootstrap,
+		RaftAddr:   *raftAddr,
+		RaftPort:   basePort,
+		JoinAddr:   *joinAddr,
+		HNSW:       hnswCfg,
 	})
+	shards := vectorRuntime.Shards
+	c := vectorRuntime.Cluster
+	replServer := vectorRuntime.Replication
+	replDB := replicationDB(shards)
 
-	// Build/version probe — consumed by the Qwen3 doctor drift-assertion (349f6e1)
-	// and by ops scripts to verify the deployed git SHA without parsing /metrics.
-	versionHandler := func(c *fiber.Ctx) error { return c.JSON(versionPayload()) }
-	app.Get("/version", versionHandler)
-
-	// ---------------------------------------------------------------
-	// Cluster replication endpoints
-	// ---------------------------------------------------------------
-	if replServer != nil {
-		app.Get("/cluster/wal/stream", adaptor.HTTPHandlerFunc(replServer.HandleStreamWAL))
-		app.Get("/cluster/snapshot", adaptor.HTTPHandlerFunc(replServer.HandleSnapshot))
-		app.Get("/cluster/state", adaptor.HTTPHandlerFunc(replServer.HandleClusterState))
-	}
-
-	// Cloud API compatibility: /api/datasets → /api/v1/datasets (cloudFetch strips /v1)
-	cloudApi := app.Group("/api")
-	cloudApi.Get("/datasets", func(c *fiber.Ctx) error {
-		return c.Redirect("/api/v1/datasets", 307)
-	})
-	cloudApi.Get("/datasets/:id/data", func(c *fiber.Ctx) error {
-		return c.Redirect("/api/v1/datasets/"+c.Params("id")+"/data", 307)
-	})
-	cloudApi.Get("/health", func(c *fiber.Ctx) error {
-		return c.JSON(fiber.Map{"status": "ready", "health": "healthy", "version": "levara-go"})
-	})
-
-	api := app.Group("/api/v1")
+	httpRuntime := initHTTPRuntime(c, *dim, replServer, errTracker)
+	app := httpRuntime.App
+	api := httpRuntime.API
+	handler := httpRuntime.VectorHandler
 
 	// Neo4j schema bootstrap is one-time at startup. Per-request handlers
 	// should not execute DDL for latency and side-effect reasons.
@@ -380,29 +257,7 @@ func main() {
 		// DB set after pgDB init below
 	}
 
-	// Public routes (no auth required)
-	api.Get("/info", handler.Info)
-	api.Get("/health", func(c *fiber.Ctx) error {
-		return c.JSON(fiber.Map{"status": "ready", "health": "healthy", "version": "levara-go"})
-	})
-	api.Get("/version", versionHandler)
-	api.Post("/checks/connection", func(c *fiber.Ctx) error {
-		return c.JSON(fiber.Map{"status": "connected"})
-	})
 	// api.Get("/visualize", ...) — moved below after DB init to include cfg.DB
-
-	// Error tracking endpoint (P3.4 observability)
-	api.Get("/errors", func(c *fiber.Ctx) error {
-		limit := c.QueryInt("limit", 50)
-		return c.JSON(fiber.Map{
-			"errors": errTracker.Recent(limit),
-			"total":  errTracker.Count(),
-		})
-	})
-	api.Delete("/errors", func(c *fiber.Ctx) error {
-		errTracker.Clear()
-		return c.JSON(fiber.Map{"cleared": true})
-	})
 
 	// Initialize CollectionManager for native collections (used by gRPC + the
 	// collection-aware HTTP write/search/delete paths).
@@ -416,93 +271,9 @@ func main() {
 	// for backward compatibility.
 	handler.SetCollections(colManager)
 
-	// Database connection pool (shared across all HTTP handlers)
-	// DB_PROVIDER: "sqlite" (embedded, no external server) or "postgres" (default)
-	pgDSN := ""
-	var pgDB *sql.DB
-	dbProvider := os.Getenv("DB_PROVIDER")
-
-	if dbProvider == "sqlite" {
-		// SQLite mode: pure-Go, no CGO, ARM64 ready (Raspberry Pi)
-		vectorHttp.SetDBProvider(vectorHttp.DBSQLite)
-		ingest.SetSQLiteMode(true)
-		dbPath := os.Getenv("DB_PATH")
-		if dbPath == "" {
-			dbPath = filepath.Join(*dataDir, "levara.db")
-		}
-		// Ensure parent directory exists
-		os.MkdirAll(filepath.Dir(dbPath), 0755)
-
-		var dbErr error
-		// ncruces/go-sqlite3: connection string with pragma query params
-		// ncruces/go-sqlite3: pragma params become part of filename — this is by design.
-		// Use simple WAL pragma only to keep filename manageable.
-		// ncruces/go-sqlite3: use file: URI with pragmas (file: prefix prevents
-		// pragma params from becoming part of the literal filename on disk)
-		dsn := "file:" + dbPath + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)"
-		pgDB, dbErr = sql.Open("sqlite3", dsn)
-		log.Printf("SQLite DSN: %s", dsn)
-		if dbErr != nil {
-			log.Printf("SQLite init warning: %v (running without DB)", dbErr)
-		} else {
-			// Allow multiple connections — ncruces driver may close connections
-			// after use; pool needs room to create replacements
-			pgDB.SetMaxOpenConns(4)
-			pgDB.SetMaxIdleConns(4)
-			pgDB.SetConnMaxLifetime(0)
-			pgDB.SetConnMaxIdleTime(0)
-			if err := pgDB.Ping(); err != nil {
-				log.Printf("SQLite ping warning: %v (running without DB)", err)
-				pgDB.Close()
-				pgDB = nil
-			} else {
-				log.Printf("SQLite database ready: %s", dbPath)
-				if err := vectorHttp.MigrateSchema(pgDB); err != nil {
-					log.Printf("Schema migration warning: %v", err)
-				}
-			}
-		}
-	} else if dbHost := os.Getenv("DB_HOST"); dbHost != "" {
-		// PostgreSQL mode (default)
-		vectorHttp.SetDBProvider(vectorHttp.DBPostgres)
-		dbUser := os.Getenv("DB_USERNAME")
-		if dbUser == "" {
-			dbUser = "levara"
-		}
-		dbPass := os.Getenv("DB_PASSWORD")
-		if dbPass == "" {
-			dbPass = "levara"
-		}
-		dbName := os.Getenv("DB_NAME")
-		if dbName == "" {
-			dbName = "levara_db"
-		}
-		dbPort := os.Getenv("DB_PORT")
-		if dbPort == "" {
-			dbPort = "5432"
-		}
-		pgDSN = fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", dbUser, dbPass, dbHost, dbPort, dbName)
-
-		var dbErr error
-		pgDB, dbErr = sql.Open("pgx", pgDSN)
-		if dbErr != nil {
-			log.Printf("PostgreSQL pool init warning: %v (running without DB)", dbErr)
-		} else {
-			pgDB.SetMaxOpenConns(25)
-			pgDB.SetMaxIdleConns(10)
-			pgDB.SetConnMaxLifetime(5 * time.Minute)
-			if err := pgDB.Ping(); err != nil {
-				log.Printf("PostgreSQL ping warning: %v (running without DB)", err)
-				pgDB.Close()
-				pgDB = nil
-			} else {
-				log.Printf("PostgreSQL connection pool ready (max_open=25, max_idle=10)")
-				if err := vectorHttp.MigrateSchema(pgDB); err != nil {
-					log.Printf("Schema migration warning: %v", err)
-				}
-			}
-		}
-	}
+	sqlRuntime := initSQLRuntime(*dataDir)
+	pgDSN := sqlRuntime.DSN
+	pgDB := sqlRuntime.DB
 	vizCfg.DB = pgDB // PostgreSQL/SQLite fallback for graph visualization
 	api.Get("/visualize", vectorHttp.VisualizeHTML(&vizCfg))
 	if pgDB != nil {
@@ -662,49 +433,49 @@ func main() {
 	workspaceWatcher := vectorHttp.NewWorkspaceWatchState()
 
 	apiCfg := vectorHttp.APIConfig{
-		PostgresDSN:      pgDSN,
-		StoragePath:      *dataDir + "/uploads",
-		WorkspacePath:    *dataDir + "/workspace",
-		JWTSecret:        authCfg.JWTSecret,
-		RequireAuth:      *requireAuth,
-		WorkspaceWatcher: workspaceWatcher,
-		EmbedEndpoint:    embedEndpoint,
-		EmbedModel:       embedModel,
-		EmbedClient:      sharedEmbed,
-		Collections:      colManager,
-		Neo4jCfg:         vizCfg,
-		DB:               pgDB,
-		BM25Indexes:      grpcSvc.BM25Indexes(),
-		LLMCache:         llmCache,
-		LLMProvider:      llmProvider,
-		ErrorTracker:     errTracker,
-		FileStorage:      fileStore,
-		Logger:           srvLog,
+		PostgresDSN:             pgDSN,
+		StoragePath:             *dataDir + "/uploads",
+		WorkspacePath:           *dataDir + "/workspace",
+		JWTSecret:               authCfg.JWTSecret,
+		RequireAuth:             *requireAuth,
+		WorkspaceWatcher:        workspaceWatcher,
+		EmbedEndpoint:           embedEndpoint,
+		EmbedModel:              embedModel,
+		EmbedClient:             sharedEmbed,
+		Collections:             colManager,
+		Neo4jCfg:                vizCfg,
+		DB:                      pgDB,
+		BM25Indexes:             grpcSvc.BM25Indexes(),
+		LLMCache:                llmCache,
+		LLMProvider:             llmProvider,
+		ErrorTracker:            errTracker,
+		FileStorage:             fileStore,
+		Logger:                  srvLog,
 		RerankEndpoint:          rerankCfg.Endpoint,
 		RerankModel:             rerankCfg.Model,
 		RerankTimeoutMs:         rerankCfg.TimeoutMs,
 		RerankBudgetMs:          rerankCfg.BudgetMs,
 		RerankScoreGapThreshold: rerankCfg.ScoreGapThreshold,
 		AdaptiveWeights:         adaptiveWeights,
-		Runs:             runs,
-		SearchStrategies: searchStrategies,
+		Runs:                    runs,
+		SearchStrategies:        searchStrategies,
 	}
 
 	// Protected routes: Levara API (datasets, upload, cognify, search)
 	vectorHttp.RegisterAPI(api, apiCfg)
 
 	mcpCfg := vectorHttp.APIConfig{
-		EmbedEndpoint:    embedEndpoint,
-		EmbedModel:       embedModel,
-		EmbedClient:      sharedEmbed,
-		WorkspacePath:    *dataDir + "/workspace",
-		JWTSecret:        authCfg.JWTSecret,
-		RequireAuth:      *requireAuth,
-		WorkspaceWatcher: workspaceWatcher,
-		Collections:      colManager,
-		DB:               pgDB,
-		BM25Indexes:      grpcSvc.BM25Indexes(),
-		LLMCache:         llmCache,
+		EmbedEndpoint:           embedEndpoint,
+		EmbedModel:              embedModel,
+		EmbedClient:             sharedEmbed,
+		WorkspacePath:           *dataDir + "/workspace",
+		JWTSecret:               authCfg.JWTSecret,
+		RequireAuth:             *requireAuth,
+		WorkspaceWatcher:        workspaceWatcher,
+		Collections:             colManager,
+		DB:                      pgDB,
+		BM25Indexes:             grpcSvc.BM25Indexes(),
+		LLMCache:                llmCache,
 		RerankEndpoint:          rerankCfg.Endpoint,
 		RerankModel:             rerankCfg.Model,
 		RerankTimeoutMs:         rerankCfg.TimeoutMs,

--- a/Levara/internal/http/api.go
+++ b/Levara/internal/http/api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stek0v/levara/pkg/router"
 	"github.com/stek0v/levara/pkg/runreg"
 	"github.com/stek0v/levara/pkg/storage"
+	"github.com/stek0v/levara/pkg/workspace"
 )
 
 // APIConfig holds configuration for Levara API endpoints.
@@ -80,12 +81,7 @@ type APIConfig struct {
 
 // RegisterAPI registers all Levara endpoints on the Fiber app.
 func RegisterAPI(app fiber.Router, cfg APIConfig) {
-	if cfg.StoragePath == "" {
-		cfg.StoragePath = "data/uploads"
-	}
-	if cfg.WorkspacePath == "" {
-		cfg.WorkspacePath = "data/workspace"
-	}
+	cfg.StoragePath, cfg.WorkspacePath = workspace.ResolveRuntimePaths(cfg.StoragePath, cfg.WorkspacePath)
 	// BL-2: log MkdirAll failures so ops can see permission / disk-full
 	// issues before the first upload attempt returns a cryptic 500. We
 	// don't fail startup — readonly filesystems are a legit deployment

--- a/Levara/internal/http/workspace.go
+++ b/Levara/internal/http/workspace.go
@@ -1345,7 +1345,7 @@ func loadWorkspaceManifest(cfg APIConfig, projectID, branch string) (*workspace.
 }
 
 func workspaceManifestPath(cfg APIConfig, projectID, branch string) string {
-	return filepath.Join(workspaceRoot(cfg), ".kb", "manifests", safeWorkspaceID(projectID)+"__"+safeWorkspaceID(branch)+".json")
+	return workspace.ManifestPath(workspaceRoot(cfg), projectID, branch)
 }
 
 func workspaceRoot(cfg APIConfig) string {
@@ -1356,7 +1356,7 @@ func workspaceRoot(cfg APIConfig) string {
 }
 
 func workspaceProjectRoot(cfg APIConfig, projectID, branch string) string {
-	return filepath.Join(workspaceRoot(cfg), "projects", safeWorkspaceID(projectID), safeWorkspaceID(branch))
+	return workspace.ProjectRoot(workspaceRoot(cfg), projectID, branch)
 }
 
 func workspaceFilePath(cfg APIConfig, projectID, branch, path string) (string, string, error) {
@@ -1891,10 +1891,7 @@ func workspaceSearchEnrichedResults(raw any, target workspaceSearchTarget, fresh
 }
 
 func defaultBranch(branch string) string {
-	if branch == "" {
-		return "main"
-	}
-	return branch
+	return workspace.DefaultBranch(branch)
 }
 
 func digestText(text string) string {
@@ -1903,23 +1900,7 @@ func digestText(text string) string {
 }
 
 func safeWorkspaceID(s string) string {
-	if s == "" {
-		return "default"
-	}
-	var b strings.Builder
-	for _, r := range s {
-		switch {
-		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
-			b.WriteRune(r)
-		default:
-			b.WriteByte('_')
-		}
-	}
-	out := strings.Trim(b.String(), "_")
-	if out == "" {
-		return "default"
-	}
-	return out
+	return workspace.SafeID(s)
 }
 
 func (h *mcpHandler) toolWorkspaceSearch(ctx context.Context, args map[string]any) mcpToolResult {

--- a/Levara/internal/http/workspace_context.go
+++ b/Levara/internal/http/workspace_context.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"os"
-	"path/filepath"
 	"sort"
 
 	"github.com/gofiber/fiber/v2"
@@ -137,19 +136,7 @@ func workspaceContextProjectIDs(ctx context.Context, cfg APIConfig, userID, expl
 }
 
 func workspaceLocalProjectIDs(cfg APIConfig) []string {
-	root := filepath.Join(workspaceRoot(cfg), "projects")
-	entries, err := os.ReadDir(root)
-	if err != nil {
-		return []string{}
-	}
-	var ids []string
-	for _, entry := range entries {
-		if entry.IsDir() {
-			ids = append(ids, entry.Name())
-		}
-	}
-	sort.Strings(ids)
-	return ids
+	return workspace.ListLocalProjects(workspaceRoot(cfg))
 }
 
 func workspaceDBProjectIDs(ctx context.Context, db *sql.DB, userID string) ([]string, error) {
@@ -198,20 +185,7 @@ func workspaceContextBranches(ctx context.Context, cfg APIConfig, projectID, bra
 }
 
 func workspaceLocalBranches(cfg APIConfig, projectID string) []string {
-	root := workspaceProjectRoot(cfg, projectID, "")
-	root = filepath.Dir(root)
-	entries, err := os.ReadDir(root)
-	if err != nil {
-		return []string{}
-	}
-	var branches []string
-	for _, entry := range entries {
-		if entry.IsDir() {
-			branches = append(branches, entry.Name())
-		}
-	}
-	sort.Strings(branches)
-	return branches
+	return workspace.ListLocalBranches(workspaceRoot(cfg), projectID)
 }
 
 func workspaceContextBranch(reqCtx context.Context, cfg APIConfig, projectID, branch string, watch WorkspaceWatchStatus) workspaceBranchContext {

--- a/Levara/pkg/mcp/deps.go
+++ b/Levara/pkg/mcp/deps.go
@@ -1,9 +1,9 @@
 // Package mcp is the Model Context Protocol transport + tools layer.
 // Wire types live in types.go, session lifecycle in session.go, the tool
 // descriptor registry in tools.go. Each MCP tool has a body in its own
-// tool_*.go file (see F-4 wave 3j-split). This file holds only the Deps
-// interface and the SearchResult type — the seam between the handler in
-// internal/http and the tool bodies.
+// tool_*.go file. This file holds the capability-oriented dependency
+// interfaces: the seam between the HTTP handler and transport-independent
+// tool bodies.
 package mcp
 
 import (
@@ -17,222 +17,106 @@ import (
 	"github.com/stek0v/levara/pkg/runreg"
 )
 
-// Deps is the narrow application-state surface that MCP tool
-// implementations depend on. The concrete implementation lives in
-// internal/http (wrapping APIConfig); tests pass their own fake.
-//
-// Each F-4 wave adds only the methods the next tool needs, so the seam
-// stays minimal and tools can be unit-tested without pulling in the full
-// HTTP config (embed client, LLM provider, Cluster, ...). Growth so far:
-//   - wave 3a: DB + Q (toolDelete)
-//   - wave 3b: no growth (toolPrune reused DB)
-//   - wave 3c: + HasCollections + ListCollections (toolListData)
-//   - wave 3d: + StoragePath (toolAdd)
-//   - wave 3e: + CollectionExists (toolSetContext)
-//   - wave 3i: + EmbedAvailable + Embed + CollectionInsert + CollectionSearch
-//     (toolSaveMemory + toolRecallMemory) — first AI seam. Types
-//     stay small ([]float32 and SearchResult) so pkg/mcp doesn't
-//     import pkg/embed or internal/store.
-//   - wave 3j: + Runs + BaseCognifyConfig + OntologyPromptSuffix +
-//     PersistPipelineStatus + LogHeartbeat + RunPipeline
-//     (toolCognify + toolCognifyStatus). BaseCognifyConfig brings
-//     in pkg/orchestrator as a new pkg/mcp import; Runs brings in
-//     pkg/runreg. RunPipeline abstracts orchestrator.Run so the
-//     cognify goroutine is testable without the real LLM/embed
-//     stack.
-//   - wave 3k: + NewSearchPipeline + LLMProvider + LLMModel +
-//     SearchCapabilities (toolSearch). NewSearchPipeline returns
-//     a SearchPipeline interface (defined in this package) so
-//     production wraps *pipeline.SearchPipeline while tests
-//     supply a stub. Pkg/mcp now imports pipeline + router +
-//     llm; graphrank stays inside tool_search.go (used only
-//     there).
-//   - wave 3o: + CollectionMeta (toolGetProjectContext + toolCheckDrift).
-//     Returns CollectionInfo value type so pkg/mcp stays free of
-//     internal/store.CollectionMeta pointer.
-//   - wave 3q: + DoSync (toolSync). One high-level method absorbs all
-//     internal/http sync helpers (SyncPull, syncPush,
-//     syncPullCollections, syncPushCollections) so pkg/mcp doesn't
-//     need to know about APIConfig or *store.CollectionManager.
-type Deps interface {
-	// DB returns the shared *sql.DB used for palace / datasets / graph
-	// tables. May be nil when no PostgresDSN is configured — tool
-	// implementations must guard against it rather than panic.
+// SQLDeps is the database surface used by tools that read/write palace,
+// datasets, graph, feedback, chat, and other SQL-backed records.
+type SQLDeps interface {
 	DB() *sql.DB
-	// Q rewrites a query's placeholder style and syntax to match the
-	// active DB dialect (Postgres passthrough, SQLite translation).
-	// Tools should always route queries through Q so the SQLite test
-	// builds stay working.
 	Q(query string) string
-	// HasCollections reports whether a vector-collection manager is
-	// configured. Some tools (e.g. list_data) return an empty result
-	// when this is false, mirroring a deployment that runs without the
-	// vector engine.
+}
+
+// CollectionDeps is the vector collection surface used by data/search/memory
+// tools. It deliberately avoids exposing internal/store types.
+type CollectionDeps interface {
 	HasCollections() bool
-	// ListCollections returns the registered collection names. Returns
-	// nil when HasCollections() is false. The slice is safe to iterate
-	// but must not be mutated.
 	ListCollections() []string
-	// StoragePath returns the on-disk directory where ingested files
-	// are written. An empty string is treated as the legacy default
-	// "data/uploads" by tools that need a path.
-	StoragePath() string
-	// CollectionExists reports whether a collection with the given name
-	// is registered. Always false when HasCollections() is false.
-	// Callers use this for soft validation — unknown names are still
-	// allowed through ToolSetContext on the "will be created when data
-	// is added" promise.
 	CollectionExists(name string) bool
-	// EmbedAvailable reports whether the embedding service + collection
-	// manager are both configured. Memory tools fall back to SQL-only
-	// paths when false. Cheap boolean gate — separate from HasCollections
-	// because some deployments have a vector engine without an embed
-	// service.
-	EmbedAvailable() bool
-	// Embed generates a single-vector embedding for the given text.
-	// Caller should guard with EmbedAvailable(); implementations may
-	// panic or error if called without a configured service.
-	Embed(ctx context.Context, text string) ([]float32, error)
-	// EmbedBatch generates vectors for multiple texts, reusing the shared
-	// embedding client (same TCP pool). Returns one vector per input text
-	// in order, or an error if the underlying call failed. Callers should
-	// still guard with EmbedAvailable() before invoking.
-	//
-	// Added for tool_codify which previously constructed its own
-	// embed.Client per request; that defeated the shared-pool win from T3.
-	EmbedBatch(ctx context.Context, texts []string) ([][]float32, error)
-	// CollectionInsert adds a vector + metadata to a named collection.
-	// Best-effort — callers ignore the error (matches pre-refactor
-	// fire-and-forget ingest behavior for vector-indexed memories).
 	CollectionInsert(collection, id string, vec []float32, meta any) error
-	// CollectionSearch finds the topK nearest vectors in a named
-	// collection. Returns an empty slice + nil error when no matches
-	// (caller distinguishes "no hits" from "error" via the err return).
 	CollectionSearch(collection string, query []float32, topK int) ([]SearchResult, error)
-	// Runs returns the shared pipeline-run registry. Cognify stores a
-	// *runreg.Status here so cognify_status (and the REST SSE stream in
-	// internal/http) can read progress updates. The concrete pointer is
-	// shared across the whole server — MCP-initiated and REST-initiated
-	// runs coexist in the same map.
-	Runs() *runreg.Registry
-	// BaseCognifyConfig returns an orchestrator.Config pre-populated with
-	// deployment-level settings: embed endpoint/model, LLM endpoint/model,
-	// LLM provider + cache, Neo4j credentials, collection manager, BM25
-	// indexes, DB handle. Tool-level fields (Collection, DatasetID, Room,
-	// Tags, SystemPrompt, SkipGraph, chunking overrides, ...) are the
-	// caller's responsibility and override the returned base.
-	//
-	// For tools that only need one or two settings, prefer the narrow
-	// accessors below (EmbedEndpoint / EmbedModel) — they don't pull
-	// orchestrator.Config into your file's type surface, which keeps
-	// tests lighter and the seam easier to reason about. BaseCognifyConfig
-	// is still the right choice when you mutate many fields to build a
-	// pipeline config from this template (see tool_cognify, tool_git).
-	BaseCognifyConfig() orchestrator.Config
-	// EmbedEndpoint returns the deployment-wide embedding service URL. Empty
-	// string when the embed service isn't configured — callers must guard.
-	EmbedEndpoint() string
-	// EmbedModel returns the deployment-wide embedding model name. Empty
-	// string when not configured.
-	EmbedModel() string
-	// OntologyPromptSuffix returns the ontology-guided extraction text to
-	// append to the system prompt for a given collection. Returns empty
-	// string when no ontology is configured for the collection. Harmless
-	// to concatenate unconditionally.
-	OntologyPromptSuffix(collection string) string
-	// PersistPipelineStatus writes terminal pipeline state to the data
-	// table so subsequent /cognify calls can skip already-processed
-	// datasets. Best-effort — errors are swallowed to match the
-	// pre-refactor signature which takes no error return.
-	PersistPipelineStatus(datasetID, collection, status string, chunks, entities, edges int, elapsedMs int64)
-	// LogHeartbeat records an event (arbitrary payload) into the
-	// heartbeats table when DB is configured, no-op otherwise. Used by
-	// long-running tools (cognify, sync, prune) for observability.
-	LogHeartbeat(eventType string, payload any)
-	// RunPipeline runs the cognify orchestrator end-to-end against texts
-	// with the given config, emitting Progress on progressCh and closing
-	// it when done. Production wiring calls orchestrator.Run; tests can
-	// substitute a stub that closes the channel immediately to exercise
-	// the post-run bookkeeping (status transition, persist, heartbeat)
-	// without the real LLM + embed stack.
-	RunPipeline(ctx context.Context, texts []string, cfg orchestrator.Config, progress chan<- orchestrator.Progress) error
-	// NewSearchPipeline returns a configured SearchPipeline (embed +
-	// collections + optional reranker) or nil when the embed service /
-	// collection manager isn't configured. doRerank tells the builder
-	// whether to construct a rerank client; callers should still gate
-	// rerank-only branches on SearchPipeline.RerankEnabled().
-	NewSearchPipeline(doRerank bool) SearchPipeline
-	// LLMProvider returns the multi-provider LLM abstraction, or nil
-	// when no provider is configured. Used by the multi-query search
-	// branch.
-	LLMProvider() llm.Provider
-	// LLMModel returns the configured LLM model name (from env var in
-	// the current wiring). Empty string when unset. The multi-query
-	// search branch forwards this to the provider.
-	LLMModel() string
-	// SearchCapabilities returns the router.Capabilities used by
-	// smart-routing (AUTO / FEELING_LUCKY search types). May be a
-	// relatively expensive call — the production implementation hits
-	// the DB to detect communities.
-	SearchCapabilities() router.Capabilities
-	// AllowedDatasetIDs returns the dataset/project scopes visible to the
-	// caller represented by ctx. Nil means no filtering (dev mode, anonymous,
-	// or superuser); an empty non-nil slice means fail closed.
-	AllowedDatasetIDs(ctx context.Context) []string
-	// ListLexicalCollections returns collection names known to the lexical
-	// index. It may differ from ListCollections on deployments that have BM25
-	// indexes but no vector engine.
-	ListLexicalCollections() []string
-	// LexicalSearch performs a BM25/keyword search against one collection.
-	// Returns an empty slice when the collection has no lexical index.
-	LexicalSearch(collection, query string, topK int) ([]LexicalResult, error)
-	// CollectionMeta returns observable metadata for a named collection.
-	// Returns zero CollectionInfo when the collection doesn't exist or
-	// HasCollections() is false. Used by toolGetProjectContext and
-	// toolCheckDrift to read per-collection stats without leaking the
-	// internal/store.CollectionMeta pointer into pkg/mcp.
 	CollectionMeta(name string) CollectionInfo
-	// DoSync orchestrates a bidirectional sync operation with a remote
-	// Levara instance. It returns the per-type sync result map and the
-	// remote manifest map. The caller is responsible for adding
-	// remote_manifest to result and calling LogHeartbeat. error is
-	// returned only for connectivity failures (manifest fetch); per-type
-	// sync errors are folded into the result map under "<type>_error"
-	// keys, matching the pre-refactor behaviour. One method absorbs all
-	// internal/http sync helpers so pkg/mcp doesn't need APIConfig or
-	// *store.CollectionManager.
+}
+
+// StorageDeps is the filesystem/object-storage surface used by ingest tools.
+type StorageDeps interface {
+	StoragePath() string
+}
+
+// EmbedDeps is the embedding surface used by memory, codify, and search tools.
+type EmbedDeps interface {
+	EmbedAvailable() bool
+	Embed(ctx context.Context, text string) ([]float32, error)
+	EmbedBatch(ctx context.Context, texts []string) ([][]float32, error)
+	EmbedEndpoint() string
+	EmbedModel() string
+}
+
+// MemoryDeps groups the capabilities needed by the memory palace tools.
+type MemoryDeps interface {
+	SQLDeps
+	CollectionDeps
+	EmbedDeps
+}
+
+// PipelineDeps is the cognify/git-ingest pipeline surface.
+type PipelineDeps interface {
+	Runs() *runreg.Registry
+	BaseCognifyConfig() orchestrator.Config
+	OntologyPromptSuffix(collection string) string
+	PersistPipelineStatus(datasetID, collection, status string, chunks, entities, edges int, elapsedMs int64)
+	RunPipeline(ctx context.Context, texts []string, cfg orchestrator.Config, progress chan<- orchestrator.Progress) error
+}
+
+// SearchDeps is the semantic/lexical/graph search surface.
+type SearchDeps interface {
+	CollectionDeps
+	EmbedDeps
+	NewSearchPipeline(doRerank bool) SearchPipeline
+	LLMProvider() llm.Provider
+	LLMModel() string
+	SearchCapabilities() router.Capabilities
+	AllowedDatasetIDs(ctx context.Context) []string
+	ListLexicalCollections() []string
+	LexicalSearch(collection, query string, topK int) ([]LexicalResult, error)
+}
+
+// SyncDeps is the cross-instance sync surface.
+type SyncDeps interface {
 	DoSync(ctx context.Context, remoteURL, direction string, types []string, since string, collections []string) (result, manifest map[string]any, err error)
 }
 
-// SearchPipeline is the narrow interface toolSearch calls into. The
-// production implementation in internal/http is a thin adapter over
-// *pipeline.SearchPipeline plus the optional *rerank.Client. Tests
-// supply their own stub so the dispatch logic can be exercised
-// without a live embed/rerank service.
+// ObservabilityDeps is the heartbeat/ops event surface.
+type ObservabilityDeps interface {
+	LogHeartbeat(eventType string, payload any)
+}
+
+// Deps is the full application-state surface that the current MCP tool set
+// depends on. New tools should prefer the narrow capability interface they
+// actually need (SQLDeps, SearchDeps, PipelineDeps, SyncDeps, etc.) so the
+// transport boundary stays understandable as MCP grows.
+type Deps interface {
+	SQLDeps
+	CollectionDeps
+	StorageDeps
+	EmbedDeps
+	PipelineDeps
+	SearchDeps
+	SyncDeps
+	ObservabilityDeps
+}
+
+// SearchPipeline is the narrow interface toolSearch calls into. The production
+// implementation in internal/http is a thin adapter over *pipeline.SearchPipeline
+// plus the optional reranker. Tests supply their own stub so dispatch logic can
+// be exercised without a live embed/rerank service.
 type SearchPipeline interface {
-	// SearchByText runs the default vector similarity search.
 	SearchByText(ctx context.Context, collection, query string, topK int) ([]pipeline.ScoredResult, error)
-	// SearchByTextParentChild uses the parent-child hierarchical
-	// chunking strategy.
 	SearchByTextParentChild(ctx context.Context, collection, query string, topK int) ([]pipeline.ScoredResult, error)
-	// SearchByTextMultiQuery generates n rewritten queries via the
-	// given provider/model and merges their results.
 	SearchByTextMultiQuery(ctx context.Context, collection, query string, topK int, provider llm.Provider, model string, n int) ([]pipeline.ScoredResult, error)
-	// ApplyRerank reranks an ACL-prefiltered slice against `query` using
-	// the configured cross-encoder. Returns (reranked, ordered) — true
-	// only when the sidecar successfully scored at least one row. Callers
-	// MUST ACL-filter `in` first; passing unfiltered candidates leaks
-	// forbidden text to the third-party reranker (see Phase 2.5 RCA).
 	ApplyRerank(ctx context.Context, query string, in []pipeline.ScoredResult, topK int) (bool, []pipeline.ScoredResult)
-	// RerankEnabled reports whether the underlying rerank client is
-	// configured + reachable. Callers gate the rerank branch on this.
 	RerankEnabled() bool
 }
 
-// SearchResult is one entry returned by CollectionSearch. Kept small
-// and type-clean so pkg/mcp doesn't need to import internal/store's
-// VectroRecord. Data carries raw JSON metadata that callers unmarshal
-// on demand.
+// SearchResult is one entry returned by CollectionSearch. Kept small and
+// type-clean so pkg/mcp doesn't need to import internal/store's VectroRecord.
 type SearchResult struct {
 	ID    string
 	Score float32
@@ -240,16 +124,13 @@ type SearchResult struct {
 }
 
 // LexicalResult is one BM25/keyword hit returned by Deps.LexicalSearch.
-// Score follows BM25 convention: higher is better.
 type LexicalResult struct {
 	ID       string
 	Score    float64
 	Metadata []byte
 }
 
-// CollectionInfo is the observable metadata for a single collection
-// returned by Deps.CollectionMeta. It is a plain value type — no
-// internal/store pointers — so pkg/mcp stays free of that import.
+// CollectionInfo is observable collection metadata without internal pointers.
 type CollectionInfo struct {
 	Name       string
 	Records    int

--- a/Levara/pkg/workspace/config.go
+++ b/Levara/pkg/workspace/config.go
@@ -1,0 +1,19 @@
+package workspace
+
+const (
+	DefaultStoragePath   = "data/uploads"
+	DefaultWorkspacePath = "data/workspace"
+)
+
+// ResolveRuntimePaths applies Levara's default data roots for API/workspace
+// handlers. Keeping this in pkg/workspace makes the workspace path policy
+// reusable outside the HTTP transport.
+func ResolveRuntimePaths(storagePath, workspacePath string) (string, string) {
+	if storagePath == "" {
+		storagePath = DefaultStoragePath
+	}
+	if workspacePath == "" {
+		workspacePath = DefaultWorkspacePath
+	}
+	return storagePath, workspacePath
+}

--- a/Levara/pkg/workspace/paths.go
+++ b/Levara/pkg/workspace/paths.go
@@ -1,0 +1,73 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func DefaultBranch(branch string) string {
+	if branch == "" {
+		return "main"
+	}
+	return branch
+}
+
+func SafeID(s string) string {
+	if s == "" {
+		return "default"
+	}
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	out := strings.Trim(b.String(), "_")
+	if out == "" {
+		return "default"
+	}
+	return out
+}
+
+func ProjectRoot(root, projectID, branch string) string {
+	return filepath.Join(root, "projects", SafeID(projectID), SafeID(branch))
+}
+
+func ManifestPath(root, projectID, branch string) string {
+	return filepath.Join(root, ".kb", "manifests", SafeID(projectID)+"__"+SafeID(branch)+".json")
+}
+
+func ListLocalProjects(root string) []string {
+	entries, err := os.ReadDir(filepath.Join(root, "projects"))
+	if err != nil {
+		return []string{}
+	}
+	var ids []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			ids = append(ids, entry.Name())
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func ListLocalBranches(root, projectID string) []string {
+	entries, err := os.ReadDir(filepath.Dir(ProjectRoot(root, projectID, "")))
+	if err != nil {
+		return []string{}
+	}
+	var branches []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			branches = append(branches, entry.Name())
+		}
+	}
+	sort.Strings(branches)
+	return branches
+}

--- a/Levara/pkg/workspace/paths_test.go
+++ b/Levara/pkg/workspace/paths_test.go
@@ -1,0 +1,39 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWorkspacePathsPolicy(t *testing.T) {
+	root := t.TempDir()
+	if got := DefaultBranch(""); got != "main" {
+		t.Fatalf("DefaultBranch empty = %q, want main", got)
+	}
+	if got := SafeID("../bad id!"); got != "bad_id" {
+		t.Fatalf("SafeID = %q, want bad_id", got)
+	}
+	if got := ManifestPath(root, "proj/1", "feature/x"); got != filepath.Join(root, ".kb", "manifests", "proj_1__feature_x.json") {
+		t.Fatalf("ManifestPath = %q", got)
+	}
+}
+
+func TestListLocalProjectsAndBranches(t *testing.T) {
+	root := t.TempDir()
+	for _, dir := range []string{
+		filepath.Join(root, "projects", "proj_b", "main"),
+		filepath.Join(root, "projects", "proj_a", "dev"),
+		filepath.Join(root, "projects", "proj_a", "main"),
+	} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := ListLocalProjects(root); len(got) != 2 || got[0] != "proj_a" || got[1] != "proj_b" {
+		t.Fatalf("ListLocalProjects = %#v", got)
+	}
+	if got := ListLocalBranches(root, "proj_a"); len(got) != 2 || got[0] != "dev" || got[1] != "main" {
+		t.Fatalf("ListLocalBranches = %#v", got)
+	}
+}

--- a/docs/codebase-component-analysis-ru.md
+++ b/docs/codebase-component-analysis-ru.md
@@ -1,0 +1,1013 @@
+# Levara: подробный покомпонентный анализ кода
+
+Дата анализа: 2026-05-16.
+
+Область анализа: актуальная реализация в `Levara/`, Web UI в `Levara/webui/`,
+внешние интеграции `cognee-plugin/` и `clawdbot/`. Каталог `Levara-legacy/`
+является исторической реализацией и в основную архитектурную картину не входит.
+
+## Краткая суть
+
+Levara в текущем виде — это не просто HNSW-векторная база. Это серверная
+платформа памяти для AI-агентов и RAG/KG-приложений. В одном Go-процессе
+собраны:
+
+- векторное хранилище с HNSW, WAL, append-only metadata store и коллекциями;
+- REST API для Web UI и продуктовых сценариев;
+- gRPC API для быстрых backend-интеграций и Cognee-адаптера;
+- MCP Streamable HTTP API для AI-агентов;
+- пайплайн `cognify`: chunking, embeddings, LLM extraction, graph write,
+  BM25 indexing и прогресс через SSE/MCP;
+- SQL-метаданные: пользователи, datasets, data, memories, graph mirror, RBAC,
+  sync, feedback, notebooks, workspace;
+- интеграции с Neo4j, embedding service, LLM-провайдерами, reranker sidecar,
+  S3-compatible storage, Prometheus и Langfuse.
+
+Иными словами, Levara — это композиция из трех крупных слоев:
+
+1. **Storage/runtime ядро**: коллекции, HNSW, WAL, shard/cluster/replication.
+2. **Memory/RAG/KG слой**: ingest, search, cognify, graph, memory palace,
+   workspace.
+3. **Интеграционные поверхности**: REST, gRPC, MCP, Web UI, Cognee adapter,
+   clawdbot plugin.
+
+## Общая схема системы
+
+```mermaid
+flowchart LR
+    subgraph Clients["Клиенты и потребители"]
+        WebUI["Next.js Web UI"]
+        Cognee["Cognee VectorDBInterface"]
+        Agents["AI agents / MCP clients"]
+        Clawdbot["clawdbot memory plugin"]
+        CLI["CLI / scripts / tests"]
+    end
+
+    subgraph Server["Levara Go server"]
+        Fiber["Fiber HTTP server"]
+        REST["REST API /api/v1"]
+        MCP["MCP JSON-RPC /mcp"]
+        GRPC["gRPC v1/v2"]
+        LegacyHTTP["Legacy vector HTTP"]
+    end
+
+    subgraph Core["Внутренние сервисы"]
+        Collections["CollectionManager"]
+        Cluster["Shard Cluster"]
+        Store["Levara store"]
+        Pipeline["Cognify orchestrator"]
+        SearchPipe["Search pipeline"]
+        BM25["BM25 indexes"]
+        Workspace["Workspace indexer"]
+        RunReg["Run registry"]
+    end
+
+    subgraph External["Внешние зависимости"]
+        SQL["PostgreSQL / SQLite"]
+        Neo4j["Neo4j"]
+        Embed["Embedding service"]
+        LLM["LLM provider"]
+        Rerank["Rerank sidecar"]
+        S3["Local FS / S3 storage"]
+        Prom["Prometheus"]
+    end
+
+    WebUI --> Fiber
+    Clawdbot --> Fiber
+    CLI --> Fiber
+    Agents --> MCP
+    Cognee --> GRPC
+
+    Fiber --> REST
+    Fiber --> MCP
+    Fiber --> LegacyHTTP
+    GRPC --> Collections
+    REST --> Collections
+    MCP --> Collections
+    LegacyHTTP --> Cluster
+
+    Collections --> Store
+    Cluster --> Store
+    REST --> Pipeline
+    MCP --> Pipeline
+    GRPC --> Pipeline
+    Pipeline --> Collections
+    Pipeline --> BM25
+    Pipeline --> SQL
+    Pipeline --> Neo4j
+    Pipeline --> Embed
+    Pipeline --> LLM
+
+    REST --> Workspace
+    MCP --> Workspace
+    SearchPipe --> Collections
+    SearchPipe --> Embed
+    SearchPipe --> Rerank
+    REST --> SQL
+    MCP --> SQL
+    REST --> S3
+    Fiber --> Prom
+```
+
+## Точка входа и bootstrap
+
+Главная точка входа: `Levara/cmd/server/main.go`.
+
+Этот файл является composition root: он не просто запускает сервер, а собирает
+все зависимости и передает их в REST, gRPC и MCP слои.
+
+На старте происходит следующее:
+
+1. Читаются CLI flags: размерность embeddings, HTTP/gRPC порты, количество
+   шардов, data directory, HNSW-параметры, auth, Neo4j, Raft/replica settings.
+2. Создаются logger и error tracker из `pkg/observe`.
+3. Инициализируется storage backend:
+   - local filesystem по умолчанию;
+   - S3-compatible backend при `STORAGE_BACKEND=s3`.
+4. Формируется `store.HNSWConfig`.
+5. Создаются shard handlers:
+   - `cluster.DirectNode` в standalone-режиме;
+   - `cluster.RaftNode` в Raft-режиме.
+6. Создается `store.Cluster` для legacy shard path.
+7. Поднимается WAL replication server, если доступен underlying DB.
+8. Создается Fiber HTTP app, подключаются CORS, logger, `/metrics`,
+   `/health`, `/version`, Swagger.
+9. Создается `store.CollectionManager`, который является основным современным
+   механизмом коллекций.
+10. Открывается SQL DB:
+   - SQLite при `DB_PROVIDER=sqlite`;
+   - PostgreSQL при наличии `DB_HOST`;
+   - если DB нет, часть функций работает в degraded mode.
+11. Выполняется `MigrateSchema`.
+12. Регистрируются auth endpoints.
+13. После auth middleware регистрируются защищенные REST endpoints.
+14. Создается gRPC service, его BM25 indexes передаются в REST/MCP.
+15. Создаются LLM cache, LLM provider, adaptive router, run registry,
+   shared embedding client, rerank config.
+16. Регистрируется MCP endpoint `/mcp`.
+17. Опционально запускаются workspace watcher и workspace index worker.
+18. Стартуют gRPC server и Fiber HTTP server.
+
+Главная особенность этого bootstrap: один процесс обслуживает сразу несколько
+протоколов, но большая часть состояния общая: `CollectionManager`, SQL DB,
+BM25 map, embedding client, run registry, LLM cache.
+
+## Основные транспортные поверхности
+
+### REST API
+
+REST слой находится в `Levara/internal/http`.
+
+Регистрация основной группы endpoint-ов происходит в `RegisterAPI`:
+`Levara/internal/http/api.go`.
+
+REST API нужен прежде всего для:
+
+- Web UI;
+- dataset/data CRUD;
+- upload и ingest;
+- search/chat workflows;
+- auth, users, tenants, RBAC;
+- memory CRUD;
+- workspace lifecycle;
+- sync между инстансами;
+- feedback и telemetry;
+- notebooks/settings/product features.
+
+Основные группы endpoint-ов:
+
+| Группа | Файлы | Назначение |
+|---|---|---|
+| Auth | `auth.go`, `users.go` | JWT, registration, login, API keys, current user |
+| Datasets | `api_datasets.go`, `api_upload.go` | datasets, uploaded data, raw content, storage URLs |
+| Legacy vector ops | `handler.go` | `/insert`, `/batch_insert`, `/search`, `/delete` |
+| Search | `api_search.go`, `dualsearch.go`, `search_strategy.go` | semantic, lexical, graph, hybrid, rerank search |
+| Cognify | `api_cognify.go` | background RAG/KG pipeline, status, SSE |
+| Memify | `memify.go` | post-cognify graph enrichment |
+| Collections | `collections.go`, `reembed.go` | collection metadata, re-embedding migration |
+| Memory | `memories.go`, `memory_events.go` | project/user memories and SSE events |
+| MCP bridge | `mcp.go`, `mcp_palace.go`, `mcp_doctor.go` | MCP endpoint and HTTP-specific tool wiring |
+| Workspace | `workspace*.go` | markdown workspace index/read/write/reconcile/jobs |
+| Sync | `sync.go` | export/import memories, interactions, graph, collections |
+| Graph | `graph_search.go`, `api_graph_path.go`, `visualize.go` | graph search, path, visualization |
+| RBAC/tenant | `rbac.go`, `tenants.go` | ACL, dataset sharing, tenant selection |
+| Feedback | `feedback.go` | search feedback, stats, adaptive weights |
+| Product UI | `notebooks.go`, `settings.go` | notebooks, settings |
+| Ops | `observe_middleware.go`, `confidence.go`, `verify.go` | metrics, confidence, diagnostics |
+
+REST слой достаточно широкий. Это не только HTTP wrappers, а фактически
+application layer для UI и многих agent-facing сценариев.
+
+### gRPC API
+
+Основной код: `Levara/internal/grpc/service.go`.
+
+gRPC API нужен для низколатентных backend-интеграций. Его использует
+`cognee-plugin/levara_adapter/LevaraAdapter.py`.
+
+Ключевые RPC:
+
+- collections: `CreateCollection`, `DropCollection`, `ListCollections`,
+  `HasCollection`;
+- records: `Insert`, `BatchInsert`, `Delete`, `Search`, `GetByID`;
+- text: `ChunkText`, `SearchByText`, `BatchSearchByText`;
+- graph: `ProcessTriplets`, `BatchWriteGraph`, `GraphRead`,
+  `GraphCompletionSearch`;
+- pipeline: `PipelineCognify` streaming;
+- lexical: `BM25Index`, `BM25Search`, `HybridSearch`;
+- operations: `BatchEmbedAndIndex`, `ParallelWriteDataPoints`,
+  `IngestData`, `ExtractText`, `TemporalSearch`;
+- LLM cache: `LLMCacheGet`, `LLMCachePut`, `LLMCacheStats`;
+- maintenance: `Compact`.
+
+Есть `service_v2.go`, который оборачивает v1 и дает более компактную v2
+поверхность с алиасами `Add`, `Save`, `Create`.
+
+### MCP API
+
+MCP endpoint: `POST /mcp`, `GET /mcp`, `DELETE /mcp`.
+
+Код:
+
+- HTTP transport: `Levara/internal/http/mcp.go`;
+- tool descriptors и tool bodies: `Levara/pkg/mcp`;
+- дополнительные HTTP-bound tools: `mcp_palace.go`, `mcp_doctor.go`,
+  `workspace*.go`.
+
+MCP слой делает Levara памятью для AI-агентов. Важная архитектурная граница:
+`pkg/mcp.Deps`. Tool code не зависит напрямую от Fiber, а получает узкий набор
+методов: DB, collections, embeddings, search pipeline, LLM provider, sync,
+workspace и т.д.
+
+Основные MCP tool families:
+
+- **ingestion/search**: `cognify`, `cognify_status`, `search`,
+  `cross_search`, `codify`;
+- **data**: `add`, `list_data`, `delete`, `prune`;
+- **memory palace**: `save_memory`, `recall_memory`, `list_memories`,
+  `pin_memory`, `unpin_memory`, `wake_up`;
+- **chat history**: `save_chat`, `recall_chat`, `search_chats`;
+- **graph**: `query_entity`, `list_communities`, `check_drift`,
+  `prune_graph`;
+- **workspace**: context, access check, audit, search, read, write, index,
+  reconcile, jobs, commit, revert, GC;
+- **ops**: `doctor`, `heartbeat`, runtime stats, recent errors, sync status.
+
+## Storage engine
+
+Основное ядро: `Levara/internal/store`.
+
+Компоненты:
+
+- `Levara` DB: объект одной физической базы/коллекции;
+- `CollectionManager`: map collection name -> `*Levara`;
+- `Cluster`: legacy hash shard router;
+- `VectorArena`: хранение нормализованных float32-векторов;
+- `HNSWIndex`: approximate nearest neighbor index;
+- `DiskStore`: append-only metadata store;
+- `WAL`: write-ahead log с group flush;
+- `pendingVecs`: векторы, уже записанные, но еще не добавленные в HNSW;
+- `indexerLoop`: background goroutine для асинхронного HNSW indexing.
+
+```mermaid
+flowchart TD
+    Client["REST/gRPC/MCP"] --> CM["CollectionManager"]
+    Client --> Cluster["Legacy Cluster"]
+    CM --> DB["Levara DB"]
+    Cluster --> DB
+
+    subgraph DB["Levara DB internals"]
+        Insert["Insert / BatchInsert"]
+        Search["Search / Get"]
+        Arena["VectorArena"]
+        Disk["DiskStore metadata"]
+        WAL["WAL"]
+        Pending["pendingVecs"]
+        Indexer["indexerLoop"]
+        HNSW["HNSWIndex"]
+    end
+
+    Insert --> Arena
+    Insert --> Disk
+    Insert --> WAL
+    Insert --> Pending
+    Pending --> Indexer
+    Indexer --> HNSW
+    Search --> HNSW
+    Search --> Pending
+    Search --> Disk
+```
+
+### Почему есть и CollectionManager, и Cluster
+
+В коде есть два пути:
+
+1. **Современный collection-aware path**: если request содержит `collection`,
+   используется `CollectionManager`. Это основной путь для gRPC, REST search,
+   MCP, cognify, memory.
+2. **Legacy cluster path**: если `collection` не указан, legacy HTTP vector
+   endpoints используют `store.Cluster`, который hash-роутит ID по шардам.
+
+Это дает обратную совместимость, но создает важный архитектурный нюанс: новые
+фичи должны явно работать с коллекциями, иначе легко попасть в legacy path.
+
+### Write path
+
+```mermaid
+sequenceDiagram
+    participant Client as Клиент
+    participant Handler as REST/gRPC/MCP handler
+    participant CM as CollectionManager
+    participant DB as Levara DB
+    participant Arena
+    participant Disk
+    participant WAL
+    participant Indexer as Background indexer
+    participant HNSW
+
+    Client->>Handler: insert / batch_insert
+    Handler->>CM: выбрать коллекцию
+    CM->>DB: Insert / BatchInsert
+    DB->>Arena: записать vector
+    DB->>Disk: записать metadata
+    DB->>WAL: записать WAL entry
+    DB->>WAL: async flush signal
+    DB->>Indexer: добавить в pending queue
+    Handler-->>Client: response
+    Indexer->>HNSW: добавить node в индекс
+```
+
+Важная особенность: HNSW indexing вынесен в background. Поэтому write latency
+не зависит напрямую от стоимости graph insertion. Чтобы свежие записи не
+терялись для поиска, search дополнительно сканирует `pendingVecs`.
+
+### Search path
+
+```mermaid
+flowchart TD
+    Req["search request"] --> Vector{"Есть vector?"}
+    Vector -- no --> Embed["embed.Client -> embedding endpoint"]
+    Vector -- yes --> QueryVec["query vector"]
+    Embed --> QueryVec
+    QueryVec --> HNSW["HNSW search"]
+    QueryVec --> Pending["brute-force pending scan"]
+    HNSW --> Merge["merge + dedup"]
+    Pending --> Merge
+    Merge --> Metadata["hydrate metadata from DiskStore"]
+    Metadata --> Response["ranked results"]
+```
+
+## Cognify pipeline
+
+Основной код: `Levara/pkg/orchestrator/pipeline.go`.
+
+`cognify` — это серверный pipeline, который превращает текст/файлы в:
+
+- chunks;
+- embeddings;
+- vector records;
+- BM25 records;
+- graph nodes/edges;
+- temporal facts;
+- community summaries;
+- pipeline status.
+
+```mermaid
+flowchart TD
+    Input["Text / uploaded files / MCP data"] --> Classify["classify + extract"]
+    Classify --> Chunk["chunker"]
+    Chunk --> Mode{"mode"}
+
+    Mode -->|rag / SkipGraph| EmbedChunks["embed chunks"]
+    Mode -->|full| LLMExtract["LLM entity extraction"]
+    LLMExtract --> Dedup["dedup nodes/edges"]
+    Dedup --> Temporal["temporal extraction"]
+    Temporal --> GraphWrite["write SQL graph + Neo4j"]
+    GraphWrite --> Community["community detection"]
+
+    LLMExtract --> EmbedChunks
+    EmbedChunks --> VectorWrite["CollectionManager.BatchInsert"]
+    EmbedChunks --> BM25Write["BM25 index update"]
+    VectorWrite --> Status["runreg + pipeline_status"]
+    BM25Write --> Status
+    Community --> Status
+```
+
+Поддерживаемые режимы:
+
+- `rag`: только chunk + embed + vector/BM25, без LLM и graph;
+- `full`: полный pipeline с entity extraction, graph write и temporal logic.
+
+Chunking стратегии:
+
+- `merged`;
+- `paragraph`;
+- `sentence`;
+- `row`;
+- `code`;
+- `sliding`;
+- `auto`;
+- parent-child chunking.
+
+Parent-child chunking нужен для баланса:
+
+- child chunks дают точность поиска;
+- parent chunks дают больше контекста при ответе.
+
+## Search layer
+
+Search существует в нескольких формах:
+
+- REST: `internal/http/api_search.go`;
+- gRPC: `SearchByText`, `HybridSearch`, `GraphCompletionSearch`;
+- MCP: `pkg/mcp/tool_search.go`;
+- shared in-process helpers: `Levara/pipeline`.
+
+Поиск может использовать:
+
+- vector search через `CollectionManager`;
+- lexical BM25;
+- hybrid fusion;
+- graph traversal / graph rank;
+- temporal filters;
+- LLM completion;
+- multi-query expansion;
+- rerank sidecar.
+
+```mermaid
+flowchart TD
+    Query["Natural language query"] --> Router["router / search_type"]
+    Router --> Vector["CHUNKS / vector"]
+    Router --> Lexical["CHUNKS_LEXICAL / BM25"]
+    Router --> Hybrid["HYBRID"]
+    Router --> Graph["GRAPH_COMPLETION"]
+    Router --> Temporal["TEMPORAL"]
+    Router --> RAG["RAG_COMPLETION"]
+
+    Vector --> Results
+    Lexical --> Results
+    Hybrid --> Fusion["RRF / weighted fusion"]
+    Graph --> GraphRank["graph context + scoring"]
+    Temporal --> TimeFilter["date-aware filtering"]
+    RAG --> LLMAnswer["LLM answer from retrieved context"]
+
+    Fusion --> ACL["RBAC filter"]
+    GraphRank --> ACL
+    TimeFilter --> ACL
+    Results --> ACL
+    ACL --> Rerank{"rerank?"}
+    Rerank -- yes --> Sidecar["rerank.Client"]
+    Rerank -- no --> Final["final ranked results"]
+    Sidecar --> Final
+    LLMAnswer --> Final
+```
+
+Критически важное правило в коде: rerank должен запускаться после ACL-filter.
+Иначе текст запрещенных документов может уйти во внешний reranker.
+
+## SQL metadata layer
+
+Миграция: `Levara/internal/http/schema.go`.
+
+SQL DB используется как общая metadata-плоскость. Поддерживаются PostgreSQL и
+SQLite.
+
+Основные таблицы:
+
+- `principals`, `users`, `api_keys`: пользователи, auth, API keys;
+- `datasets`, `data`, `dataset_data`: каталог загруженных данных;
+- `graph_nodes`, `graph_edges`: SQL-зеркало knowledge graph;
+- `tenants`, `user_tenant`, `roles`, `user_role`, `acl`,
+  `dataset_shares`: multi-tenant и RBAC;
+- `interactions`: история пользовательских запросов/ответов;
+- `memories`: memory palace / project memory;
+- `ontologies`: загруженные ontology files;
+- `notebooks`, `notebook_cells`: UI notebooks;
+- `user_settings`: настройки пользователя;
+- `feedback`: обратная связь по search results;
+- workspace/sync/heartbeat таблицы добавляются дальнейшими migration
+  statements в том же schema layer.
+
+SQL слой важен не меньше vector store. Без него Levara теряет пользователей,
+память, graph mirror, datasets, RBAC, sync и workspace state.
+
+## Knowledge graph
+
+Graph функциональность распределена по нескольким пакетам:
+
+- `pkg/graph`: triplets, graph primitives, dedup, LSH, multi-query;
+- `pkg/graphdb`: Neo4j writer/cached writer;
+- `pkg/graphstore`: SQL-backed graph store;
+- `pkg/graphrank`: graph proximity ranking;
+- `pkg/community`: Louvain community detection;
+- `pkg/temporal`: timestamp extraction and temporal search;
+- `internal/http/api_graph_path.go`: REST graph path;
+- `internal/http/visualize.go`: graph visualization.
+
+Graph хранится в двух формах:
+
+1. **Neo4j**: для graph visualization и graph traversal.
+2. **SQL mirror**: для query_entity, sync, temporal validity, fallback search.
+
+Temporal model:
+
+- edge может иметь `valid_from` и `valid_until`;
+- exclusive relationships могут supersede старые edges;
+- `superseded_by` хранит связь на новый edge;
+- можно запрашивать текущее состояние или состояние на дату.
+
+## Memory palace
+
+Memory palace — это агентская память поверх SQL + vector collections.
+
+```mermaid
+flowchart TD
+    Agent["AI Agent"] --> Context["set_context(collection)"]
+    Context --> Wake["wake_up"]
+    Agent --> Save["save_memory"]
+    Save --> Validate["validate hall + room"]
+    Validate --> SQL["SQL memories"]
+    Validate --> Embed["embed memory text"]
+    Embed --> Vector["memory vector collection"]
+    Agent --> Recall["recall_memory / list_memories"]
+    Recall --> SQL
+    Recall --> Vector
+    Recall --> Pins["pinned memories"]
+    Agent --> Diary["diary_write/read"]
+    Diary --> SQL
+```
+
+Модель `room × hall`:
+
+- `room`: о чем факт, например `auth`, `deploy`, `mcp`, `workspace`;
+- `hall`: тип факта из контролируемого словаря:
+  `fact`, `event`, `decision`, `preference`, `advice`, `discovery`.
+
+`pin_memory` используется для фактов, которые должны попадать в `wake_up`.
+
+Отдельно есть `diary_write`/`diary_read` для subagent-local памяти через
+`owner_id="agent:<name>"`.
+
+## Workspace subsystem
+
+Workspace — это markdown-native слой для работы агентов с проектными файлами.
+
+Код:
+
+- core manifest helpers: `pkg/workspace`;
+- REST/MCP handlers: `internal/http/workspace*.go`;
+- watcher: `workspace_watcher.go`;
+- durable jobs: `workspace_jobs.go`;
+- audit: `workspace_audit.go`;
+- context artifacts: `workspace_artifacts.go`.
+
+```mermaid
+flowchart TD
+    Files["Markdown files"] --> Manifest["workspace manifest"]
+    Files --> Index["workspace index"]
+    Index --> Chunker["chunker"]
+    Chunker --> VectorCollection["derived vector collection"]
+    Chunker --> BM25["BM25 index"]
+    Manifest --> ActiveGen["active generation"]
+    Watcher["workspace watcher"] --> Jobs["index jobs"]
+    Jobs --> Index
+    Client["REST/MCP client"] --> Context["workspace_context"]
+    Client --> Search["workspace_search"]
+    Search --> ActiveGen
+    Search --> VectorCollection
+    Search --> BM25
+    Client --> Read["workspace_read"]
+    Client --> Write["workspace_write"]
+    Write --> Files
+```
+
+Workspace дает агенту:
+
+- список доступных проектов/веток;
+- active generation и active collection;
+- поиск по workspace;
+- exact read после search hit;
+- write/reindex/reconcile;
+- job retry/dead-letter;
+- audit log без сохранения markdown snippets;
+- conflict detection между filesystem truth и indexed generation.
+
+## Auth, tenants, RBAC
+
+Auth слой:
+
+- JWT middleware;
+- API keys;
+- optional `RequireAuth`;
+- current user через `c.Locals("user_id")`;
+- `DBRef` wrapper для SQL DB, чтобы Fiber/fasthttp не закрыл connection pool
+  при recycling request context.
+
+Tenant/RBAC слой:
+
+- tenant selection через header/user context;
+- ACL grants;
+- dataset sharing;
+- `GetAllowedDatasetIDs` используется в search path;
+- permissions учитываются в workspace и dataset operations.
+
+С точки зрения безопасности, самый чувствительный путь — search + rerank:
+сначала нужно отфильтровать данные по ACL, и только затем отправлять кандидаты
+во внешний rerank service.
+
+## External connectors
+
+| Интеграция | Код | Протокол | Что делает |
+|---|---|---|---|
+| Cognee adapter | `cognee-plugin/levara_adapter` | Python gRPC | Реализует Cognee `VectorDBInterface` поверх Levara |
+| clawdbot plugin | `clawdbot/extensions/memory-levara` | Node REST | Store/recall/forget через `/api/v1/memories`, fallback outbox |
+| Embedding service | `pkg/embed` | HTTP | Batch/single embeddings |
+| LLM provider | `pkg/llm` | HTTP | OpenAI-compatible, Ollama/vLLM, Anthropic |
+| Reranker | `pkg/rerank`, `cmd/qwen3rerank` | HTTP | Cross-encoder reranking |
+| Neo4j | `pkg/graphdb` | Bolt | KG write/read/visualization |
+| SQL | `database/sql` | PostgreSQL/SQLite | metadata, memory, graph mirror, auth |
+| S3 storage | `pkg/storage` | HTTP SigV4 | raw uploads and object storage |
+| Prometheus | `internal/metrics` | scrape | metrics |
+| Langfuse | `pkg/observe` | HTTP | LLM tracing |
+
+## Web UI
+
+Расположение: `Levara/webui`.
+
+Stack:
+
+- Next.js 16;
+- React 19;
+- TypeScript;
+- React Query;
+- D3;
+- Tailwind;
+- Playwright e2e.
+
+API client: `Levara/webui/src/lib/api.ts`.
+
+Основные страницы:
+
+- login;
+- dashboard;
+- datasets;
+- dataset detail;
+- search;
+- chat;
+- graph;
+- memories;
+- collections;
+- analytics;
+- notebooks;
+- settings.
+
+Web UI не содержит основной domain logic. Он вызывает REST API и отображает
+состояние backend-а.
+
+## Пакеты и ответственность
+
+| Пакет | Ответственность |
+|---|---|
+| `cmd/server` | Bootstrap, wiring, route registration, graceful shutdown |
+| `cmd/cli` | HTTP CLI |
+| `cmd/backup` | Backup tooling |
+| `cmd/reconcile` | Workspace/server reconcile tooling |
+| `cmd/qwen3rerank` | Rerank sidecar |
+| `internal/store` | HNSW, Arena, WAL, DiskStore, CollectionManager, Cluster |
+| `internal/cluster` | DirectNode, RaftNode, FSM, replication |
+| `internal/grpc` | gRPC v1/v2 services, interceptors, metrics |
+| `internal/http` | REST API, MCP transport, auth, sync, workspace, UI API |
+| `internal/metrics` | Prometheus metrics |
+| `pipeline` | In-process search pipeline and rerank application |
+| `pkg/mcp` | MCP descriptors and transport-independent tool logic |
+| `pkg/orchestrator` | Cognify pipeline |
+| `pkg/embed` | Embedding client/cache |
+| `pkg/llm` | LLM provider abstraction |
+| `pkg/llmcache` | LLM response cache |
+| `pkg/rerank` | Rerank client |
+| `pkg/chunker` | Chunking strategies |
+| `pkg/extract` | Text/code/audio extraction |
+| `pkg/ingest` | Data ingest metadata and hashing |
+| `pkg/bm25` | Lexical indexing/search |
+| `pkg/graph` | Graph primitives, triplets, dedup |
+| `pkg/graphdb` | Neo4j writer |
+| `pkg/graphstore` | SQL graph store |
+| `pkg/graphrank` | Graph ranking |
+| `pkg/community` | Louvain communities |
+| `pkg/temporal` | Temporal extraction/search |
+| `pkg/router` | Search intent routing/adaptive weights |
+| `pkg/workspace` | Workspace manifests and indexing primitives |
+| `pkg/storage` | Local/S3 storage |
+| `pkg/auth` | JWT helpers |
+| `pkg/observe` | Logger, Langfuse, error tracker |
+| `pkg/backup` | Backup helpers |
+| `pkg/vectorstore` | Vector store helper abstraction |
+| `pkg/fileio` | Hash and file walking |
+| `pkg/fetch` | URL fetching |
+| `pkg/audio` | Whisper-compatible transcription |
+| `pkg/ontology` | Ontology parsing |
+| `pkg/runreg` | Background run registry |
+| `pkg/agenthosts` | Agent host installation helpers |
+
+## Основные связи и зависимости
+
+```mermaid
+flowchart TD
+    Main["cmd/server"] --> HTTP["internal/http"]
+    Main --> GRPC["internal/grpc"]
+    Main --> Store["internal/store"]
+    Main --> Cluster["internal/cluster"]
+    Main --> Embed["pkg/embed"]
+    Main --> LLM["pkg/llm"]
+    Main --> Cache["pkg/llmcache"]
+    Main --> Storage["pkg/storage"]
+    Main --> Observe["pkg/observe"]
+
+    HTTP --> MCP["pkg/mcp"]
+    HTTP --> Orchestrator["pkg/orchestrator"]
+    HTTP --> Pipeline["pipeline"]
+    HTTP --> Workspace["pkg/workspace"]
+    HTTP --> GraphDB["pkg/graphdb"]
+    HTTP --> GraphRank["pkg/graphrank"]
+    HTTP --> Community["pkg/community"]
+    HTTP --> Router["pkg/router"]
+    HTTP --> Rerank["pkg/rerank"]
+
+    GRPC --> Orchestrator
+    GRPC --> Pipeline
+    GRPC --> GraphDB
+    GRPC --> BM25["pkg/bm25"]
+    GRPC --> Graph["pkg/graph"]
+
+    Orchestrator --> Chunker["pkg/chunker"]
+    Orchestrator --> Embed
+    Orchestrator --> LLM
+    Orchestrator --> Store
+    Orchestrator --> GraphDB
+    Orchestrator --> BM25
+    Orchestrator --> Temporal["pkg/temporal"]
+
+    Pipeline --> Store
+    Pipeline --> Embed
+    Pipeline --> Rerank
+```
+
+## Deployment modes
+
+Из кода и compose-файлов видны несколько режимов:
+
+1. **Standalone local/dev**
+   - один процесс;
+   - local data dir;
+   - optional SQLite;
+   - HTTP + gRPC + MCP.
+
+2. **Full stack**
+   - Levara;
+   - PostgreSQL;
+   - Neo4j;
+   - embed server;
+   - LLM/Ollama;
+   - Prometheus;
+   - optional rerank.
+
+3. **Raspberry Pi**
+   - SQLite-friendly path;
+   - local storage;
+   - отдельные scripts и compose под Pi.
+
+4. **Primary/replica**
+   - `/cluster/wal/stream`;
+   - `/cluster/snapshot`;
+   - replica client pulls WAL/snapshot.
+
+5. **Raft mode**
+   - Hashicorp Raft per shard;
+   - FSM snapshot/restore;
+   - legacy shard path.
+
+6. **S3/object storage**
+   - `STORAGE_BACKEND=s3`;
+   - uploads mirrored to S3-compatible backend;
+   - SQL metadata stores `storage://` locations.
+
+## Оценка зрелости компонентов
+
+Шкала зрелости:
+
+| Уровень | Название | Значение |
+|---|---|---|
+| 1 | Прототип | Есть базовая реализация, но API/поведение еще легко меняются |
+| 2 | Рабочий MVP | Основные сценарии работают, но мало изоляции, тестов или эксплуатационных гарантий |
+| 3 | Production candidate | Есть тесты, понятные контракты, обработка ошибок, но остаются архитектурные риски |
+| 4 | Production ready | Компонент покрыт тестами, имеет устойчивые контракты, observability и понятные failure modes |
+| 5 | Mature / hardened | Компонент стабилен, хорошо изолирован, имеет нагрузочные/chaos/e2e проверки и низкий coupling |
+
+Оценка ниже не равна качеству кода в целом. Это оценка инженерной зрелости:
+насколько компонент стабилен как самостоятельный production-блок, насколько
+понятны его контракты, насколько он покрыт тестами и насколько легко безопасно
+менять его без каскадных эффектов.
+
+### Сводная таблица
+
+| Компонент | Зрелость | Оценка | Почему |
+|---|---:|---|---|
+| Storage engine: HNSW/Arena/WAL/DiskStore | 4/5 | Production ready | Есть отдельные unit/concurrency/recovery tests, понятная внутренняя модель, WAL и pending-indexing закрывают durability/freshness. До 5 не хватает более формализованных benchmark/chaos гарантий как обязательного CI-контракта. |
+| CollectionManager | 3.5/5 | Production candidate+ | Основной современный путь, есть metadata и dimension handling. Зрелость снижает сосуществование с legacy `Cluster` path и риск misrouting без `collection`. |
+| Legacy Cluster / shard router | 3/5 | Production candidate | Работает и тестируется, но это compatibility layer. Новая функциональность живет в collection-aware path, поэтому стратегически компонент менее зрелый как целевой API. |
+| Raft mode | 2.5/5 | Рабочий MVP+ | Есть FSM/snapshot tests, но по архитектуре это отдельный HA-путь, не основной для collection manager. Требует отдельной deployment-матрицы и e2e multi-node проверок. |
+| Primary/replica WAL streaming | 3/5 | Production candidate | Есть replication и chaos tests. Но это еще один HA-механизм рядом с Raft, поэтому зрелость ограничена неоднозначностью operational модели. |
+| gRPC API v1 | 4/5 | Production ready | Широкий контракт, service/contract/rate/auth tests, используется Cognee adapter. Риск: очень широкий service.go, много функций в одном сервисе. |
+| gRPC v2 wrapper | 3/5 | Production candidate | Простая обертка над v1, поэтому надежность наследуется от v1. Но собственная продуктовая роль v2 пока узкая. |
+| REST API core | 3/5 | Production candidate | Много endpoint-ов, широкие тесты, auth/rate/metrics. Зрелость снижает большой `internal/http`, сильный coupling через `APIConfig`, множество optional режимов. |
+| Legacy vector HTTP endpoints | 3/5 | Production candidate | Простые и стабильные, но это compatibility path. Новые сценарии должны идти через collections/search API. |
+| MCP transport `/mcp` | 3.5/5 | Production candidate+ | Хорошая граница через `pkg/mcp.Deps`, много tool tests, session lifecycle. Риск: tool surface очень быстро выросла и зависит от широкого набора backend capability. |
+| MCP memory palace | 4/5 | Production ready | Четкая room×hall модель, hall validation, save/recall/list/pin/wake tools, тесты. До 5 не хватает эксплуатационной политики cleanup/noise для pinned memories на уровне продукта. |
+| MCP workspace tools | 3.5/5 | Production candidate+ | Богатая функциональность, audit/access/job tests. Зрелость снижает сложность сценариев и часть business logic в HTTP package. |
+| Cognify orchestrator | 3/5 | Production candidate | Pipeline продвинутый: chunking, LLM extraction, graph, BM25, progress. Но много внешних зависимостей, много режимов, и failure modes зависят от LLM/embed/Neo4j/SQL. |
+| RAG-only ingest path | 3.5/5 | Production candidate+ | Проще полного KG path: chunk + embed + vector/BM25. Меньше внешних зависимостей, поэтому зрелее полного cognify. |
+| Search pipeline | 3.5/5 | Production candidate+ | Есть in-process search, rerank application, multi-query/dedup tests. Риск: много search modes и сложная комбинация ACL, rerank, graph, lexical, temporal. |
+| BM25 lexical index | 4/5 | Production ready | Небольшой изолированный пакет, есть persist/index tests, понятный контракт. |
+| Hybrid search / fusion | 3/5 | Production candidate | Рабочий слой поверх vector+BM25, но качество зависит от весов, router и feedback. Нужны стабильные eval-наборы. |
+| Rerank client/sidecar | 3.5/5 | Production candidate+ | Есть budget/concurrency/default tests, Cohere-compatible contract, Qwen adapter. Риск: внешний сервис и обязательное соблюдение ACL-before-rerank. |
+| Search router / adaptive weights | 3/5 | Production candidate | Есть intent/adaptive tests. Для зрелости 4 нужны измеримые offline evals и контроль регрессий маршрутизации. |
+| SQL schema/migration layer | 3/5 | Production candidate | Поддерживает PostgreSQL и SQLite, много таблиц и compatibility logic. Риск: один общий schema stream для многих подсистем и высокая цена migration ошибок. |
+| Auth/JWT/API keys | 3.5/5 | Production candidate+ | Есть тесты JWT/auth/API key flow, rate limiting. До 4 нужно больше security review/e2e вокруг tenant/API-key permissions. |
+| Tenants/RBAC | 3/5 | Production candidate | Есть dataset sharing и RBAC search tests. Риск: dev-mode nil filtering, legacy/global rows, много мест, где фильтр должен применяться вручную. |
+| Graph core (`pkg/graph`) | 3.5/5 | Production candidate+ | Triplets, dedup, LSH, semantic dedup, multi-query покрыты тестами. Зрелость снижает сложность интеграции с SQL/Neo4j/LLM extraction. |
+| Neo4j writer (`pkg/graphdb`) | 3.5/5 | Production candidate+ | Есть cache/path/neo4j tests и schema bootstrap. Зависит от внешнего Neo4j и требует operational checks. |
+| SQL graph mirror / temporal graph | 3/5 | Production candidate | Temporal validity модель продумана, есть query/path tests. Риск: graph truth распределен между SQL и Neo4j. |
+| Community detection | 3.5/5 | Production candidate+ | Louvain и race tests есть. Но как продуктовая функция зависит от качества graph extraction. |
+| Temporal extraction/search | 3.5/5 | Production candidate+ | Изолированный пакет с тестами. Интеграционная зрелость ниже, потому что temporal semantics зависят от graph upsert и query layer. |
+| Workspace core (`pkg/workspace`) | 3.5/5 | Production candidate+ | Manifest/indexer/gc tests, понятная модель generation/collection. |
+| Workspace HTTP/MCP lifecycle | 3/5 | Production candidate | Очень функциональный слой: access, audit, jobs, watcher, read/write/reconcile. Зрелость снижает высокая сложность и большое количество сценариев. |
+| Workspace watcher/index worker | 2.5/5 | Рабочий MVP+ | Есть реализация и статусные endpoint-ы, но background watchers требуют больше soak/e2e/operational тестов. |
+| Sync | 3/5 | Production candidate | Есть memory/graph sync tests и MCP sync tool. Риск: collection sync с re-embedding, dimension differences и partial failures. |
+| Storage backend local/S3 | 3.5/5 | Production candidate+ | Есть local/S3 mock tests, простой интерфейс. До 4 нужно больше проверок больших файлов, retries и credential failure modes. |
+| Ingest/file metadata | 3/5 | Production candidate | Есть ingest tests и SQL writer. Зависит от storage, extract, classify, DB availability. |
+| Extract/chunker/classify | 4/5 | Production ready | Хорошо изолированные пакеты, много chunker tests, code/text extraction tests. |
+| Embedding client/cache | 3.5/5 | Production candidate+ | Есть client/cache tests, shared client снижает latency. Зависит от внешнего embedding endpoint и dimension consistency. |
+| LLM provider/structured output | 3/5 | Production candidate | Есть provider abstraction, tracing/rate/structured tests. Риск: разные OpenAI-compatible провайдеры, schema support и долгие timeouts. |
+| LLM cache / proxy | 3.5/5 | Production candidate+ | Есть persistent cache tests и proxy contract tests. |
+| Observability/metrics | 3.5/5 | Production candidate+ | Prometheus middleware, user bucket, error tracker, doctor tools. До 4 нужно формализовать SLO/alert rules. |
+| Backup tooling | 3/5 | Production candidate | Есть backup tests, но восстановление и multi-backend сценарии нужно проверять end-to-end. |
+| Web UI | 3/5 | Production candidate | Есть Next.js app и Playwright e2e набор. UI является consumer API, зрелость зависит от стабильности REST contracts. |
+| Cognee adapter | 3.5/5 | Production candidate+ | Узкий и понятный gRPC adapter, соответствует VectorDBInterface. Нужны contract/e2e tests против live Levara в CI. |
+| clawdbot plugin | 3/5 | Production candidate | Простая REST-интеграция с outbox fallback. Зрелость ограничена тем, что search/recall фильтрация в основном клиентская. |
+| Agent hosts tooling | 2.5/5 | Рабочий MVP+ | Есть install helpers и tests, но это вспомогательный tooling, не core runtime. |
+| CLI/scripts/deploy | 2.5/5 | Рабочий MVP+ | Полезны для эксплуатации, но зрелость ниже core: больше shell/env coupling, меньше contract tests. |
+
+### Зрелость по слоям
+
+```mermaid
+flowchart TD
+    Mature["Наиболее зрелые: storage engine, BM25, chunker/extract, memory palace"]
+    Candidate["Production candidate: REST, gRPC, MCP, search, graph, workspace core, auth"]
+    MVP["MVP+/нужно укреплять: Raft mode, workspace watcher, CLI/deploy tooling, agent hosts"]
+
+    Mature --> Candidate
+    Candidate --> MVP
+```
+
+### Главные выводы по зрелости
+
+1. **Самое зрелое ядро — storage и локальные алгоритмические пакеты.**
+
+   `internal/store`, `pkg/bm25`, `pkg/chunker`, `pkg/extract`, `pkg/temporal`
+   выглядят наиболее изолированными и тестируемыми. Они ближе всего к уровню
+   production-ready.
+
+2. **MCP memory palace архитектурно удачен.**
+
+   У него есть понятная модель `room × hall`, валидация hall vocabulary,
+   отдельные инструменты recall/pin/wake_up и хорошая тестируемость через
+   `pkg/mcp.Deps`.
+
+3. **REST и MCP функционально богаты, но слишком связаны с composition root.**
+
+   Их зрелость снижает не отсутствие функций, а ширина зависимостей:
+   SQL, collections, embeddings, LLM, BM25, rerank, workspace, graph, sync.
+
+4. **Search зрелый как набор возможностей, но требует eval-дисциплины.**
+
+   Vector, BM25, hybrid, graph, temporal, rerank, multi-query — это сильный
+   набор. Но для уровня 4/5 нужны регулярные retrieval evals, golden queries и
+   regression tracking.
+
+5. **Graph/KG слой мощный, но интеграционно сложный.**
+
+   Graph extraction зависит от LLM, graph write зависит от SQL/Neo4j, graph
+   search зависит от качества extracted edges. Поэтому отдельные пакеты зрелее,
+   чем end-to-end KG продукт.
+
+6. **Workspace — перспективный, но сложный продуктовый слой.**
+
+   Manifest/generation модель хорошая, есть audit и jobs. Но watcher,
+   reconcile, exact read/write, conflicts и MCP tools образуют большую матрицу
+   сценариев; ей нужны soak/e2e тесты.
+
+7. **HA/replication модель требует прояснения.**
+
+   В коде одновременно есть Raft shards и primary/replica WAL streaming.
+   Оба механизма полезны, но для maturity 4 нужно явно определить, какой режим
+   является canonical для production.
+
+### Что нужно сделать, чтобы поднять зрелость
+
+| Цель | Компоненты | Что сделать |
+|---|---|---|
+| 3 -> 4 | REST, MCP, Search | Зафиксировать API contracts, добавить route/tool drift tests, golden response tests |
+| 3 -> 4 | Search/router/rerank | Добавить offline retrieval evals, regression suite, ACL-before-rerank invariant tests |
+| 3 -> 4 | SQL schema | Сгенерировать schema inventory, добавить migration compatibility tests PostgreSQL + SQLite |
+| 3 -> 4 | Graph/KG | Ввести graph extraction evals, consistency checks SQL vs Neo4j, temporal edge invariants |
+| 2.5 -> 3.5 | Raft/replication | Описать canonical HA modes, добавить multi-node e2e и recovery playbooks |
+| 2.5 -> 3.5 | Workspace watcher | Добавить soak tests, crash/restart job recovery, filesystem race tests |
+| 3 -> 4 | Web UI | Зафиксировать OpenAPI/typed client contract, расширить e2e на auth/RBAC/search/workspace |
+| 3 -> 4 | Deploy scripts | Превратить critical scripts в проверяемые commands с dry-run и smoke checks |
+
+## Архитектурные риски
+
+1. **Большой composition root**
+
+   `cmd/server/main.go` отвечает за слишком много подсистем. Это удобно для
+   одного binary, но усложняет изменения: auth, storage, graph, MCP, workspace,
+   LLM и gRPC связаны в одном startup flow.
+
+2. **Два vector path**
+
+   `CollectionManager` и legacy `Cluster` сосуществуют. Если request без
+   `collection`, он может пойти не туда, куда ожидает новый код.
+
+3. **Очень широкий `internal/http`**
+
+   В одном пакете находятся REST API, MCP adapter, workspace, auth, sync,
+   datasets, graph, search, notebooks. Логические границы есть по файлам, но
+   package-level граница слабая.
+
+4. **SQL DB как общий substrate**
+
+   SQL содержит почти все metadata-состояние. Любые проблемы migration/schema
+   могут затронуть сразу память, graph, auth, UI, workspace и sync.
+
+5. **Optional external dependencies**
+
+   Embed, LLM, Neo4j, rerank, S3 могут быть выключены. Код должен аккуратно
+   обрабатывать nil/degraded mode.
+
+6. **RBAC and external rerank**
+
+   Внешний rerank получает тексты кандидатов. Поэтому ACL-filter до rerank —
+   обязательное условие безопасности.
+
+7. **Несколько HA/replication идей**
+
+   В коде есть Raft shards, WAL primary/replica streaming и collection manager.
+   Это разные уровни отказоустойчивости, и их границы стоит явно документировать.
+
+## Рекомендуемые следующие шаги
+
+1. Разделить bootstrap на модули:
+   `initStorage`, `initSQL`, `initVector`, `initLLM`, `initREST`, `initMCP`,
+   `initWorkspace`, `initGRPC`.
+
+2. Зафиксировать canonical APIs:
+   - collection-aware path как основной;
+   - legacy vector endpoints как compatibility layer.
+
+3. Разбить `pkg/mcp.Deps` на capability-интерфейсы:
+   memory, search, workspace, sync, observability.
+
+4. Сгенерировать отдельную schema inventory из migrations.
+
+5. Выделить workspace business logic глубже в `pkg/workspace`, оставив в
+   `internal/http` только parsing/response.
+
+6. Добавить архитектурные тесты на route/tool drift:
+   REST endpoints, MCP tool descriptors, gRPC proto должны расходиться только
+   осознанно.
+
+7. Составить отдельную deployment матрицу:
+   standalone, full-stack, Pi, primary/replica, Raft, S3 mode.
+
+## Статус реализации рекомендаций
+
+Обновлено: 2026-05-17.
+
+| Рекомендация | Статус | Что сделано |
+|---|---|---|
+| Разделить bootstrap | Частично реализовано | В `cmd/server/bootstrap.go` вынесены `initStorageBackend`, `initSQLRuntime`, `initVectorRuntime`, `initHTTPRuntime`, уже существующие `initLLMProvider`, `startGRPCServer`, LLM proxy, health details и shutdown helpers. `main.go` стал ближе к sequencing scaffold. |
+| Зафиксировать canonical APIs | Реализовано как contract inventory | Добавлен `internal/http/routes.go` с `RESTRouteInventory()` и статусами `canonical`, `legacy_compat`, `alias`, `ops`. Legacy vector endpoints явно отмечены как compatibility layer. |
+| Разбить `pkg/mcp.Deps` | Реализовано без изменения поведения | `Deps` разложен на capability-интерфейсы: `SQLDeps`, `CollectionDeps`, `StorageDeps`, `EmbedDeps`, `PipelineDeps`, `SearchDeps`, `SyncDeps`, `ObservabilityDeps`. |
+| Schema inventory | Реализовано | Добавлен `internal/http/schema_inventory.go`, который строит inventory из migration statements, и документ `docs/schema-inventory.md`. |
+| Workspace logic глубже в `pkg/workspace` | Начато | Вынесены runtime path defaults, safe workspace IDs, manifest/project paths, local project/branch discovery в `pkg/workspace`. Большие workflow-сценарии audit/jobs/watcher/reconcile остаются в `internal/http` и требуют отдельных итераций. |
+| Route/tool/proto drift tests | Реализовано для базового контракта | Добавлены architecture contract tests для REST inventory, schema inventory, MCP descriptors и gRPC proto descriptor. |
+| Deployment matrix | Реализовано | Добавлен `docs/deployment-matrix.md` с режимами standalone, full-stack, Pi, primary/replica, Raft, S3. |
+
+Оставшиеся крупные итерации:
+
+- вынести workspace jobs/audit/conflicts/reconcile business logic из
+  `internal/http` в `pkg/workspace`;
+- разбить `APIConfig` на capability-конфиги для REST modules;
+- добавить generated/public REST inventory documentation из `RESTRouteInventory`;
+- формализовать canonical HA mode: primary/replica vs Raft;
+- добавить eval/regression contracts для search/router/rerank.

--- a/docs/codebase-component-analysis.md
+++ b/docs/codebase-component-analysis.md
@@ -1,0 +1,569 @@
+# Levara Codebase Component Analysis
+
+Дата анализа: 2026-05-16.
+
+Область: текущая кодовая база в `Levara/`, внешние адаптеры в `cognee-plugin/`,
+расширение `clawdbot/`, Web UI в `Levara/webui/`. `Levara-legacy/` рассматривается
+как историческая реализация и не включается в основную архитектуру.
+
+## Executive Summary
+
+Levara сейчас не только векторная БД. Это сервер памяти для AI-агентов с четырьмя
+основными поверхностями:
+
+- **gRPC v1/v2** для низколатентных операций: коллекции, vector search, chunking,
+  batch embed/index, graph read/write, BM25/hybrid, pipeline cognify.
+- **REST API `/api/v1`** для UI и интеграций: datasets, upload, cognify, search,
+  memories, tenants/RBAC, sync, workspace, feedback, notebooks, auth.
+- **MCP Streamable HTTP `/mcp`** для агентских клиентов: `cognify`, `search`,
+  memory palace, graph query, workspace tools, sync, doctor, telemetry.
+- **Web UI** на Next.js: dashboard, datasets, search/chat, graph, memories,
+  collections, notebooks, settings.
+
+Внутри сервер собирает несколько независимых подсистем: HNSW+WAL storage engine,
+collection manager, SQL metadata store, Neo4j graph writer/reader, BM25 indexes,
+LLM provider/cache, embedding client, reranker, workspace markdown indexer,
+sync/import-export, observability.
+
+## High-Level System Map
+
+```mermaid
+flowchart LR
+    subgraph Clients
+        WebUI["Next.js Web UI"]
+        Cognee["Cognee VectorDBInterface"]
+        Agents["AI agents / MCP clients"]
+        Clawdbot["clawdbot memory plugin"]
+        CLI["CLI / scripts / tests"]
+    end
+
+    subgraph Server["Levara Go server cmd/server"]
+        Fiber["Fiber HTTP server"]
+        GRPC["gRPC server v1/v2"]
+        MCP["MCP JSON-RPC handler"]
+        LegacyHTTP["Legacy vector HTTP handler"]
+        API["REST API modules"]
+    end
+
+    subgraph Core["Core services"]
+        Collections["CollectionManager"]
+        Cluster["Shard Cluster"]
+        Store["Levara store: HNSW + Arena + DiskStore + WAL"]
+        Pipeline["Cognify orchestrator"]
+        SearchPipe["Search pipeline"]
+        BM25["BM25 indexes"]
+        Workspace["Workspace indexer"]
+        RunReg["Run registry + SSE"]
+    end
+
+    subgraph External["External dependencies"]
+        SQL["PostgreSQL or SQLite"]
+        Neo4j["Neo4j"]
+        Embed["Embedding server / OpenAI-compatible embeddings"]
+        LLM["OpenAI-compatible / Anthropic / Ollama LLM"]
+        Rerank["Qwen3/rerank sidecar"]
+        S3["Local FS or S3-compatible storage"]
+        Prom["Prometheus"]
+    end
+
+    WebUI --> Fiber
+    Clawdbot --> Fiber
+    CLI --> Fiber
+    Cognee --> GRPC
+    Agents --> MCP
+    Fiber --> API
+    Fiber --> LegacyHTTP
+    Fiber --> MCP
+    GRPC --> Collections
+    API --> Collections
+    MCP --> Collections
+    LegacyHTTP --> Cluster
+    Collections --> Store
+    Cluster --> Store
+    API --> Pipeline
+    MCP --> Pipeline
+    Pipeline --> Collections
+    Pipeline --> BM25
+    Pipeline --> SQL
+    Pipeline --> Neo4j
+    Pipeline --> Embed
+    Pipeline --> LLM
+    SearchPipe --> Collections
+    SearchPipe --> Embed
+    SearchPipe --> Rerank
+    API --> Workspace
+    MCP --> Workspace
+    API --> SQL
+    MCP --> SQL
+    API --> S3
+    Fiber --> Prom
+```
+
+## Runtime Bootstrap
+
+Entry point: `Levara/cmd/server/main.go`.
+
+Startup sequence:
+
+1. Parse flags: dimensions, ports, shard count, data dir, HNSW params, auth,
+   Neo4j, Raft/replica mode, LLM proxy.
+2. Initialize structured logger, error tracker, storage backend.
+3. Create HNSW config and shard handlers.
+4. Build `store.Cluster` over shards.
+5. Optionally initialize primary/replica WAL streaming.
+6. Create Fiber app, CORS, logging, `/metrics`, `/health`, `/version`, Swagger.
+7. Create `CollectionManager`; wire it into legacy vector handler.
+8. Open SQL DB: SQLite via `DB_PROVIDER=sqlite`, otherwise PostgreSQL if
+   `DB_HOST` is set; run idempotent schema migration.
+9. Register public endpoints: info, health, version, auth.
+10. Install JWT/API-key middleware, per-user rate limiting, Prometheus
+    instrumentation, tenant middleware.
+11. Register protected legacy vector endpoints: insert, batch_insert, search,
+    delete.
+12. Create gRPC service and share its BM25 map with REST/MCP.
+13. Initialize LLM cache, LLM provider, adaptive router, run registry,
+    shared embedding client, rerank config.
+14. Register REST API modules and MCP endpoint.
+15. Optionally start workspace watcher/index worker.
+16. Start gRPC server and Fiber HTTP server; install graceful shutdown.
+
+## Transport Surfaces
+
+### gRPC
+
+Implementation: `Levara/internal/grpc/service.go`, `service_v2.go`.
+
+Primary roles:
+
+- Native collection lifecycle.
+- Record insert/batch/delete/search/get.
+- Server-side text chunking.
+- File hash/list acceleration.
+- Triplet processing and graph dedup.
+- Batch embed + vector indexing.
+- Neo4j batch graph writes.
+- Search by text, batch text search, hybrid search.
+- Graph read and graph completion search.
+- Streaming `PipelineCognify`.
+- LLM cache operations.
+- BM25 index/search.
+- Semantic dedup, multi-query search, ingest, extract text, temporal search.
+
+v2 is a compatibility wrapper around v1 with aliased write names (`Add`,
+`Save`, `Create`) and a smaller surface.
+
+### REST `/api/v1`
+
+Implementation registry: `Levara/internal/http/api.go`.
+
+Functional groups:
+
+| Group | Endpoints | Purpose |
+|---|---|---|
+| Auth/API keys | `/auth/login`, `/auth/register`, `/auth/me`, `/auth/keys` | JWT and API-key auth |
+| Vector legacy | `/insert`, `/batch_insert`, `/search`, `/delete` | Direct vector ops |
+| Datasets/data | `/datasets`, `/datasets/:id/data`, raw download URLs | Dataset metadata and data records |
+| Upload/OCR | `/add`, `/ocr` | File/text ingestion and extraction |
+| Cognify | `/cognify`, status, SSE stream | Background RAG/KG pipeline |
+| Memify | `/memify`, status, SSE stream | Post-cognify graph enrichment |
+| Search | `/search/text`, `/search`, `/search/dual` | Unified semantic/lexical/graph search |
+| Collections | `/collections`, `/collections/:name/meta` | Collection metadata and lifecycle |
+| Reembed | `/reembed`, status | Collection re-embedding migration |
+| Memory | `/memories`, `/memories/:key`, stream | Project/user memory store |
+| Sync | `/sync/export/*`, `/sync/import/*`, manifest | Cross-instance sync |
+| Workspace | `/workspace/*` | Markdown workspace lifecycle |
+| Feedback | `/feedback`, `/feedback/stats` | Search feedback and adaptive weights |
+| Tenant/RBAC | `/tenants`, `/acl`, `/datasets/:id/shares` | Multi-user isolation |
+| Graph | `/datasets/:id/graph`, `/graph/path`, `/visualize` | SQL/Neo4j graph reads and UI |
+| Notebooks/settings/users | `/notebooks`, `/settings`, `/users/*` | UI product features |
+| Ops | `/errors`, `/cache/stats`, `/heartbeats`, `/health/details` | Diagnostics |
+
+### MCP `/mcp`
+
+Implementation: `Levara/internal/http/mcp.go` plus tool bodies in
+`Levara/pkg/mcp/tool_*.go` and HTTP-specific forwarders.
+
+MCP exposes Levara as an agent memory substrate. The dependency boundary is
+`pkg/mcp.Deps`; HTTP implements that boundary over `APIConfig`, which keeps
+tool logic unit-testable and avoids importing Fiber into `pkg/mcp`.
+
+Important tool families:
+
+- Knowledge ingestion/search: `cognify`, `cognify_status`, `search`,
+  `cross_search`, `codify`.
+- Data management: `add`, `list_data`, `delete`, `prune`.
+- Memory palace: `save_memory`, `recall_memory`, `list_memories`,
+  `pin_memory`, `unpin_memory`, `wake_up`.
+- Knowledge graph: `query_entity`, `list_communities`, `check_drift`,
+  `prune_graph`.
+- Chat history: `save_chat`, `recall_chat`, `search_chats`.
+- Workspace: context, access check, audit log, search, read/write, index,
+  reindex, reconcile, jobs, watcher, commits, revert, GC.
+- Sync/ops: `sync`, `doctor`, `heartbeat`, runtime stats, ingestion status,
+  recent errors, sync status.
+
+## Storage Engine
+
+Core package: `Levara/internal/store`.
+
+```mermaid
+flowchart TD
+    CM["CollectionManager"] --> DB1["Levara DB per collection"]
+    Cluster["Cluster shard router"] --> DB2["Levara DB per shard"]
+
+    subgraph DB["Levara DB"]
+        APIWrite["Insert / BatchInsert / Delete"]
+        APISearch["Search / Get / AllRecords"]
+        Arena["VectorArena: normalized float32 storage"]
+        HNSW["HNSWIndex: approximate kNN graph"]
+        Disk["DiskStore: append-only metadata"]
+        WAL["WAL: binary op log + group flush"]
+        Pending["pendingVecs: inserted but not indexed"]
+        Indexer["background indexerLoop"]
+    end
+
+    APIWrite --> Arena
+    APIWrite --> Disk
+    APIWrite --> WAL
+    APIWrite --> Pending
+    Pending --> Indexer
+    Indexer --> HNSW
+    APISearch --> HNSW
+    APISearch --> Pending
+    APISearch --> Disk
+```
+
+Key properties:
+
+- Vectors are normalized and stored in `VectorArena`.
+- Metadata is append-only in `DiskStore`.
+- WAL records mutations; group commit reduces fsync pressure.
+- HNSW indexing is asynchronous. Pending vectors are brute-force scanned during
+  search so fresh writes remain visible before indexing catches up.
+- Deletes mark tombstones in HNSW and are WAL-backed.
+- `CollectionManager` owns independent DB stacks per collection; `Cluster`
+  routes legacy shard operations by ID hash.
+
+## Write Path
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Handler as HTTP/gRPC/MCP handler
+    participant CM as CollectionManager/Cluster
+    participant DB as Levara DB
+    participant Arena
+    participant Disk
+    participant WAL
+    participant Indexer as Async indexer
+    participant HNSW
+
+    Client->>Handler: insert / batch_insert
+    Handler->>CM: route by collection or shard
+    CM->>DB: Insert/BatchInsert
+    DB->>DB: marshal metadata outside critical path where possible
+    DB->>Arena: append vector
+    DB->>Disk: append metadata
+    DB->>WAL: write entry, async flush signal
+    DB->>Indexer: enqueue pending vector
+    Handler-->>Client: success/partial errors
+    Indexer->>HNSW: add graph node in background
+```
+
+## Search Path
+
+```mermaid
+flowchart TD
+    Query["Query text or vector"] --> IsText{"text?"}
+    IsText -- yes --> Embed["embed.Client -> embedding endpoint"]
+    IsText -- no --> Vector["query vector"]
+    Embed --> Vector
+    Vector --> SearchMode{"Search mode"}
+    SearchMode -->|vector| HNSW["CollectionManager.Search"]
+    SearchMode -->|lexical| BM25["BM25 index"]
+    SearchMode -->|hybrid| Fusion["RRF / weighted fusion"]
+    SearchMode -->|graph| Graph["SQL/Neo4j graph traversal"]
+    HNSW --> Fusion
+    BM25 --> Fusion
+    Graph --> Fusion
+    Fusion --> ACL["RBAC dataset filter"]
+    ACL --> Rerank{"rerank enabled?"}
+    Rerank -- yes --> Cross["rerank.Client sidecar"]
+    Rerank -- no --> Results["results"]
+    Cross --> Results
+```
+
+Search entry points exist in REST (`api_search.go`), MCP (`tool_search.go`) and
+gRPC (`SearchByText`, `HybridSearch`, `GraphCompletionSearch`,
+`MultiQuerySearch`). The shared in-process path is `Levara/pipeline`.
+
+## Cognify / Ingestion Pipeline
+
+Core package: `Levara/pkg/orchestrator`.
+
+```mermaid
+flowchart TD
+    Input["Uploaded text/files or MCP data"] --> Extract["extract/classify/chunk"]
+    Extract --> Mode{"mode"}
+    Mode -->|rag / SkipGraph| EmbedChunks["embed chunks"]
+    Mode -->|full| LLMExtract["LLM entity + edge extraction"]
+    LLMExtract --> Dedup["graph semantic/name dedup"]
+    Dedup --> Temporal["temporal extraction / validity"]
+    Temporal --> GraphWrite["Neo4j + SQL graph upsert"]
+    GraphWrite --> Community["community detection summaries"]
+    LLMExtract --> EmbedChunks
+    EmbedChunks --> VectorWrite["CollectionManager.BatchInsert"]
+    EmbedChunks --> LexicalWrite["BM25 index update"]
+    VectorWrite --> Status["runreg status + pipeline_status"]
+    LexicalWrite --> Status
+    GraphWrite --> Status
+```
+
+The pipeline supports:
+
+- chunk strategies: merged, paragraph, sentence, row, code, sliding, auto;
+- parent/child chunking for precision/context split;
+- document title/ID metadata;
+- room/tags propagation for filtered recall;
+- RAG-only mode without LLM/graph;
+- structured LLM output when available;
+- BM25 side-index update;
+- SQL and Neo4j graph persistence;
+- progress streaming through `runreg` and SSE/MCP status.
+
+## SQL Metadata Schema
+
+Migration: `Levara/internal/http/schema.go`.
+
+Main tables:
+
+- Auth and principals: `principals`, `users`, `api_keys`.
+- Dataset/data catalog: `datasets`, `data`, `dataset_data`.
+- Graph mirror: `graph_nodes`, `graph_edges` with `valid_from`,
+  `valid_until`, `superseded_by`, confidence and dataset scoping.
+- Multi-tenant/RBAC: `tenants`, `user_tenant`, `roles`, `user_role`, `acl`,
+  `dataset_shares`.
+- Product/UI: `notebooks`, `notebook_cells`, `user_settings`,
+  `interactions`, `feedback`.
+- Memory palace: `memories`, memory pins and chat/history related tables
+  defined later in the schema file.
+- Sync/ops/workspace support tables as added by later migration statements.
+
+The code supports PostgreSQL and SQLite through `sqlcompat.go` and query
+placeholder rewriting.
+
+## Knowledge Graph
+
+Graph functionality is split across:
+
+- `pkg/graph`: in-memory graph primitives, triplets, dedup, LSH, multi-query.
+- `pkg/graphdb`: Neo4j writer/cached writer and schema bootstrap.
+- `pkg/graphstore`: SQL graph store abstraction.
+- `pkg/graphrank`: graph-distance/proximity ranking.
+- `pkg/community`: Louvain community detection, incremental store, pruning.
+- `pkg/temporal`: timestamp extraction and time-aware search helpers.
+
+Temporal validity model:
+
+- Exclusive relationships such as assignment/status/ownership are superseded
+  on insert.
+- Edges have validity windows and can be queried as current or as-of snapshots.
+- Search can mix vector hits with graph proximity and temporal filters.
+
+## Memory Palace
+
+Memory palace is exposed primarily through MCP and mirrored in REST memory
+endpoints.
+
+```mermaid
+flowchart LR
+    Agent["Agent session"] --> SetContext["set_context(collection)"]
+    SetContext --> Wake["wake_up"]
+    Agent --> Save["save_memory room + hall"]
+    Save --> SQL["SQL memories table"]
+    Save --> Embed["embedding"]
+    Embed --> MemCollection["vector collection"]
+    Agent --> Recall["recall_memory / search"]
+    Recall --> SQL
+    Recall --> MemCollection
+    Recall --> Pins["pinned memories"]
+    Agent --> Diary["diary_write/read owner_id=agent:*"]
+    Diary --> SQL
+```
+
+Controlled hall vocabulary is enforced in `internal/http/mcp_palace.go` /
+`pkg/mcp` tool validation: `fact`, `event`, `decision`, `preference`,
+`advice`, `discovery`.
+
+## Workspace System
+
+Workspace support is a separate markdown-native layer:
+
+- Manifests in `pkg/workspace`.
+- REST handlers in `internal/http/workspace*.go`.
+- MCP tools forwarded from the same handlers.
+- Optional watcher and durable index worker.
+- Audit logs deliberately avoid storing markdown text and exact snippets.
+- Search resolves project/branch/generation to derived vector/BM25 collections.
+
+```mermaid
+flowchart TD
+    FS["Markdown workspace files"] --> Manifest["workspace Manifest"]
+    FS --> Index["workspace index/reindex"]
+    Index --> Chunk["chunker"]
+    Chunk --> Collection["derived vector collection"]
+    Chunk --> BM25["BM25 side index"]
+    Manifest --> Active["active generation"]
+    Watcher["polling watcher"] --> Jobs["index jobs"]
+    Jobs --> Index
+    Agent["MCP/REST client"] --> Context["workspace_context"]
+    Agent --> Search["workspace_search"]
+    Search --> Active
+    Search --> Collection
+    Search --> BM25
+    Agent --> Read["workspace_read exact file read"]
+    Agent --> Write["workspace_write/commit/revert"]
+    Write --> FS
+```
+
+## External Connectors
+
+| Connector | Code | Direction | Functionality |
+|---|---|---|---|
+| Cognee adapter | `cognee-plugin/levara_adapter` | Python -> gRPC | Implements Cognee `VectorDBInterface` over Levara collections/search |
+| clawdbot memory plugin | `clawdbot/extensions/memory-levara` | Node -> REST | Store/recall/forget memories via `/api/v1/memories`, with NDJSON outbox |
+| Embedding server | `pkg/embed`, `tools/embed_server.py` | Go -> HTTP | Batch and single text embeddings |
+| LLM providers | `pkg/llm` | Go -> HTTP | OpenAI-compatible/Ollama/vLLM and Anthropic chat completions |
+| Reranker | `pkg/rerank`, `cmd/qwen3rerank` | Go -> HTTP | Cross-encoder reranking with budget/gap gating |
+| Neo4j | `pkg/graphdb` | Go -> Bolt | Graph visualization, graph completion, KG writes |
+| PostgreSQL/SQLite | `internal/http/schema.go` | Go -> SQL | Metadata, users, memory, graph mirror, sync, RBAC |
+| S3-compatible storage | `pkg/storage` | Go -> HTTP SigV4 | Raw uploads and object storage URLs |
+| Prometheus | `internal/metrics` | scrape | HTTP/gRPC/search/LLM/storage metrics |
+| Langfuse | `pkg/observe` | Go -> HTTP | Optional LLM tracing |
+
+## Web UI
+
+Location: `Levara/webui`.
+
+Stack:
+
+- Next.js 16, React 19, TypeScript.
+- API client in `src/lib/api.ts`.
+- Pages: login, dashboard, datasets, dataset detail, search, chat, graph,
+  memories, collections, analytics, notebooks, settings.
+- Uses `/api/v1/*`, with `NEXT_PUBLIC_API_URL` optional.
+- E2E coverage in `webui/e2e`.
+
+The UI is a consumer of the REST API, not a source of domain logic.
+
+## Component Inventory
+
+| Package | Responsibility |
+|---|---|
+| `cmd/server` | Process bootstrap, dependency wiring, route registration, shutdown |
+| `cmd/cli` | Lightweight HTTP CLI |
+| `cmd/backup` | Backup command |
+| `cmd/reconcile` | Workspace/server reconcile tooling |
+| `cmd/qwen3rerank` | Rerank sidecar server |
+| `internal/store` | HNSW/Arena/WAL/DiskStore/collections/sharding primitives |
+| `internal/cluster` | Direct node, Raft node, FSM snapshots, primary/replica WAL streaming |
+| `internal/grpc` | gRPC v1/v2 service implementation, auth/rate/metrics interceptors |
+| `internal/http` | REST/MCP HTTP layer, auth, API modules, workspace, sync, UI support |
+| `internal/metrics` | Prometheus collectors and bounded user-label bucket |
+| `pipeline` | In-process text/vector search helpers and rerank application |
+| `pkg/mcp` | MCP tool descriptors and transport-independent tool bodies |
+| `pkg/orchestrator` | Streaming cognify pipeline |
+| `pkg/embed` | Embedding HTTP client, cache, local/auto embedder abstraction |
+| `pkg/llm` | Provider abstraction, structured output, rate limit, tracing wrapper |
+| `pkg/llmcache` | In-memory and JSONL persistent LLM response cache |
+| `pkg/rerank` | Rerank HTTP client, normalization and ordering |
+| `pkg/chunker` | Paragraph/sentence/row/code/sliding/parent-child chunking |
+| `pkg/extract` | Text extraction from files, code, audio/OCR-related flows |
+| `pkg/ingest` | File metadata writer, hash/classify/save pipeline pieces |
+| `pkg/bm25` | Lexical index, persistence, hybrid helper |
+| `pkg/graph` | Triplets, graph scoring, dedup, LSH, multi-query utilities |
+| `pkg/graphdb` | Neo4j writer and cached writer |
+| `pkg/graphstore` | SQL-backed graph store |
+| `pkg/graphrank` | Graph proximity ranking |
+| `pkg/community` | Louvain communities, summaries, pruning |
+| `pkg/temporal` | Date/time extraction and temporal search |
+| `pkg/router` | Search intent routing and adaptive weights |
+| `pkg/workspace` | Markdown workspace manifest/index primitives |
+| `pkg/storage` | Local/S3 storage interface |
+| `pkg/auth` | JWT signing/verification helpers |
+| `pkg/observe` | Structured logs, Langfuse, error tracker |
+| `pkg/backup` | Tar/gzip backup and restore helper code |
+| `pkg/vectorstore` | Adapter-like vector store helper over internal store |
+| `pkg/fileio` | Hash and directory walk acceleration |
+| `pkg/fetch` | URL fetching/extraction |
+| `pkg/audio` | Whisper-compatible audio transcription client |
+| `pkg/ontology` | Ontology parsing and matching |
+| `pkg/runreg` | Background run status registry |
+| `pkg/agenthosts` | Agent host install/config helpers |
+
+## Deployment Shapes
+
+Common modes inferred from code and compose files:
+
+- **Standalone dev/local**: Fiber + gRPC + local data dir, optional SQLite.
+- **Full stack**: Levara + PostgreSQL + Neo4j + Redis/other services +
+  embed server + Ollama/LLM.
+- **Raspberry Pi**: SQLite/local storage optimized path, setup scripts under
+  `Raspberry/` and `scripts/setup-embed-pi.sh`.
+- **Primary/replica**: WAL stream and snapshot endpoints under `/cluster/*`.
+- **Raft mode**: Hashicorp Raft per shard, currently separate from collection
+  manager path.
+- **Object storage mode**: `STORAGE_BACKEND=s3`, raw data mirrored to S3-style
+  backend with `storage://` metadata.
+
+## Main Coupling Points
+
+1. `cmd/server/main.go` is the composition root. Most dependencies are created
+   there and passed through `APIConfig` or gRPC service constructors.
+2. `APIConfig` is broad. It carries SQL DB, collections, embedding, LLM, BM25,
+   rerank, storage, run registry, workspace watcher, logger, adaptive weights.
+3. MCP depends on `pkg/mcp.Deps`; HTTP implements the interface. This is a good
+   boundary despite many methods.
+4. BM25 indexes are owned by gRPC service and shared into REST/MCP via
+   `grpcSvc.BM25Indexes()`.
+5. Run registry is shared between REST and MCP so background jobs are visible
+   across transports.
+6. `CollectionManager` is the central vector store for modern paths. Legacy
+   no-collection HTTP still routes through `store.Cluster`.
+7. SQL schema is shared by UI, MCP memory, graph mirror, auth/RBAC, sync and
+   workspace ops, so migration compatibility is critical.
+
+## Notable Risks / Complexity
+
+- **Composition root size**: `cmd/server/main.go` wires many unrelated concerns.
+  It is functional, but changes in one subsystem can easily affect startup.
+- **Dual vector paths**: collection manager and legacy cluster/shard path coexist.
+  This is useful for compatibility, but easy to misroute if `collection` is
+  omitted.
+- **Broad HTTP package**: `internal/http` contains REST, MCP adapters, workspace,
+  auth, sync, search, datasets and UI product features. Boundaries are logical
+  by file, not by package.
+- **SQL as shared substrate**: memory, graph, users, tenants, sessions, feedback
+  and workspace all share one DB handle and schema migration stream.
+- **External service optionality**: Embed/LLM/Neo4j/rerank/S3 are all optional
+  or env-driven. Handlers must keep nil/disabled cases robust.
+- **RBAC + rerank leakage risk**: code comments explicitly note rerank must run
+  after ACL prefiltering because sending forbidden text to reranker leaks data.
+- **Raft vs replication vs collection manager**: there are multiple HA concepts:
+  Raft shards, direct-node WAL replication, and collection-level storage.
+
+## Suggested Next Architectural Moves
+
+1. Split `cmd/server` wiring into small bootstrap builders:
+   storage, SQL, vector, graph, LLM, REST, MCP, workspace.
+2. Keep `pkg/mcp.Deps` as the agent boundary, but group methods into embedded
+   interfaces by capability: memory, search, workspace, sync, observability.
+3. Document which endpoints are legacy and which are canonical. Prefer
+   collection-aware paths for all new features.
+4. Add an architecture test that fails when REST/MCP/gRPC route registries drift
+   from generated documentation.
+5. Create a schema inventory generated from migration statements so SQL tables
+   stay discoverable.
+6. Treat workspace as a first-class package boundary if it keeps growing:
+   move more workspace HTTP helper logic into `pkg/workspace`.
+

--- a/docs/deployment-matrix.md
+++ b/docs/deployment-matrix.md
@@ -1,0 +1,42 @@
+# Levara Deployment Matrix
+
+Дата: 2026-05-17.
+
+Этот документ фиксирует поддерживаемые режимы развертывания и их границы. Он
+должен обновляться вместе с `docker-compose*.yml`, `Raspberry/`, `cmd/server`
+flags и ops scripts.
+
+## Matrix
+
+| Mode | Primary use | Required services | Optional services | Storage | HA story | Notes |
+|---|---|---|---|---|---|---|
+| Standalone local/dev | Development, demos, local agents | Levara server | SQLite, embed, LLM, Neo4j | local `data/` | none | Default `-standalone=true`; fastest feedback loop |
+| Full stack | Production-like RAG/KG | Levara, PostgreSQL, Neo4j, embed service | LLM, rerank, Prometheus, S3 | local or S3 | external DB/Neo4j durability | Canonical feature-complete mode |
+| Raspberry Pi | Edge/local memory appliance | Levara, SQLite/local storage | embed service, local LLM | local disk | backup scripts | Prefer SQLite and conservative resource settings |
+| Primary/replica | Read replica / warm standby | Primary Levara + replica Levara | SQL/Neo4j stack as needed | local per node | WAL stream + snapshot endpoints | Uses `/cluster/wal/stream`, `/cluster/snapshot`, `/cluster/state` |
+| Raft shards | Experimental/legacy consensus path | Multiple Levara nodes | Prometheus | local per node | Hashicorp Raft per shard | Separate from CollectionManager canonical path; needs explicit e2e before production use |
+| S3/object storage | Shared raw upload storage | Levara + SQL | S3/MinIO/Spaces | `storage://` raw data | backend-dependent | Set `STORAGE_BACKEND=s3` and S3 env vars |
+
+## Canonical API Policy
+
+- New vector and memory features should use collection-aware APIs.
+- Legacy vector endpoints `/insert`, `/batch_insert`, `/delete` remain
+  compatibility endpoints.
+- Unified semantic search should use `/api/v1/search/text` or the MCP `search`
+  tool. `/api/v1/search` is retained as a frontend compatibility alias.
+- gRPC collection APIs are canonical for backend adapters such as Cognee.
+- MCP is canonical for AI-agent memory workflows.
+
+## Production Readiness Checklist
+
+| Area | Required before production |
+|---|---|
+| Auth | `JWT_SECRET`, API-key policy, `-require-auth=true` where exposed |
+| SQL | PostgreSQL migrations verified; SQLite only for local/Pi-style deployments |
+| Embeddings | Embedding dimension matches `-dim` and collection metadata |
+| Search | ACL-before-rerank invariant tested for any external reranker |
+| Graph | Neo4j schema bootstrap decision documented via `NEO4J_BOOTSTRAP_SCHEMA` |
+| Storage | Local/S3 raw data access verified, including raw URL/download paths |
+| Observability | `/metrics`, `/health/details`, doctor tool, alerting/SLOs wired |
+| Backup | Backup/restore tested for SQL, vector data, uploads, and workspace state |
+

--- a/docs/reviews/agent-memory-comparison.md
+++ b/docs/reviews/agent-memory-comparison.md
@@ -1,0 +1,171 @@
+# Levara vs альтернативы для agent memory — честное сравнение
+
+**Дата:** 2026-05-15
+**Цель документа:** дать сбалансированное сравнение, включая оси, где Levara проигрывает или находится в паритете. Исходная таблица (5 строк) показывала только сильные стороны — для принятия решения этого мало.
+
+Колонки:
+- **Levara** — этот проект (LevaraOS = Levara + mem0 wrapper + MemoryFS).
+- **mem0 OSS** — open-source mem0 c sqlite/chroma backend (без облака).
+- **Qdrant** — raw production-grade vector DB без memory-семантики поверх.
+- **Mem0 Cloud** — managed-версия mem0.
+
+Легенда: ✅ есть / частично; ❌ нет; ~ оценка; ? не подтверждено.
+
+---
+
+## 1. Maturity / экосистема (Levara в основном позади)
+
+| Параметр | Levara | mem0 OSS | Qdrant | Mem0 Cloud |
+|---|---|---|---|---|
+| GitHub stars | ~0 (приватный) | ~32k★ | ~22k★ | n/a |
+| Возраст публичного проекта | <1 года | 2+ года | 5+ лет | 1+ год |
+| Активные контрибьюторы | 1 | 100+ | 100+ | команда Mem0 |
+| Production case-studies | внутренние | публичные (десятки) | публичные (сотни) | публичные |
+| SDK языки (first-class) | HTTP/gRPC только | Python, JS/TS | Python, JS, Go, Rust, Java | Python, JS/TS |
+| Готовые интеграции (LangChain / LlamaIndex / AutoGen / Crew) | ❌ | ✅ все 4 | ✅ все 4 | ✅ все 4 |
+| Документация (туториалы, cookbook, troubleshooting) | README + CLAUDE.md | полные docs.mem0.ai | полные docs.qdrant.tech | полные |
+| Сообщество (Discord/Slack/GitHub Discussions) | ❌ | Discord активный | Discord активный | поддержка |
+
+**Вывод:** для проекта, где «memory layer ставится на 2+ года и его не хочется поддерживать» — Levara сейчас рисковее. Это главная честная оговорка.
+
+---
+
+## 2. Производительность (mixed — обе стороны медали)
+
+| Параметр | Levara | mem0 OSS | Qdrant | Mem0 Cloud |
+|---|---|---|---|---|
+| Search p50 latency | **2.6 ms** | ~15 ms (chroma) | ~3–5 ms | ~50 ms (network+LLM) |
+| Search p99 latency | ~? (нужен бенч) | ~50 ms | ~10–20 ms | ~150–300 ms |
+| Concurrent QPS (single node) | **719** | ~50–100 | ~500–2000 | rate-limited по плану |
+| Insert throughput, 1 writer | 188 ips | bottleneck = LLM ~5 ips | ~1000+ ips | bottleneck = LLM |
+| Insert throughput, 8 writers | 1616 ips | n/a | ~5000+ ips | n/a |
+| Bulk insert (LanceDB-class baseline) | 741 ips | n/a | **~5000+ ips** | n/a |
+| RAM per 1M векторов (768-dim, fp32) | ~3 GB (HNSW in-mem) | ~3 GB | ~750 MB (со scalar quant), ~190 MB (binary quant) | managed |
+| Cold start (WAL replay) | секунды–минуты | мгновенно | секунды | n/a |
+
+**Где Levara впереди:** read-heavy сценарий с одной нодой, hybrid+rerank, низкая p50.
+**Где проигрывает:** bulk-ingest throughput (LanceDB/Qdrant в 3–6× быстрее), отсутствие квантизации (× RAM при росте корпуса).
+
+---
+
+## 3. Search & retrieval features
+
+| Параметр | Levara | mem0 OSS | Qdrant | Mem0 Cloud |
+|---|---|---|---|---|
+| Vector ANN (HNSW) | ✅ | ✅ (через chroma) | ✅ | ✅ |
+| BM25 / sparse | ✅ | ❌ | ✅ (sparse vectors) | ❌ |
+| Hybrid (RRF) | ✅ | ❌ | ✅ | ❌ |
+| Rerank default-on | ✅ Phase 2 | ❌ | ручной | ❌ |
+| Adaptive rerank skip (score-gap) | ✅ Phase 2.5 | ❌ | ❌ | ❌ |
+| Smart routing (semantic / fact / temporal) | ✅ | ❌ | ❌ | частично |
+| Quantization (scalar/product/binary) | ❌ | ❌ | ✅ все три | n/a (managed) |
+| Богатые payload-фильтры (range, geo, nested, has_id) | базовые (room/tags) | базовые | ✅ полные | базовые |
+| Multi-modal (image/audio embeddings) | ❌ | ✅ через клиента | ✅ native | ✅ |
+
+---
+
+## 4. Memory semantics (главная зона силы Levara)
+
+| Параметр | Levara | mem0 OSS | Qdrant | Mem0 Cloud |
+|---|---|---|---|---|
+| Hall/room taxonomy | ✅ (fact/event/decision/preference/advice/discovery) | ❌ flat | ❌ raw vectors | частично (category) |
+| Pin / wake_up | ✅ | ❌ | ❌ | ❌ |
+| Per-agent diaries (isolated namespace) | ✅ | ❌ | через collections вручную | ❌ |
+| Temporal KG (valid_from/valid_until, superseded_by) | ✅ | ❌ | ❌ | ❌ |
+| Auto-supersede edges (whitelist relations) | ✅ | ❌ | ❌ | ❌ |
+| `query_entity(as_of=...)` | ✅ | ❌ | ❌ | ❌ |
+| Chat history (save/recall/search) | ✅ | через API | ❌ | ✅ |
+| Cognify (chunk→entity→edge pipeline) | ✅ | ❌ (mem0 делает другое) | ❌ | частично |
+| MCP tools count | **25+** (63 endpoints) | ~7 | 0 (raw API) | ~10 |
+
+**Это и есть «moat» Levara.** Если эти фичи не нужны — Qdrant + тонкая обёртка может быть проще и дешевле.
+
+---
+
+## 5. Operations
+
+| Параметр | Levara | mem0 OSS | Qdrant | Mem0 Cloud |
+|---|---|---|---|---|
+| Crash recovery (WAL fsync) | ✅ 100% | ❌ зависит от sqlite/chroma | ✅ | ✅ |
+| Distributed / sharding / replication | ❌ single-node | ❌ | ✅ кластер | ✅ managed |
+| Сколько сервисов держать | 6 (Levara + MemoryFS + mem0 + Postgres + Neo4j + Ollama) | 2 (mem0 + sqlite/chroma) | **1 бинарь** | 0 (managed) |
+| Backup / restore CLI | ✅ levara-backup | дамп sqlite | ✅ snapshots | автоматический |
+| Snapshot / point-in-time | через WAL | ❌ | ✅ | ✅ |
+| Prometheus метрики | ✅ | ограниченно | ✅ | дашборд в облаке |
+| OpenTelemetry tracing | частично | ❌ | ✅ | ✅ |
+| Health-check / readiness | ✅ | ✅ | ✅ | ✅ |
+| Graceful shutdown | ✅ | ✅ | ✅ | n/a |
+
+**Operational tax Levara высокий.** 6 сервисов = много мест, где может сломаться. Для команды из 1–2 человек это ощутимо.
+
+---
+
+## 6. Auth, безопасность, enterprise
+
+| Параметр | Levara | mem0 OSS | Qdrant | Mem0 Cloud |
+|---|---|---|---|---|
+| AuthN: API key | ✅ JWT | ✅ | ✅ | ✅ |
+| AuthN: OAuth / SSO | ❌ | ❌ | ✅ Cloud | ✅ |
+| AuthN: mTLS | ❌ | ❌ | ✅ | n/a |
+| Multi-tenancy / namespace isolation | через collection + owner_id | через user_id | через collections | ✅ |
+| RBAC (роли, scopes) | ❌ | ❌ | ✅ Cloud/Enterprise | ✅ |
+| Audit logs | ❌ | ❌ | ✅ Cloud | ✅ |
+| Rate limits на route и user | ✅ (T2: per-IP + per-user) | ❌ | ✅ | ✅ |
+| SOC 2 / GDPR / HIPAA | ❌ | ❌ | ✅ Cloud (SOC2) | ✅ SOC2 |
+| Encryption at rest | OS-level | OS-level | ✅ Cloud | ✅ |
+| VPC peering / private link | ❌ | ❌ | ✅ Cloud | ✅ |
+
+---
+
+## 7. Стоимость владения (1M memories, грубая оценка)
+
+| Параметр | Levara (self-hosted) | mem0 OSS | Qdrant (self-hosted) | Mem0 Cloud | Qdrant Cloud |
+|---|---|---|---|---|---|
+| RAM нужный | ~4–6 GB (HNSW + KG + BM25) | ~3 GB | ~1 GB (со scalar quant) | n/a | ~1 GB |
+| Disk | ~5–10 GB (WAL + arena + KG) | ~3 GB | ~2 GB | n/a | ~2 GB |
+| Месячная инфра (AWS m6i.large ~$70/мес) | ~$70 + LLM API | ~$50 + LLM API | ~$50 | ~$50–200 (по плану) | ~$60–150 |
+| LLM API расходы (embeddings) | пропорционально writes | пропорционально writes | пропорционально writes | включено в план | пропорционально |
+| Время инженера на ops (часов/мес) | 4–10 ч (6 сервисов) | 1–3 ч | 1–2 ч | ~0 | ~0 |
+| TCO для команды из 1 dev | infra дёшево, но dev-time дорого | средне | низко | dev-time = 0 | dev-time = 0 |
+
+Управленческий вывод: при «эффективной ставке dev = $100/ч», 6 часов ops/мес = $600. Это часто перекрывает разницу с managed на small scale.
+
+---
+
+## 8. Когда что выбирать — best-fit workload
+
+| Сценарий | Победитель | Почему |
+|---|---|---|
+| Personal agent memory с graph-aware recall, локально, привередливый dev | **Levara** | hall/room, temporal KG, diaries, MCP-first |
+| Read-heavy agent (>100:1 read/write), нужна низкая p50 | Levara или Qdrant | hybrid+rerank vs скорость и quantization |
+| Bulk-ingest 100M+ векторов | **Qdrant** (или LanceDB) | quantization, sharding, throughput |
+| Production-scale multi-tenant memory как-a-service | **Mem0 Cloud** или Qdrant Cloud | SLA, RBAC, audit |
+| Python-агент, минимум кода, «просто работает» | **mem0 OSS** | API из 3 строк, экосистема |
+| Multi-modal (image+text) поиск | Qdrant | native multi-vector |
+| Enterprise compliance (SOC2 / HIPAA / VPC) | Qdrant Cloud / Mem0 Cloud | сертификации |
+| Свой LLM-powered KG pipeline + temporal reasoning | **Levara** | cognify + temporal edges нигде больше нет |
+| Team из 1 человека, не хочет поддерживать стек | mem0 OSS или Cloud | один-два сервиса vs шесть |
+
+---
+
+## 9. Что можно улучшить в самой Levara, чтобы оси выровнять
+
+1. **Quantization (scalar/binary)** — закроет RAM-разрыв с Qdrant, важно при 10M+.
+2. **Bulk-ingest API с пропуском WAL fsync на батч** — догнать LanceDB по throughput.
+3. **Python/JS SDK** — без них экосистема не подтянется.
+4. **Хотя бы один публичный case study + бенчмарк-репо** — для доверия.
+5. **Опциональный «single-binary» режим** (sqlite + embedded KG) — снять operational tax для соло-юзеров.
+6. **OpenTelemetry tracing end-to-end** — для production debugging.
+7. **RBAC + audit log** — порог входа для команд.
+
+---
+
+## 10. Источники и оговорки
+
+- Цифры Levara: `CLAUDE.md` (search 2.6 ms p50, insert 188–1616 ips, концurrent 719 QPS).
+- Цифры конкурентов: публичные docs и бенчмарки на 2025–2026, оценочные, не свежий A/B на одинаковом железе.
+- Числа GitHub stars: на 2026-05, могут устареть.
+- Mem0 Cloud latency сильно зависит от региона; ~50 ms — оптимистичный сценарий.
+- Все «❌» означают «нет из коробки» — иногда руками можно добавить.
+
+Эта таблица — не «маркетинговый one-pager», а внутренний документ для честной оценки, где Levara действительно сильна и где сейчас разрыв до production-grade альтернатив.

--- a/docs/reviews/final_test.md
+++ b/docs/reviews/final_test.md
@@ -1,0 +1,448 @@
+# Final Test Plan — валидация Levara перед внешним сравнением
+
+**Дата:** 2026-05-15
+**Контекст:** `agent-memory-comparison.md` содержит 30+ ✅ для Levara, большая часть которых опирается на внутренние замеры на одной машине без реалистичной нагрузки. Red-team review (см. чат от 2026-05-15) выделил конкретные слабые места в этих заявках. Этот документ превращает каждое такое место в проверяемую задачу с гипотезой, методом и критерием успеха.
+
+**Definition of done для всего плана:** мы можем показать таблицу сравнения наружу (потенциальному пользователю / в README / в техблоге) без чувства, что что-то нарисовано. Каждая ✅ должна либо подтвердиться воспроизводимым артефактом (бенч-репорт, eval-репорт, postmortem chaos-теста), либо смягчиться до «частично» / «при условии X».
+
+**Легенда приоритетов:**
+- **P0** — блокирует утверждение «production-ready»; без этого таблицу нельзя показывать.
+- **P1** — существенно влияет на честное позиционирование; нужно до публичного релиза.
+- **P2** — для полноты; можно отложить на v2 документа.
+
+**Легенда effort:** грубая оценка в днях для одного инженера full-time.
+
+---
+
+## §1. Производительность под реалистичной нагрузкой
+
+Цель секции: заменить «2.6 ms p50 на голом HNSW» на матрицу latency × pipeline-config × dataset-size, измеренную на стенде, который можно повторить.
+
+### T1.1 — Realistic search latency matrix
+**Приоритет:** P0 — **Effort:** 3 дня
+**Гипотеза/риск:** Заявленные 2.6 ms p50 / 719 QPS — это raw HNSW lookup без rerank/hybrid/filter. С полным пайплайном агентского recall цифры могут вырасти на порядок и таблица перестанет давать преимущество перед Qdrant.
+
+**Метод:**
+1. Подготовить три датасета: 10k, 100k, 1M chunks из BEIR (msmarco) или synthetic.
+2. Запросный набор: 200 реальных query шаблонов (semantic, fact, temporal).
+3. Прогнать 6 конфигов: `{raw HNSW}`, `{+ BM25 RRF}`, `{+ rerank default-on}`, `{+ room filter}`, `{+ all}`, `{+ all + cognify-extracted KG walk}`.
+4. Для каждого: warmup 1k запросов, замер 10k запросов, при QPS = 10, 50, 100, 500.
+5. Записать p50, p95, p99 latency и actual QPS sustain.
+
+**Success criteria:**
+- Артефакт: `bench/realistic_latency.csv` + `bench/realistic_latency.md` отчёт.
+- В таблице сравнения цифру «2.6 ms» заменить на диапазон с явным указанием конфига.
+- p50 < 50 ms на конфиге `{+ all}` при QPS=100 — иначе нужно либо помечать как «slow», либо чинить.
+
+### T1.2 — Concurrent QPS под полным пайплайном
+**Приоритет:** P0 — **Effort:** 2 дня
+**Гипотеза/риск:** 719 QPS — это HNSW concurrent reads. С rerank cross-encoder cap = (1 / rerank_latency) × N_workers. Реалистичный потолок может быть 50–100 QPS, а не 719.
+
+**Метод:**
+1. Locust / k6 harness с auth (JWT), bursts 1×, 5×, 10× от ожидаемого RPS.
+2. Снимать `levara_http_request_duration_seconds`, `levara_rerank_outcome_total`, CPU/RAM Levara и rerank backend.
+3. Измерить деградацию: при каком QPS p99 пробивает 1 s, при каком 5xx начинает расти.
+
+**Success criteria:**
+- Sustained QPS при p99 < 500 ms задокументирован для конфига `{+ all}`.
+- Понятный график: «Levara держит N QPS при том-то конфиге», публикуемый.
+
+### T1.3 — End-to-end `add()` throughput с cognify
+**Приоритет:** P1 — **Effort:** 1 день
+**Гипотеза/риск:** «1616 inserts/sec на 8 writers» — это write в WAL+arena без cognify. Реальный agent write-path: agent → mem0 → MemoryFS → cognify (DeepSeek) → embed → graph. End-to-end latency на add() — секунды, не миллисекунды.
+
+**Метод:**
+1. Скрипт: 1000 `add()` calls через mem0 SDK на одного пользователя.
+2. Замер p50/p95 end-to-end latency и общего throughput.
+3. Разделить: время в каждом hop'е (mem0 API, MemoryFS commit, cognify extraction, embed, Levara insert, graph upsert).
+
+**Success criteria:**
+- Артефакт: stacked bar chart «где время в add()».
+- В сравнении заменить «1616 ips» на «N add()/sec end-to-end» — это релевантная агентам цифра.
+- Если bottleneck в DeepSeek call — задокументировать, дать batched/async вариант или fallback.
+
+---
+
+## §2. Crash recovery / chaos testing
+
+Цель: подтвердить «WAL 100%» под реалистичными failure modes, а не только `kill levara && start levara`.
+
+### T2.1 — Chaos harness для Levara WAL
+**Приоритет:** P0 — **Effort:** 4 дня
+**Гипотеза/риск:** «Crash recovery 100%» не тестировалось с in-flight cognify, in-flight gRPC stream, disk-full, corrupt WAL pages, partial fsync.
+
+**Метод:**
+1. Toxiproxy / pumba для chaos на сетевом и process уровне.
+2. Сценарии:
+   - `kill -9` в момент batch insert (1, 10, 100, 1000 inflight).
+   - `kill -9` посреди cognify-run'а (фоновая задача).
+   - `kill -9` посреди WAL fsync group-commit.
+   - Disk-full на WAL volume.
+   - Corrupt: zero out последний WAL page, flip random byte.
+   - Power loss simulation: SIGKILL + drop page cache + restart.
+3. После каждого: WAL replay, проверка инвариантов (HNSW connectivity, BM25 counts, KG edge consistency).
+4. Опубликовать `crash_recovery_report.md` с матрицей сценарий × outcome.
+
+**Success criteria:**
+- 100% data loss = 0 на N=50 запусков каждого сценария.
+- Если выявлены классы ошибок — фикс или явное «known limitation» в docs.
+
+### T2.2 — Сквозная consistency через 6 сервисов
+**Приоритет:** P0 — **Effort:** 3 дня
+**Гипотеза/риск:** При краше любого из {Levara, MemoryFS, mem0, Postgres, Neo4j, Ollama} стек оказывается в несогласованном состоянии: .md committed в MemoryFS, но не проиндексирован в Levara; entity в Levara KG, но связанный chunk потерян; mem0 metadata в Postgres расходится с реальным Levara.
+
+**Метод:**
+1. Скрипт: 10k `add()` через mem0; в случайные моменты убивать любой из сервисов.
+2. После каждого убийства — automatic restart и инвариант-чекер:
+   - Каждый .md файл в MemoryFS имеет запись в Levara.
+   - Каждая запись Levara имеет соответствующий .md.
+   - Postgres `memories` row count == Levara doc count для каждого пользователя.
+   - KG edges указывают на существующие entities.
+
+**Success criteria:**
+- Документ `consistency_report.md` со списком обнаруженных разрывов и фиксов.
+- Eventual consistency lag измерен: «после краха MemoryFS reindexer догоняет Levara за < N секунд».
+
+---
+
+## §3. Search quality A/B (а не только latency)
+
+«Hybrid BM25+HNSW» и «rerank default-on» отмечены ✅, но без доказательства, что они **улучшают** recall на агентских запросах.
+
+### T3.1 — Hybrid vs pure vector на agent-memory ground truth
+**Приоритет:** P0 — **Effort:** 4 дня
+**Гипотеза/риск:** RRF может ухудшать качество на коротких semantic-запросах, где BM25 шумит. Без A/B мы не знаем, помогает ли hybrid вообще.
+
+**Метод:**
+1. Собрать eval-датасет: 500 query → expected chunk_id пар, размеченных вручную или из реальных Claude сессий. Не из BEIR — нужен agent-memory distribution.
+2. Прогнать 4 режима: pure vector, pure BM25, hybrid RRF, hybrid + rerank.
+3. Метрики: NDCG@10, Recall@5, MRR.
+
+**Success criteria:**
+- Артефакт: `bench/search_quality.md` с таблицей метрик.
+- Hybrid должен бить pure vector минимум на 5% NDCG@10 — иначе hybrid выключаем по умолчанию.
+- Если rerank даёт +X% но стоит +Y ms — публикуем trade-off curve.
+
+### T3.2 — Smart routing accuracy
+**Приоритет:** P1 — **Effort:** 1 день
+**Гипотеза/риск:** Smart routing (`pkg/router`) разбивает запросы на fact / temporal / semantic. Это эвристика; её точность не измерена. Mis-routing запроса = выбор не той стратегии = худший recall.
+
+**Метод:**
+1. 300 запросов вручную размечены классом (fact / temporal / semantic / mixed).
+2. Прогнать через router, посчитать precision/recall/F1 для каждого класса.
+3. Confusion matrix.
+
+**Success criteria:**
+- F1 >= 0.8 на каждом классе.
+- Если F1 < 0.6 для какого-то класса — либо чинить router (LLM-based?), либо отключить smart routing и оставить hybrid as default.
+
+### T3.3 — Rerank cost-benefit при разных score gaps
+**Приоритет:** P1 — **Effort:** 1 день
+**Гипотеза/риск:** Phase 2.5 ввела `RERANK_SCORE_GAP_THRESHOLD` для adaptive skip — само существование этого флага означает, что «default-on» имеет существенный latency cost. Нужно найти sweet spot.
+
+**Метод:**
+1. На eval-датасете из T3.1 прогнать с порогом = {0, 0.1, 0.2, 0.3, 0.5}.
+2. Метрики: NDCG@10 vs avg latency.
+3. Доля запросов, на которых rerank скипнут.
+
+**Success criteria:**
+- Кривая trade-off published.
+- Рекомендуемое значение `RERANK_SCORE_GAP_THRESHOLD` для default config.
+
+---
+
+## §4. Memory semantics (главный «moat»)
+
+Hall/room/pin/wake_up/diaries — это **конвенции** поверх payload. Нужно подтвердить, что они дают реальный uplift, а не только удобную ментальную модель.
+
+### T4.1 — Recall quality с пустыми/неправильными hall
+**Приоритет:** P1 — **Effort:** 2 дня
+**Гипотеза/риск:** В CLAUDE.md сказано «пустые поля резко снижают полезность recall». Значит система чувствительна к дисциплине заполнения. Нужно измерить: насколько резко?
+
+**Метод:**
+1. Тот же eval-датасет: 500 query → chunk_id, но теперь варьируем hall заполнение в записях.
+2. Конфиги: 100% hall заполнен, 50%, 0%, 50% заполнен неверно.
+3. Замер NDCG@10 / Recall@5 для recall с hall-filter и без.
+
+**Success criteria:**
+- График деградации recall vs % missing hall.
+- Если 50% missing → recall падает на >30% — нужно либо auto-classification hall через LLM, либо явный warning в docs «без hall — на 30% хуже».
+
+### T4.2 — Pin / wake_up под нагрузкой
+**Приоритет:** P1 — **Effort:** 1 день
+**Гипотеза/риск:** `wake_up(max_tokens=300)` режет по бюджету. Если запинено больше, чем влезает — какие выпадают? Стабильно ли поведение?
+
+**Метод:**
+1. Pin 100 memories с разными priority (10, 8, 5, 3, 1).
+2. Вызвать `wake_up` 1000 раз, посмотреть, какие реально возвращаются.
+3. Проверить инвариант: priority=10 всегда возвращается до того, как режется по бюджету.
+
+**Success criteria:**
+- Алгоритм отбора задокументирован (greedy по priority? round-robin? recency?).
+- Если есть случаи, когда priority=10 выпадает — это баг.
+- Recommendation в docs: «pin не более N items с priority=10, иначе non-deterministic».
+
+### T4.3 — Per-agent diaries: что реально изолировано
+**Приоритет:** P2 — **Effort:** 0.5 дня
+**Гипотеза/риск:** Diaries — это namespace через `owner_id="agent:X"`. Может ли cross-namespace утечка случиться через graph walk, через `cross_search`, через hybrid BM25?
+
+**Метод:**
+1. Diary записи для агентов A, B, C.
+2. От имени A: вызвать все 25 MCP tools и проверить, что результаты ни в каком ответе не содержат записи B/C.
+3. Прогнать `cross_search` и убедиться, что diary записи не попадают в результат, если они не указаны явно.
+
+**Success criteria:**
+- Audit report: «diary isolation подтверждена для всех 25 tools» или список утечек.
+
+---
+
+## §5. Temporal KG validation
+
+«Temporal KG ✅» — но supersede работает только на whitelist из 10 relations, а entity resolution не валидирована.
+
+### T5.1 — Temporal coverage audit
+**Приоритет:** P1 — **Effort:** 1 день
+**Гипотеза/риск:** Cognify извлекает много типов relations, но автосупершед только на whitelist. Всё остальное — duplicates без temporal semantics.
+
+**Метод:**
+1. Прогнать cognify на 200 chunks из реальных текстов (новости, чат-логи, википедия).
+2. Посчитать, какая доля извлечённых edges попадает в whitelist, какая нет.
+3. Для non-whitelist — посчитать, сколько из них **по смыслу** должны были бы быть temporal.
+
+**Success criteria:**
+- Артефакт: «temporal coverage = X%».
+- Если < 50% — расширить whitelist или признать честно «temporal KG = 10 relations only».
+
+### T5.2 — Entity resolution F1
+**Приоритет:** P1 — **Effort:** 2 дня
+**Гипотеза/риск:** «Alex» и «Alexey» → разные узлы → supersede не сработает → граф «протекает» с дубликатами.
+
+**Метод:**
+1. Eval-датасет: 500 пар (mention_a, mention_b, same_entity: yes/no).
+2. Cognify на текстах, посмотреть, сколько раз создались разные узлы для одной сущности.
+3. Метрики: F1 на entity merge / non-merge.
+
+**Success criteria:**
+- F1 >= 0.85 — иначе нужно добавлять coreference / fuzzy matching.
+- Если F1 < 0.7 — temporal-KG advantage в таблице понижаем до «частично».
+
+---
+
+## §6. Cognify extraction quality
+
+Cognify — главный технический moat, и при этом единственная фича, опирающаяся на качество внешнего LLM (DeepSeek V3.2).
+
+### T6.1 — Cognify extraction precision/recall
+**Приоритет:** P0 — **Effort:** 5 дней
+**Гипотеза/риск:** Качество extraction нигде не измерено. На out-of-distribution доменах (юридика, медицина, код) может быть катастрофически плохим.
+
+**Метод:**
+1. Эталон: 200 chunks из 4 доменов (general, legal, medical, code), вручную размеченные на entities/relations.
+2. Прогнать cognify, сравнить.
+3. Метрики: entity precision/recall, relation precision/recall, F1 по типу relation.
+
+**Success criteria:**
+- Артефакт: `bench/cognify_quality.md` с таблицей метрик по доменам.
+- Если F1 < 0.5 на каком-то домене — отметить как «not recommended for this domain».
+- Если F1 < 0.3 — рассматривать как deal-breaker для KG-features таблицы.
+
+### T6.2 — Cognify failure modes (DeepSeek недоступен / медленный / возвращает мусор)
+**Приоритет:** P1 — **Effort:** 1 день
+**Гипотеза/риск:** Зависимость от внешнего LLM = SPOF. Что происходит, когда DeepSeek даун?
+
+**Метод:**
+1. Toxiproxy блокирует api.deepseek.com.
+2. Запустить 100 `add()` с включённым cognify.
+3. Поведение: ошибки? retries? .md commit-ятся, а graph остаётся пустым? user-facing error message?
+
+**Success criteria:**
+- Поведение задокументировано и предсказуемо.
+- Есть retry с экспоненциальным backoff.
+- Опционально: fallback на локальный gemma3:4b для extraction (медленнее но не падает).
+
+---
+
+## §7. Operational debuggability
+
+«Prometheus метрики ✅» — но 6 сервисов без distributed tracing превращают любой production-incident в «гадание по логам».
+
+### T7.1 — End-to-end distributed tracing audit
+**Приоритет:** P1 — **Effort:** 3 дня
+**Гипотеза/риск:** Когда у пользователя `add()` зависает на 30 секунд — где? mem0 → MemoryFS → cognify → embed → graph. Без trace ID через все hops debug = боль.
+
+**Метод:**
+1. Инструментировать OpenTelemetry trace ID propagation через все 6 сервисов.
+2. Smoke test: один `add()` → один trace span с всеми 5 child spans.
+3. Тоже для `search` через mem0 → Levara.
+
+**Success criteria:**
+- Один trace на один user-facing request, видный в Jaeger/Tempo.
+- Документация: «как дебажить slow add()» с примером trace.
+
+### T7.2 — Correlation IDs в логах
+**Приоритет:** P2 — **Effort:** 1 день
+**Метод:** Все 6 сервисов логируют `request_id` в каждой строке.
+**Success criteria:** `grep <request_id> logs/*.log` показывает весь путь запроса.
+
+---
+
+## §8. Backup / restore consistency
+
+«✅ levara-backup CLI» покрывает только Levara. Полный snapshot стека из 6 сервисов нужно проверить отдельно.
+
+### T8.1 — Consistent snapshot across 6 services
+**Приоритет:** P0 — **Effort:** 3 дня
+**Гипотеза/риск:** Backup только Levara → restore даёт несогласованность с Postgres (mem0 metadata), Neo4j (graph), MemoryFS (.md). Реальный recovery после disaster выдаст «mixed state».
+
+**Метод:**
+1. Snapshot test: пишем 1000 memories с cognify включённым.
+2. Снимаем snapshot всех 6 хранилищ (Levara WAL, Postgres dump, Neo4j dump, MemoryFS .md tarball).
+3. Восстанавливаем на чистом стенде.
+4. Проверяем все инварианты consistency как в T2.2.
+
+**Success criteria:**
+- Артефакт: `backup_runbook.md` с пошаговой инструкцией consistent snapshot.
+- Если current `levara-backup` недостаточен — расширить CLI до `levaraos-backup` (включая остальные 5 хранилищ).
+- Опубликовать RPO/RTO numbers.
+
+### T8.2 — Point-in-time recovery
+**Приоритет:** P2 — **Effort:** 2 дня
+**Метод:** Можно ли откатиться к состоянию «вчера в 14:00»? Что для этого нужно?
+**Success criteria:** Либо ✅ + runbook, либо честное «PITR не поддерживается» в docs.
+
+---
+
+## §9. Security defaults audit
+
+«JWT ✅» — но `JWT_SECRET` auto-generates в dev. Production deployment требует ручной настройки, которую легко пропустить.
+
+### T9.1 — Secure-by-default audit
+**Приоритет:** P0 — **Effort:** 2 дня
+**Гипотеза/риск:** Дефолтный `docker compose up` ставит небезопасную конфигурацию (auto-gen JWT, no TLS, default Postgres password, открытые порты).
+
+**Метод:**
+1. Свежий clone репо → `docker compose up -d` → security scan.
+2. Чек-лист:
+   - `JWT_SECRET` стабильный между рестартами?
+   - Postgres password дефолтный?
+   - Все API endpoints требуют auth?
+   - TLS между сервисами?
+   - CORS — wildcard?
+3. nmap на хост: сколько портов наружу?
+
+**Success criteria:**
+- Документ `security_defaults_report.md` со списком issues.
+- P0 issues — фикс перед публикацией comparison.
+- Дефолтный `docker-compose.prod.yml` с secure config.
+
+### T9.2 — Cross-tenant data leakage
+**Приоритет:** P1 — **Effort:** 1 день
+**Метод:**
+1. Создать users A и B, каждый пишет 100 memories.
+2. От имени A прогнать все 25 MCP tools, проверить, что ни в одном ответе нет данных B.
+3. Включая edge cases: cross_search, sync, graph queries.
+
+**Success criteria:** No cross-tenant leak across all tools.
+
+### T9.3 — Auth bypass / token forgery
+**Приоритет:** P1 — **Effort:** 1 день
+**Метод:** Можно ли подделать JWT? Что, если `JWT_SECRET` слабый? Reusable replay attack?
+**Success criteria:** Стандартный JWT-security чек-лист пройден.
+
+---
+
+## §10. End-to-end TCO measurement
+
+«$70 + LLM API» — оценка без учёта DeepSeek calls на cognify, GPU для embed-server, managed Postgres/Neo4j.
+
+### T10.1 — Реальный TCO на small-scale (1k memories/день, 100k recall/день)
+**Приоритет:** P1 — **Effort:** 2 дня
+**Метод:**
+1. Развернуть production-grade на AWS / Hetzner.
+2. Прогнать симуляцию агентской нагрузки 30 дней.
+3. Снять счета: compute, storage, network, DeepSeek API, OpenAI embeddings, managed DB (если используется).
+
+**Success criteria:**
+- Артефакт: реальная TCO-разбивка, опубликована в comparison.
+- Сравнение vs Qdrant Cloud / Mem0 Cloud honest.
+
+### T10.2 — Scaling cost к 10M memories
+**Приоритет:** P2 — **Effort:** 1 день
+**Метод:** Расчёт + extrapolation. Что узким горлом станет первым (RAM HNSW, Postgres rows, Neo4j edges)?
+**Success criteria:** Recommendations: «до 1M ok без quantization; от 10M нужен X».
+
+---
+
+## §11. Bus factor / community
+
+Самый честный риск, который mem0/Qdrant закрывают community, а Levara — нет.
+
+### T11.1 — Bus factor mitigation plan
+**Приоритет:** P1 — **Effort:** 5+ дней (постепенно)
+**Метод:**
+1. Документация: ARCHITECTURE.md с актуальной картой стека (не только CLAUDE.md, который TLDR для агентов).
+2. CONTRIBUTING.md с runbook'ами для типичных задач.
+3. ADRs (architecture decision records) для последних 10 ключевых решений.
+4. Onboarding script: «новый dev может deploy + написать 1 endpoint за день».
+5. Открыть репо или хотя бы invite 1–2 trusted reviewer на code review.
+
+**Success criteria:**
+- Внешний инженер за 1 день поднимает стек и делает meaningful PR.
+- В Comparison честно: «bus factor = 1 → 3 после plan».
+
+### T11.2 — Public benchmark репозиторий
+**Приоритет:** P2 — **Effort:** 3 дня
+**Метод:** Все бенчи из §1–§6 — в отдельный публичный репо с CI, чтобы любой мог воспроизвести.
+**Success criteria:** Третье лицо запускает `make bench` и видит ту же цифру ± 10%.
+
+---
+
+## §12. Сводка задач и приоритизация
+
+### P0 (блокеры публичного релиза comparison):
+1. T1.1 Realistic search latency matrix
+2. T1.2 Concurrent QPS с полным пайплайном
+3. T2.1 Chaos harness для WAL
+4. T2.2 Cross-service consistency
+5. T3.1 Hybrid vs pure vector A/B
+6. T6.1 Cognify extraction quality
+7. T8.1 Consistent backup/restore
+8. T9.1 Secure-by-default audit
+
+**Суммарно P0:** ~26 дней инженерного времени. Реалистично — 5–7 недель календарно с буфером.
+
+### P1 (для честного позиционирования):
+T1.3, T3.2, T3.3, T4.1, T4.2, T5.1, T5.2, T6.2, T7.1, T9.2, T9.3, T10.1, T11.1
+**Суммарно P1:** ~21 день. Можно параллельно с финальными P0.
+
+### P2 (опционально, для v2 документа):
+T4.3, T7.2, T8.2, T10.2, T11.2
+**Суммарно P2:** ~7 дней.
+
+---
+
+## §13. Артефакты и публикация
+
+После завершения P0+P1 в `docs/reviews/` должны быть:
+- `bench/realistic_latency.md` + CSV
+- `bench/search_quality.md`
+- `bench/cognify_quality.md`
+- `crash_recovery_report.md`
+- `consistency_report.md`
+- `security_defaults_report.md`
+- `backup_runbook.md`
+- Обновлённый `agent-memory-comparison.md` со ссылками на эти артефакты вместо голословных ✅.
+
+После этого таблицу можно показывать наружу с чистой совестью.
+
+---
+
+## §14. Что мы НЕ тестируем (и почему)
+
+Чтобы не растягивать план до бесконечности:
+- **Multi-modal embeddings** — фича не заявлена, и не нужна для агентской памяти.
+- **Distributed mode** — отсутствует в Levara, и не планируется в этой итерации; в таблице это уже ❌.
+- **Compliance audits (SOC2)** — не уровень self-hosted OSS; в таблице ❌.
+- **SDK языки** — не тестирование, а scope expansion; вне рамок «final test».
+
+Эти пункты в comparison остаются ❌ или «n/a» с явным указанием.

--- a/docs/schema-inventory.md
+++ b/docs/schema-inventory.md
@@ -1,0 +1,46 @@
+# Levara Schema Inventory
+
+Дата: 2026-05-17.
+
+Источник истины: migration statements в `Levara/internal/http/schema.go`.
+Кодовый инвентарь строится функцией `SchemaInventory()` в
+`Levara/internal/http/schema_inventory.go`; architecture tests проверяют
+критичные таблицы для PostgreSQL и SQLite.
+
+## Назначение
+
+Этот документ фиксирует смысловые группы SQL-схемы. Он не заменяет migrations:
+при расхождении править нужно `schema.go`, затем обновлять этот документ.
+
+## Core Tables
+
+| Группа | Таблицы | Назначение |
+|---|---|---|
+| Principals/Auth | `principals`, `users`, `api_keys` | Пользователи, JWT/API-key identity |
+| Datasets | `datasets`, `data`, `dataset_data` | Каталог загруженных документов и связь dataset -> data |
+| Graph mirror | `graph_nodes`, `graph_edges` | SQL-зеркало knowledge graph, включая temporal validity |
+| RBAC/Tenants | `tenants`, `user_tenant`, `roles`, `user_role`, `acl`, `dataset_shares` | Tenant membership, ACL, dataset sharing |
+| Sessions | `interactions` | История запросов/ответов и session tracking |
+| Memory palace | `memories` and memory pin/chat related tables | Project/user/agent memory |
+| Product UI | `user_settings`, `notebooks`, `notebook_cells`, `ontologies` | Настройки, notebooks, ontology upload |
+| Feedback/Ops | `feedback`, `heartbeats` | Search feedback, adaptive routing, operation history |
+| Workspace/Sync | workspace and sync support tables | Workspace jobs/audit/generation state and import/export support |
+
+## Important Columns
+
+| Table | Columns | Why they matter |
+|---|---|---|
+| `data` | `room`, `tags`, `pipeline_status`, `raw_data_location` | Filtered search, pipeline idempotency, local/S3 raw data access |
+| `graph_edges` | `valid_from`, `valid_until`, `superseded_by`, `dataset_id` | Temporal KG snapshots and tenant/project scoping |
+| `memories` | `room`, `type/hall`, `owner_id`, pin fields | Memory palace recall precision and wake-up behavior |
+| `feedback` | query/result/rating fields | Adaptive search routing and quality analytics |
+
+## Rules
+
+- PostgreSQL and SQLite migrations must remain semantically equivalent.
+- New SQL-backed features should add an inventory test when they introduce a
+  critical table.
+- Graph rows with empty `dataset_id` are legacy/global rows; new scoped writes
+  should prefer explicit dataset/project IDs.
+- Raw data locations should use `storage://...` for non-local storage backends.
+


### PR DESCRIPTION
## Summary

Five housekeeping commits that landed alongside the architecture-contract work (#79). Rebased onto main after #79 merged.

- ``workspace``: extract path policy (DefaultBranch, SafeID, ProjectRoot, ManifestPath, ListLocalProjects, ListLocalBranches, ResolveRuntimePaths) from ``internal/http`` into ``pkg/workspace`` so the policy is reusable outside HTTP. No behaviour change.
- ``mcp``: split monolithic ``Deps`` into capability interfaces (``SQLDeps``, ``CollectionDeps``, ``StorageDeps``, ``EmbedDeps``, ``MemoryDeps``, ``PipelineDeps``, ``SearchDeps``, ``SyncDeps``, ``ObservabilityDeps``); ``Deps`` remains as their union for the HTTP adapter.
- ``server``: extract storage / SQL / vector-runtime / HTTP-runtime init out of ``main`` into focused ``initXxx`` helpers in ``bootstrap.go``. ``main`` shrinks from straight-line wiring to a sequence of helper calls.
- ``docs``: ``deployment-matrix.md`` + ``schema-inventory.md`` (companion prose for in-tree inventories), plus codebase component analyses (RU + mixed) and ``docs/reviews/`` agent-memory comparison + final-test plan.

Supersedes #80 (closed because its base ``feat/architecture-contract`` was deleted on merge).

## Test plan

- [ ] CI ``vet-build``, ``test``, ``race``, ``lint``, ``contract`` all green