### PR TITLE
feat(mcp): audit log + outcome-labelled metrics (P3.3)

### DIFF
--- a/Levara/cmd/server/bootstrap.go
+++ b/Levara/cmd/server/bootstrap.go
@@ -39,6 +39,7 @@ import (
 	"github.com/stek0v/levara/pkg/llm"
 	"github.com/stek0v/levara/pkg/llmcache"
 	"github.com/stek0v/levara/pkg/llmproxy"
+	"github.com/stek0v/levara/pkg/audit"
 	"github.com/stek0v/levara/pkg/observe"
 	"github.com/stek0v/levara/pkg/storage"
 	pb "github.com/stek0v/levara/proto/pb"
@@ -602,6 +603,25 @@ type healthDeps struct {
 	embedModel    string
 	llmProvider   llm.Provider
 	colManager    *store.CollectionManager
+}
+
+// initMCPAuditSink resolves the -mcp-audit-log flag into an audit.Sink.
+// "" → JSONL on stderr (zero-config default). "-" → disabled (nil).
+// Anything else is treated as a directory for daily-rolled, gzipped logs.
+func initMCPAuditSink(path string, log *observe.Logger) audit.Sink {
+	switch path {
+	case "-":
+		return nil
+	case "":
+		return audit.NewLogger(nil) // stderr
+	}
+	fl, err := audit.NewFileLogger(path, 30)
+	if err != nil {
+		log.Warn("mcp_audit_init_failed", map[string]any{"path": path, "err": err.Error()})
+		return audit.NewLogger(nil)
+	}
+	log.Info("mcp_audit_log_ready", map[string]any{"path": path, "retention_days": 30})
+	return fl
 }
 
 // probeEmbedService tries a handful of well-known health paths under the

--- a/Levara/cmd/server/main.go
+++ b/Levara/cmd/server/main.go
@@ -173,6 +173,7 @@ func main() {
 	raftAddr := flag.String("raft-addr", "127.0.0.1", "Raft bind address (e.g. 0.0.0.0 or 10.23.0.53)")
 	raftPortBase := flag.Int("raft-port", 9000, "Base port for Raft (shard N listens on base+N)")
 	joinAddr := flag.String("join-addr", "", "Primary node address to join as replica (e.g. 10.23.0.53:8080)")
+	mcpAuditPath := flag.String("mcp-audit-log", "", "Directory for daily-rolled MCP audit logs (empty = stderr; '-' disables)")
 
 	flag.Parse()
 
@@ -482,6 +483,8 @@ func main() {
 		RerankBudgetMs:          rerankCfg.BudgetMs,
 		RerankScoreGapThreshold: rerankCfg.ScoreGapThreshold,
 		Runs:                    runs,
+		MCPAudit:                initMCPAuditSink(*mcpAuditPath, srvLog),
+		MCPAgentBucket:          metrics.NewUserBucket(20, time.Minute),
 	}
 
 	// MCP (Model Context Protocol) server — JSON-RPC 2.0 for AI agent integration

--- a/Levara/internal/http/api.go
+++ b/Levara/internal/http/api.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/stek0v/levara/internal/metrics"
 	"github.com/stek0v/levara/internal/store"
+	"github.com/stek0v/levara/pkg/audit"
 	"github.com/stek0v/levara/pkg/bm25"
 	"github.com/stek0v/levara/pkg/embed"
 	"github.com/stek0v/levara/pkg/llm"
@@ -77,6 +79,13 @@ type APIConfig struct {
 	// nil the searchHandler constructs a default registry on demand — main
 	// wiring sets this explicitly so tests can override with stubs.
 	SearchStrategies *StrategyRegistry
+	// MCPAudit records every MCP tool call (sanitized args, latency, outcome,
+	// result size) to its configured writer. Nil disables audit logging —
+	// metrics still emit, but no JSONL trail is kept.
+	MCPAudit audit.Sink
+	// MCPAgentBucket bounds agent_id cardinality on MCP audit metrics. Nil
+	// degrades to a fixed "unknown" label.
+	MCPAgentBucket *metrics.UserBucket
 }
 
 // RegisterAPI registers all Levara endpoints on the Fiber app.

--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/stek0v/levara/internal/metrics"
 	"github.com/stek0v/levara/pipeline"
+	"github.com/stek0v/levara/pkg/audit"
 	"github.com/stek0v/levara/pkg/llm"
 	"github.com/stek0v/levara/pkg/mcp"
 	"github.com/stek0v/levara/pkg/orchestrator"
@@ -621,14 +622,100 @@ func (h *mcpHandler) executeTool(ctx context.Context, sess *mcpSession, name str
 	toolStart := time.Now()
 	result := h.executeToolInner(ctx, sess, name, args)
 	h.auditWorkspaceTool(ctx, name, args, result)
-	duration := time.Since(toolStart).Seconds()
-	metrics.MCPToolDuration.WithLabelValues(name).Observe(duration)
+	duration := time.Since(toolStart)
+	metrics.MCPToolDuration.WithLabelValues(name).Observe(duration.Seconds())
 	status := "ok"
 	if result.IsError {
 		status = "error"
 	}
 	metrics.MCPToolRequests.WithLabelValues(name, status).Inc()
+	h.recordMCPAudit(ctx, sess, name, args, result, duration)
 	return result
+}
+
+// recordMCPAudit emits the per-call audit entry (P3.3) plus the
+// outcome-labelled Prometheus counters. Both the JSONL writer and the
+// new metrics live behind APIConfig so they can be disabled in tests
+// without changing call-sites.
+func (h *mcpHandler) recordMCPAudit(ctx context.Context, sess *mcpSession, name string, args map[string]any, result mcpToolResult, duration time.Duration) {
+	outcome := classifyOutcome(result)
+	agentID := ""
+	sessionID := ""
+	if sess != nil {
+		agentID = sess.UserID
+		sessionID = sess.ID
+	}
+	if agentID == "" {
+		if userID, _ := ctx.Value(mcpUserIDKey).(string); userID != "" {
+			agentID = userID
+		}
+	}
+	agentBucket := "unknown"
+	if h.cfg.MCPAgentBucket != nil {
+		h.cfg.MCPAgentBucket.Observe(agentID)
+		agentBucket = h.cfg.MCPAgentBucket.Label(agentID)
+	}
+
+	resultSize := resultPayloadSize(result)
+	metrics.MCPToolCalls.WithLabelValues(name, agentBucket, string(outcome)).Inc()
+	metrics.MCPToolLatencyMS.WithLabelValues(name, string(outcome)).Observe(float64(duration.Milliseconds()))
+	metrics.MCPToolResultBytes.WithLabelValues(name).Observe(float64(resultSize))
+
+	if h.cfg.MCPAudit == nil {
+		return
+	}
+	entry := audit.Entry{
+		TS:         time.Now().UTC().Format(time.RFC3339Nano),
+		SessionID:  sessionID,
+		AgentID:    agentID,
+		Tool:       name,
+		Args:       audit.SanitizeArgs(args),
+		LatencyMS:  duration.Milliseconds(),
+		Outcome:    outcome,
+		ResultSize: resultSize,
+	}
+	if outcome != audit.OutcomeOK && len(result.Content) > 0 {
+		entry.ErrorMessage = truncateAuditField(result.Content[0].Text)
+	}
+	h.cfg.MCPAudit.Log(entry)
+}
+
+func classifyOutcome(r mcpToolResult) audit.Outcome {
+	if !r.IsError {
+		return audit.OutcomeOK
+	}
+	if len(r.Content) == 0 {
+		return audit.OutcomeServerError
+	}
+	low := strings.ToLower(r.Content[0].Text)
+	switch {
+	case strings.Contains(low, "timeout"), strings.Contains(low, "deadline exceeded"):
+		return audit.OutcomeTimeout
+	case strings.Contains(low, "unauthorized"), strings.Contains(low, "forbidden"), strings.Contains(low, "permission denied"):
+		return audit.OutcomeUnauthorized
+	case strings.Contains(low, "rate limit"), strings.Contains(low, "too many requests"):
+		return audit.OutcomeRateLimited
+	case strings.Contains(low, "invalid"), strings.Contains(low, "missing"), strings.Contains(low, "bad request"):
+		return audit.OutcomeClientError
+	default:
+		return audit.OutcomeServerError
+	}
+}
+
+func resultPayloadSize(r mcpToolResult) int {
+	var n int
+	for _, c := range r.Content {
+		n += len(c.Text)
+	}
+	return n
+}
+
+func truncateAuditField(s string) string {
+	const lim = 256
+	if len(s) <= lim {
+		return s
+	}
+	return s[:lim] + "…"
 }
 
 func (h *mcpHandler) executeToolInner(ctx context.Context, sess *mcpSession, name string, args map[string]any) mcpToolResult {

--- a/Levara/internal/http/mcp_audit_test.go
+++ b/Levara/internal/http/mcp_audit_test.go
@@ -1,0 +1,103 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stek0v/levara/pkg/audit"
+	"github.com/stek0v/levara/pkg/mcp"
+)
+
+// captureSink retains every Entry passed through Log so tests can
+// assert on the side-effects of executeTool without parsing JSON
+// lines from a buffer.
+type captureSink struct {
+	mu      sync.Mutex
+	entries []audit.Entry
+}
+
+func (s *captureSink) Log(e audit.Entry) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries = append(s.entries, e)
+}
+
+func TestRecordMCPAuditOK(t *testing.T) {
+	sink := &captureSink{}
+	h := &mcpHandler{cfg: APIConfig{MCPAudit: sink}}
+	ctx := context.WithValue(context.Background(), mcpUserIDKey, "alice")
+	sess := &mcp.Session{ID: "s1", UserID: "alice"}
+	result := mcpToolResult{Content: []mcpContent{{Type: "text", Text: `{"ok":true}`}}}
+
+	h.recordMCPAudit(ctx, sess, "search", map[string]any{"query": "x"}, result, 12345678)
+
+	if len(sink.entries) != 1 {
+		t.Fatalf("expected 1 audit entry, got %d", len(sink.entries))
+	}
+	e := sink.entries[0]
+	if e.Tool != "search" || e.AgentID != "alice" || e.SessionID != "s1" {
+		t.Errorf("entry fields wrong: %+v", e)
+	}
+	if e.Outcome != audit.OutcomeOK {
+		t.Errorf("outcome=%q, want ok", e.Outcome)
+	}
+	if e.ResultSize != len(`{"ok":true}`) {
+		t.Errorf("result_size=%d", e.ResultSize)
+	}
+	if e.ErrorMessage != "" {
+		t.Errorf("error_message must be empty on ok, got %q", e.ErrorMessage)
+	}
+}
+
+func TestRecordMCPAuditClassifiesErrors(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want audit.Outcome
+	}{
+		{"context deadline exceeded", audit.OutcomeTimeout},
+		{"unauthorized: bad token", audit.OutcomeUnauthorized},
+		{"rate limit exceeded", audit.OutcomeRateLimited},
+		{"invalid collection name", audit.OutcomeClientError},
+		{"internal write failure", audit.OutcomeServerError},
+	}
+	for _, tc := range cases {
+		sink := &captureSink{}
+		h := &mcpHandler{cfg: APIConfig{MCPAudit: sink}}
+		result := mcpToolResult{IsError: true, Content: []mcpContent{{Type: "text", Text: tc.msg}}}
+		h.recordMCPAudit(context.Background(), nil, "search", nil, result, 1000)
+		if len(sink.entries) != 1 {
+			t.Fatalf("%q: expected 1 entry", tc.msg)
+		}
+		if sink.entries[0].Outcome != tc.want {
+			t.Errorf("%q: outcome=%q, want %q", tc.msg, sink.entries[0].Outcome, tc.want)
+		}
+		if !strings.Contains(sink.entries[0].ErrorMessage, tc.msg) {
+			t.Errorf("%q: error_message missing: %q", tc.msg, sink.entries[0].ErrorMessage)
+		}
+	}
+}
+
+func TestRecordMCPAuditSanitizesArgs(t *testing.T) {
+	var buf bytes.Buffer
+	h := &mcpHandler{cfg: APIConfig{MCPAudit: audit.NewLogger(&buf)}}
+	args := map[string]any{
+		"query":    "hello",
+		"password": "hunter2",
+		"vector":   []float64{0, 1, 0},
+	}
+	h.recordMCPAudit(context.Background(), nil, "search", args, mcpToolResult{}, 0)
+	var got audit.Entry
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v\n%s", err, buf.String())
+	}
+	if _, exists := got.Args["password"]; exists {
+		t.Errorf("password leaked into audit args: %+v", got.Args)
+	}
+	if v, ok := got.Args["vector"].(string); !ok || !strings.HasPrefix(v, "<vector len=3") {
+		t.Errorf("vector not summarized: %v", got.Args["vector"])
+	}
+}

--- a/Levara/internal/metrics/telemetry.go
+++ b/Levara/internal/metrics/telemetry.go
@@ -74,6 +74,26 @@ var (
 		Help: "Number of active MCP sessions",
 	})
 
+	// MCP audit-log metrics — finer-grained companions to MCPToolRequests
+	// and MCPToolDuration. Outcome is the closed enum from pkg/audit;
+	// agent_bucket is bounded via UserBucket (top-N + "other"/"anon").
+	MCPToolCalls = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "levara_mcp_tool_calls_total",
+		Help: "MCP tool calls by tool, agent bucket, and outcome",
+	}, []string{"tool", "agent_bucket", "outcome"})
+
+	MCPToolLatencyMS = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "levara_mcp_tool_latency_ms",
+		Help:    "MCP tool call latency (ms) by tool and outcome",
+		Buckets: []float64{5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000},
+	}, []string{"tool", "outcome"})
+
+	MCPToolResultBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "levara_mcp_tool_result_bytes",
+		Help:    "MCP tool result payload size in bytes",
+		Buckets: []float64{64, 256, 1024, 4096, 16384, 65536, 262144, 1048576},
+	}, []string{"tool"})
+
 	// 6. Embedding metrics
 	EmbedDuration = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "levara_embed_duration_seconds",

--- a/Levara/pkg/audit/audit.go
+++ b/Levara/pkg/audit/audit.go
@@ -1,0 +1,346 @@
+// Package audit emits one JSON line per MCP tool call so we have a
+// permanent record of what every agent asked for, with what arguments,
+// and how it ended.
+//
+// The Logger writes to an io.Writer (typically stderr, or a daily-rolled
+// gzipped file). Args are sanitized before serialization: secrets are
+// dropped, embedding vectors are collapsed to a short descriptor, and
+// every string is capped at maxFieldChars to keep lines bounded.
+package audit
+
+import (
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const maxFieldChars = 256
+
+// Outcome classifies how a tool call ended. The set is closed; new
+// values should be added to outcomeValues for metric label allow-listing.
+type Outcome string
+
+const (
+	OutcomeOK           Outcome = "ok"
+	OutcomeClientError  Outcome = "client_error"
+	OutcomeServerError  Outcome = "server_error"
+	OutcomeTimeout      Outcome = "timeout"
+	OutcomeUnauthorized Outcome = "unauthorized"
+	OutcomeRateLimited  Outcome = "rate_limited"
+)
+
+// AllOutcomes returns every defined outcome. Useful for metric init or
+// allow-list checks.
+func AllOutcomes() []Outcome {
+	return []Outcome{
+		OutcomeOK, OutcomeClientError, OutcomeServerError,
+		OutcomeTimeout, OutcomeUnauthorized, OutcomeRateLimited,
+	}
+}
+
+// Entry is the on-wire schema. Field order is stable; new fields must
+// be appended so log consumers can rely on positional readers if needed.
+type Entry struct {
+	TS           string         `json:"ts"`
+	RequestID    string         `json:"request_id,omitempty"`
+	SessionID    string         `json:"session_id,omitempty"`
+	AgentID      string         `json:"agent_id,omitempty"`
+	Tool         string         `json:"tool"`
+	Args         map[string]any `json:"args,omitempty"`
+	LatencyMS    int64          `json:"latency_ms"`
+	Outcome      Outcome        `json:"outcome"`
+	ResultSize   int            `json:"result_size,omitempty"`
+	ErrorCode    string         `json:"error_code,omitempty"`
+	ErrorMessage string         `json:"error_message,omitempty"`
+}
+
+// Sink is the abstract write-side of an audit log. Both Logger (plain
+// io.Writer) and FileLogger (daily-rolled file tree) satisfy it.
+type Sink interface {
+	Log(Entry)
+}
+
+// Logger serializes Entry values to JSON lines on the configured writer.
+// All exported methods are safe for concurrent use.
+type Logger struct {
+	mu  sync.Mutex
+	w   io.Writer
+	enc *json.Encoder
+}
+
+// NewLogger returns a Logger that writes to w. If w is nil, entries are
+// emitted to os.Stderr — useful as a no-config default.
+func NewLogger(w io.Writer) *Logger {
+	if w == nil {
+		w = os.Stderr
+	}
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return &Logger{w: w, enc: enc}
+}
+
+// Log writes one Entry as a JSON line. Errors writing the line are
+// swallowed — audit must never break a request.
+func (l *Logger) Log(e Entry) {
+	if l == nil {
+		return
+	}
+	if e.TS == "" {
+		e.TS = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	_ = l.enc.Encode(e)
+}
+
+// SanitizeArgs returns a copy of args with secrets dropped, vectors
+// collapsed, and long strings truncated. The input map is not modified.
+// Only top-level keys are inspected — nested maps are JSON-marshaled
+// and truncated as strings, which is enough for current MCP arg shapes
+// where nesting is rare.
+func SanitizeArgs(args map[string]any) map[string]any {
+	if len(args) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(args))
+	for k, v := range args {
+		if isSecretKey(k) {
+			continue
+		}
+		if isVectorKey(k) {
+			out[k] = vectorDescriptor(v)
+			continue
+		}
+		out[k] = clamp(v)
+	}
+	return out
+}
+
+func isSecretKey(k string) bool {
+	low := strings.ToLower(k)
+	if low == "password" || low == "secret" || low == "api_key" {
+		return true
+	}
+	return strings.HasSuffix(low, "_token") || low == "token"
+}
+
+func isVectorKey(k string) bool {
+	low := strings.ToLower(k)
+	return low == "vector" || low == "embedding" || low == "embeddings"
+}
+
+func vectorDescriptor(v any) string {
+	switch vv := v.(type) {
+	case []float64:
+		return fmt.Sprintf("<vector len=%d norm=%.4f>", len(vv), normFloat64(vv))
+	case []float32:
+		f := make([]float64, len(vv))
+		for i, x := range vv {
+			f[i] = float64(x)
+		}
+		return fmt.Sprintf("<vector len=%d norm=%.4f>", len(vv), normFloat64(f))
+	case []any:
+		nums := make([]float64, 0, len(vv))
+		for _, x := range vv {
+			if n, ok := x.(float64); ok {
+				nums = append(nums, n)
+			}
+		}
+		return fmt.Sprintf("<vector len=%d norm=%.4f>", len(vv), normFloat64(nums))
+	default:
+		return "<vector>"
+	}
+}
+
+func normFloat64(v []float64) float64 {
+	var s float64
+	for _, x := range v {
+		s += x * x
+	}
+	return math.Sqrt(s)
+}
+
+func clamp(v any) any {
+	switch vv := v.(type) {
+	case string:
+		return truncate(vv)
+	case map[string]any, []any:
+		b, err := json.Marshal(vv)
+		if err != nil {
+			return "<unmarshalable>"
+		}
+		return truncate(string(b))
+	default:
+		return v
+	}
+}
+
+func truncate(s string) string {
+	if len(s) <= maxFieldChars {
+		return s
+	}
+	return s[:maxFieldChars] + "…"
+}
+
+// ── File logger with daily rotation ─────────────────────────────────
+
+// FileLogger writes JSON lines to a daily file under dir, named
+// mcp-YYYY-MM-DD.log. On UTC date change the current file is closed,
+// gzipped to .log.gz, and a new file is opened. Files older than
+// retentionDays are pruned at rotation time.
+type FileLogger struct {
+	dir            string
+	retentionDays  int
+	mu             sync.Mutex
+	currentDay     string
+	currentFile    *os.File
+	currentLogger  *Logger
+}
+
+// NewFileLogger opens (or creates) a daily-rolling audit log under dir.
+// If dir cannot be created the error is returned and no logger is built.
+func NewFileLogger(dir string, retentionDays int) (*FileLogger, error) {
+	if retentionDays <= 0 {
+		retentionDays = 30
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("audit: mkdir %s: %w", dir, err)
+	}
+	fl := &FileLogger{dir: dir, retentionDays: retentionDays}
+	if err := fl.rotate(time.Now().UTC()); err != nil {
+		return nil, err
+	}
+	return fl, nil
+}
+
+// Log writes the entry to the current file, rotating first if the UTC
+// date has changed.
+func (fl *FileLogger) Log(e Entry) {
+	if fl == nil {
+		return
+	}
+	now := time.Now().UTC()
+	day := now.Format("2006-01-02")
+	fl.mu.Lock()
+	if day != fl.currentDay {
+		_ = fl.rotateLocked(now)
+	}
+	logger := fl.currentLogger
+	fl.mu.Unlock()
+	if logger != nil {
+		logger.Log(e)
+	}
+}
+
+// Close flushes and closes the current file. Subsequent Log calls
+// become no-ops.
+func (fl *FileLogger) Close() error {
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+	if fl.currentFile == nil {
+		return nil
+	}
+	err := fl.currentFile.Close()
+	fl.currentFile = nil
+	fl.currentLogger = nil
+	return err
+}
+
+func (fl *FileLogger) rotate(now time.Time) error {
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+	return fl.rotateLocked(now)
+}
+
+func (fl *FileLogger) rotateLocked(now time.Time) error {
+	if fl.currentFile != nil {
+		prevPath := fl.currentFile.Name()
+		_ = fl.currentFile.Close()
+		fl.currentFile = nil
+		fl.currentLogger = nil
+		if err := gzipFile(prevPath); err != nil {
+			fmt.Fprintf(os.Stderr, "audit: gzip %s failed: %v\n", prevPath, err)
+		}
+	}
+	day := now.Format("2006-01-02")
+	path := filepath.Join(fl.dir, "mcp-"+day+".log")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("audit: open %s: %w", path, err)
+	}
+	fl.currentFile = f
+	fl.currentDay = day
+	fl.currentLogger = NewLogger(f)
+	fl.pruneOldLocked(now)
+	return nil
+}
+
+func (fl *FileLogger) pruneOldLocked(now time.Time) {
+	cutoff := now.AddDate(0, 0, -fl.retentionDays)
+	entries, err := os.ReadDir(fl.dir)
+	if err != nil {
+		return
+	}
+	type aged struct {
+		name string
+		mod  time.Time
+	}
+	var olds []aged
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, "mcp-") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			olds = append(olds, aged{name: name, mod: info.ModTime()})
+		}
+	}
+	sort.Slice(olds, func(i, j int) bool { return olds[i].mod.Before(olds[j].mod) })
+	for _, o := range olds {
+		_ = os.Remove(filepath.Join(fl.dir, o.name))
+	}
+}
+
+func gzipFile(path string) error {
+	in, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	outPath := path + ".gz"
+	out, err := os.Create(outPath)
+	if err != nil {
+		return err
+	}
+	gz := gzip.NewWriter(out)
+	if _, err := io.Copy(gz, in); err != nil {
+		_ = gz.Close()
+		_ = out.Close()
+		_ = os.Remove(outPath)
+		return err
+	}
+	if err := gz.Close(); err != nil {
+		_ = out.Close()
+		_ = os.Remove(outPath)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	return os.Remove(path)
+}

--- a/Levara/pkg/audit/audit_test.go
+++ b/Levara/pkg/audit/audit_test.go
@@ -1,0 +1,140 @@
+package audit
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSanitizeArgsDropsSecrets(t *testing.T) {
+	in := map[string]any{
+		"query":      "hello",
+		"password":   "hunter2",
+		"api_key":    "sk-xxx",
+		"auth_token": "bearer-abc",
+		"token":      "raw",
+		"user_id":    "alice",
+	}
+	out := SanitizeArgs(in)
+	for _, k := range []string{"password", "api_key", "auth_token", "token"} {
+		if _, ok := out[k]; ok {
+			t.Errorf("secret key %q must be dropped", k)
+		}
+	}
+	if out["query"] != "hello" {
+		t.Errorf("non-secret %q clobbered: %v", "query", out["query"])
+	}
+}
+
+func TestSanitizeArgsCollapsesVectors(t *testing.T) {
+	in := map[string]any{
+		"vector":    []float64{0, 1, 0},
+		"embedding": []float32{1, 0, 0, 0},
+	}
+	out := SanitizeArgs(in)
+	v, ok := out["vector"].(string)
+	if !ok || !strings.HasPrefix(v, "<vector len=3 norm=1.0000") {
+		t.Errorf("vector summary wrong: %q", v)
+	}
+	e, ok := out["embedding"].(string)
+	if !ok || !strings.HasPrefix(e, "<vector len=4 norm=1.0000") {
+		t.Errorf("embedding summary wrong: %q", e)
+	}
+}
+
+func TestSanitizeArgsTruncatesLongStrings(t *testing.T) {
+	long := strings.Repeat("x", 1000)
+	out := SanitizeArgs(map[string]any{"q": long})
+	got := out["q"].(string)
+	if len(got) > maxFieldChars+5 {
+		t.Errorf("string not truncated, len=%d", len(got))
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncation marker missing: %q", got[len(got)-5:])
+	}
+}
+
+func TestSanitizeArgsMarshalsNested(t *testing.T) {
+	out := SanitizeArgs(map[string]any{
+		"filter": map[string]any{"room": "auth", "tags": []any{"a", "b"}},
+	})
+	s, ok := out["filter"].(string)
+	if !ok {
+		t.Fatalf("nested map should serialize to string, got %T", out["filter"])
+	}
+	if !strings.Contains(s, `"room":"auth"`) {
+		t.Errorf("nested map not serialized: %q", s)
+	}
+}
+
+func TestLoggerWritesJSONLine(t *testing.T) {
+	var buf bytes.Buffer
+	l := NewLogger(&buf)
+	l.Log(Entry{Tool: "search", LatencyMS: 12, Outcome: OutcomeOK})
+	line := buf.String()
+	if !strings.HasSuffix(line, "\n") {
+		t.Errorf("expected newline terminator: %q", line)
+	}
+	var got Entry
+	if err := json.Unmarshal([]byte(line), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if got.Tool != "search" || got.LatencyMS != 12 || got.Outcome != OutcomeOK {
+		t.Errorf("entry roundtrip failed: %+v", got)
+	}
+	if got.TS == "" {
+		t.Errorf("TS auto-fill missing")
+	}
+}
+
+func TestFileLoggerRotatesAndPrunes(t *testing.T) {
+	dir := t.TempDir()
+	fl, err := NewFileLogger(dir, 30)
+	if err != nil {
+		t.Fatalf("NewFileLogger: %v", err)
+	}
+	fl.Log(Entry{Tool: "search", Outcome: OutcomeOK})
+
+	// Drop an ancient log file that should be pruned on next rotation.
+	old := filepath.Join(dir, "mcp-2020-01-01.log.gz")
+	if err := os.WriteFile(old, []byte("dead"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ancient := time.Now().AddDate(0, 0, -90)
+	if err := os.Chtimes(old, ancient, ancient); err != nil {
+		t.Fatal(err)
+	}
+
+	// Force rotation by pretending tomorrow.
+	if err := fl.rotate(time.Now().UTC().AddDate(0, 0, 1)); err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if _, err := os.Stat(old); !os.IsNotExist(err) {
+		t.Errorf("ancient log should be pruned, stat err=%v", err)
+	}
+
+	// Previous day's .log should have been gzipped.
+	entries, _ := os.ReadDir(dir)
+	var gzCount int
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".log.gz") {
+			gzCount++
+		}
+	}
+	if gzCount == 0 {
+		t.Errorf("expected gzipped rotation artefact, got entries=%v", names(entries))
+	}
+	_ = fl.Close()
+}
+
+func names(es []os.DirEntry) []string {
+	out := make([]string, 0, len(es))
+	for _, e := range es {
+		out = append(out, e.Name())
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
Every MCP tool call now produces a structured audit record plus three Prometheus series. Closes P3.3 from the post-phase2.5 roadmap.

**Audit JSONL fields:** `ts, request_id, session_id, agent_id, tool, args, latency_ms, outcome, result_size, error_code, error_message`

**Outcomes:** `ok | client_error | server_error | timeout | unauthorized | rate_limited` (classified from error text — heuristic, refine later when tools emit structured codes).

**Sanitizer drops** `password / secret / api_key / *_token`, collapses `vector / embedding` to `<vector len=N norm=X>`, truncates strings & nested JSON above 256 chars.

**Sink config** via new `-mcp-audit-log` flag:
- `""` → JSONL on stderr (zero-config default)
- `"-"` → disabled
- `<dir>` → daily-rolled `mcp-YYYY-MM-DD.log`, gzipped on rotation, 30-day retention

**New metrics:**
- `levara_mcp_tool_calls_total{tool, agent_bucket, outcome}`
- `levara_mcp_tool_latency_ms{tool, outcome}` (buckets 5..5000ms)
- `levara_mcp_tool_result_bytes{tool}`

`agent_bucket` flows through a dedicated `UserBucket(20, 1m)` so cardinality stays bounded.

## Test plan
- [x] `go test ./pkg/audit/...` — sanitizer + rotation + gzip + prune
- [x] `go test ./internal/http/ -run TestRecordMCPAudit` — outcome classification + sanitization roundtrip via hook
- [x] `go test ./...` — full suite green
- [x] `make contract-check` — no architecture drift
- [ ] CI: vet+build, test, test -race, golangci-lint, architecture contract

## Out of scope (follow-up)
- Structured `error_code` from tools (today derived heuristically from `error_message`).
- `request_id` plumbing from JSON-RPC `id` field — left empty for now since current handler doesn't thread it through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)