### PR TITLE
feat(load-profiles): 5-profile load harness + RERANK_SCORE_GAP_THRESHOLD calibration

### DIFF
--- a/Levara/cmd/server/main.go
+++ b/Levara/cmd/server/main.go
@@ -146,6 +146,13 @@ func intEnv(key string, fallback int) int {
 }
 
 func main() {
+	if len(os.Args) >= 2 && os.Args[1] == "mcp" {
+		if err := runMCPStdio(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "mcp:", err)
+			os.Exit(1)
+		}
+		return
+	}
 	bootstrap := flag.Bool("bootstrap", false, "Bootstrap the Raft cluster (Leader only)")
 	standalone := flag.Bool("standalone", true, "Standalone mode: WAL-only, no Raft consensus (fastest)")
 	dim := flag.Int("dim", 128, "Vector dimension size (must match embedding model output)")

--- a/Levara/cmd/server/mcp_stdio.go
+++ b/Levara/cmd/server/mcp_stdio.go
@@ -1,0 +1,156 @@
+// mcp_stdio.go — `levara mcp serve` subcommand: stdio↔HTTP MCP bridge.
+//
+// Reads newline-delimited JSON-RPC messages from stdin, forwards each as
+// POST <backend>/mcp, writes the response to stdout (one JSON object per
+// line). The bridge tracks the Mcp-Session-Id header returned by the
+// HTTP MCP endpoint and replays it on every subsequent request so the
+// remote server keeps a single session for the lifetime of stdin.
+//
+// Use:
+//
+//	levara mcp serve --backend http://127.0.0.1:8080 [--token <jwt>]
+//
+// Auth: --token flag overrides LEVARA_TOKEN env. Empty token means no
+// Authorization header is sent (dev-mode servers without -require-auth).
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+func runMCPStdio(args []string) error {
+	fs := flag.NewFlagSet("mcp", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	var (
+		subcmd  string
+		backend string
+		token   string
+		apiKey  string
+		timeout time.Duration
+	)
+	fs.StringVar(&backend, "backend", "http://127.0.0.1:8080", "Levara HTTP base URL (the bridge POSTs to <backend>/mcp)")
+	fs.StringVar(&token, "token", os.Getenv("LEVARA_TOKEN"), "JWT bearer token (24h TTL); falls back to LEVARA_TOKEN env. Use --api-key for long-lived auth.")
+	fs.StringVar(&apiKey, "api-key", os.Getenv("LEVARA_API_KEY"), "Long-lived API key (X-API-Key header); falls back to LEVARA_API_KEY env. Mutually exclusive with --token.")
+	fs.DurationVar(&timeout, "timeout", 30*time.Second, "Per-request HTTP timeout")
+
+	if len(args) == 0 {
+		return fmt.Errorf("usage: levara mcp <serve> --backend <url> [--token <jwt>]")
+	}
+	subcmd, rest := args[0], args[1:]
+	if subcmd != "serve" {
+		return fmt.Errorf("unknown mcp subcommand %q (expected: serve)", subcmd)
+	}
+	if err := fs.Parse(rest); err != nil {
+		return err
+	}
+	backend = strings.TrimRight(backend, "/")
+	if backend == "" {
+		return fmt.Errorf("--backend required")
+	}
+	if token != "" && apiKey != "" {
+		return fmt.Errorf("--token and --api-key are mutually exclusive")
+	}
+
+	br := &bridge{
+		backend: backend + "/mcp",
+		token:   token,
+		apiKey:  apiKey,
+		client:  &http.Client{Timeout: timeout},
+	}
+	return br.run(os.Stdin, os.Stdout)
+}
+
+type bridge struct {
+	backend string
+	token   string
+	apiKey  string
+	client  *http.Client
+
+	mu        sync.Mutex
+	sessionID string
+}
+
+func (b *bridge) run(in io.Reader, out io.Writer) error {
+	scanner := bufio.NewScanner(in)
+	// MCP messages can be large (search results, cognify status). Allow up
+	// to 4 MiB per line — matches the HTTP body limit on the server side.
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	writer := bufio.NewWriter(out)
+	defer writer.Flush()
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		respBody, err := b.forward(line)
+		if err != nil {
+			// Forwarding errors are surfaced as JSON-RPC errors on stdout
+			// so the MCP client sees a structured failure instead of a
+			// dropped connection. The request ID is not recovered here —
+			// JSON-RPC permits id=null for transport-level errors.
+			fmt.Fprintf(writer, `{"jsonrpc":"2.0","id":null,"error":{"code":-32000,"message":%q}}`+"\n", err.Error())
+			writer.Flush()
+			continue
+		}
+		writer.Write(respBody)
+		writer.WriteByte('\n')
+		writer.Flush()
+	}
+	return scanner.Err()
+}
+
+func (b *bridge) forward(payload []byte) ([]byte, error) {
+	req, err := http.NewRequest("POST", b.backend, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if b.token != "" {
+		req.Header.Set("Authorization", "Bearer "+b.token)
+	}
+	if b.apiKey != "" {
+		req.Header.Set("X-API-Key", b.apiKey)
+	}
+	b.mu.Lock()
+	sid := b.sessionID
+	b.mu.Unlock()
+	if sid != "" {
+		req.Header.Set("Mcp-Session-Id", sid)
+	}
+
+	resp, err := b.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if newSID := resp.Header.Get("Mcp-Session-Id"); newSID != "" {
+		b.mu.Lock()
+		b.sessionID = newSID
+		b.mu.Unlock()
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("backend %s returned %d: %s", b.backend, resp.StatusCode, truncate(body, 200))
+	}
+	return body, nil
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "…"
+}

--- a/Levara/cmd/server/mcp_stdio_test.go
+++ b/Levara/cmd/server/mcp_stdio_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeMCPBackend captures forwarded requests and returns scripted bodies.
+type fakeMCPBackend struct {
+	mu          sync.Mutex
+	requests    []recordedRequest
+	responses   [][]byte
+	sessionToID string // value returned on first request via Mcp-Session-Id header
+	failStatus  int    // when >0, every request gets this HTTP status
+	authHeader  string
+}
+
+type recordedRequest struct {
+	body      []byte
+	sessionID string
+	authz     string
+	apiKey    string
+}
+
+func newFakeMCPBackend() (*fakeMCPBackend, *httptest.Server) {
+	f := &fakeMCPBackend{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp" {
+			http.NotFound(w, r)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		f.mu.Lock()
+		f.requests = append(f.requests, recordedRequest{
+			body:      body,
+			sessionID: r.Header.Get("Mcp-Session-Id"),
+			authz:     r.Header.Get("Authorization"),
+			apiKey:    r.Header.Get("X-API-Key"),
+		})
+		idx := len(f.requests) - 1
+		var resp []byte
+		if idx < len(f.responses) {
+			resp = f.responses[idx]
+		} else {
+			resp = []byte(`{"jsonrpc":"2.0","id":1,"result":{}}`)
+		}
+		fail := f.failStatus
+		sid := f.sessionToID
+		f.mu.Unlock()
+		if sid != "" && idx == 0 {
+			w.Header().Set("Mcp-Session-Id", sid)
+		}
+		if fail > 0 {
+			w.WriteHeader(fail)
+			w.Write(resp)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(resp)
+	}))
+	return f, srv
+}
+
+func TestBridge_ForwardsAndCapturesSessionID(t *testing.T) {
+	fake, srv := newFakeMCPBackend()
+	defer srv.Close()
+	fake.sessionToID = "sess-abc"
+	fake.responses = [][]byte{
+		[]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26"}}`),
+		[]byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}`),
+	}
+
+	br := &bridge{backend: srv.URL + "/mcp", client: srv.Client()}
+	in := strings.NewReader(
+		`{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n" +
+			`{"jsonrpc":"2.0","id":2,"method":"tools/list"}` + "\n",
+	)
+	var out bytes.Buffer
+	if err := br.run(in, &out); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if len(fake.requests) != 2 {
+		t.Fatalf("requests=%d, want 2", len(fake.requests))
+	}
+	if fake.requests[0].sessionID != "" {
+		t.Errorf("first request sent session id %q, want empty", fake.requests[0].sessionID)
+	}
+	if fake.requests[1].sessionID != "sess-abc" {
+		t.Errorf("second request session id = %q, want sess-abc", fake.requests[1].sessionID)
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("output lines=%d, want 2; got=%q", len(lines), out.String())
+	}
+	for i, line := range lines {
+		var r map[string]any
+		if err := json.Unmarshal([]byte(line), &r); err != nil {
+			t.Errorf("line[%d] not valid JSON: %v (%q)", i, err, line)
+		}
+	}
+}
+
+func TestBridge_SendsBearerToken(t *testing.T) {
+	fake, srv := newFakeMCPBackend()
+	defer srv.Close()
+	fake.responses = [][]byte{[]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`)}
+
+	br := &bridge{backend: srv.URL + "/mcp", token: "secret-jwt", client: srv.Client()}
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n")
+	if err := br.run(in, io.Discard); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := fake.requests[0].authz; got != "Bearer secret-jwt" {
+		t.Errorf("Authorization = %q, want Bearer secret-jwt", got)
+	}
+}
+
+func TestBridge_SendsAPIKey(t *testing.T) {
+	fake, srv := newFakeMCPBackend()
+	defer srv.Close()
+	fake.responses = [][]byte{[]byte(`{}`)}
+
+	br := &bridge{backend: srv.URL + "/mcp", apiKey: "k-1234", client: srv.Client()}
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n")
+	if err := br.run(in, io.Discard); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := fake.requests[0].apiKey; got != "k-1234" {
+		t.Errorf("X-API-Key = %q, want k-1234", got)
+	}
+	if got := fake.requests[0].authz; got != "" {
+		t.Errorf("Authorization = %q, want empty when only api-key set", got)
+	}
+}
+
+func TestRunMCPStdio_RejectsTokenAndAPIKeyTogether(t *testing.T) {
+	err := runMCPStdio([]string{"serve", "--backend", "http://x", "--token", "j", "--api-key", "k"})
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("err=%v, want mutually-exclusive error", err)
+	}
+}
+
+func TestBridge_OmitsAuthHeaderWhenTokenEmpty(t *testing.T) {
+	fake, srv := newFakeMCPBackend()
+	defer srv.Close()
+	fake.responses = [][]byte{[]byte(`{}`)}
+
+	br := &bridge{backend: srv.URL + "/mcp", client: srv.Client()}
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n")
+	_ = br.run(in, io.Discard)
+	if got := fake.requests[0].authz; got != "" {
+		t.Errorf("Authorization sent without token = %q, want empty", got)
+	}
+}
+
+func TestBridge_BackendErrorSurfacesAsJSONRPCError(t *testing.T) {
+	fake, srv := newFakeMCPBackend()
+	defer srv.Close()
+	fake.failStatus = 503
+	fake.responses = [][]byte{[]byte(`upstream down`)}
+
+	br := &bridge{backend: srv.URL + "/mcp", client: srv.Client()}
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n")
+	var out bytes.Buffer
+	if err := br.run(in, &out); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var r map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &r); err != nil {
+		t.Fatalf("output not JSON: %v (%q)", err, out.String())
+	}
+	errObj, ok := r["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("response missing error field: %v", r)
+	}
+	if code, _ := errObj["code"].(float64); code != -32000 {
+		t.Errorf("error.code = %v, want -32000", code)
+	}
+	msg, _ := errObj["message"].(string)
+	if !strings.Contains(msg, "503") {
+		t.Errorf("error.message = %q, want it to include 503 status", msg)
+	}
+}
+
+func TestBridge_SkipsBlankLines(t *testing.T) {
+	fake, srv := newFakeMCPBackend()
+	defer srv.Close()
+	fake.responses = [][]byte{[]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`)}
+
+	br := &bridge{backend: srv.URL + "/mcp", client: srv.Client()}
+	in := strings.NewReader("\n\n  \n" + `{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n\n")
+	var out bytes.Buffer
+	_ = br.run(in, &out)
+
+	if len(fake.requests) != 1 {
+		t.Errorf("requests=%d, want 1 (blank lines must be skipped)", len(fake.requests))
+	}
+	if got := strings.Count(strings.TrimSpace(out.String()), "\n") + 1; got != 1 {
+		t.Errorf("output lines=%d, want 1", got)
+	}
+}
+
+func TestRunMCPStdio_RejectsUnknownSubcommand(t *testing.T) {
+	if err := runMCPStdio([]string{"frobnicate"}); err == nil || !strings.Contains(err.Error(), "unknown") {
+		t.Errorf("err=%v, want unknown-subcommand error", err)
+	}
+}
+
+func TestRunMCPStdio_RequiresArgs(t *testing.T) {
+	if err := runMCPStdio(nil); err == nil {
+		t.Errorf("expected usage error for empty args")
+	}
+}

--- a/Levara/internal/http/api.go
+++ b/Levara/internal/http/api.go
@@ -147,6 +147,7 @@ func RegisterAPI(app fiber.Router, cfg APIConfig) {
 	app.Delete("/collections/:name", collectionDeleteHandler(cfg))
 	app.Get("/collections/:name/meta", collectionMetaHandler(cfg))
 	app.Put("/collections/:name/meta", collectionMetaUpdateHandler(cfg))
+	app.Post("/collections/:name/rename", collectionRenameHandler(cfg))
 
 	// Phase 2: rerank info surface (resolves design open question — clients
 	// need a cheap way to confirm which reranker variant is configured).

--- a/Levara/internal/http/api_cognify.go
+++ b/Levara/internal/http/api_cognify.go
@@ -52,6 +52,11 @@ func cognifyHandler(cfg APIConfig) fiber.Handler {
 			Collection      string   `json:"collection"`
 			RunInBackground bool     `json:"runInBackground"`
 			SessionID       string   `json:"session_id"`
+			// SkipGraph enables RAG-mode ingest: chunk → embed → HNSW only,
+			// no LLM entity extraction, no graph writes. Surfaces the
+			// orchestrator's existing SkipGraph flag (pipeline.go:93) so
+			// callers can opt into the fastest deterministic ingest path.
+			SkipGraph bool `json:"skip_graph"`
 		}
 		c.BodyParser(&req)
 
@@ -153,7 +158,8 @@ func cognifyHandler(cfg APIConfig) fiber.Handler {
 			Collection:       collection,
 			Collections:      cfg.Collections,
 			BM25Indexes:      cfg.BM25Indexes,
-			GenerateTriplets: true,
+			GenerateTriplets: !req.SkipGraph,
+			SkipGraph:        req.SkipGraph,
 			SystemPrompt:     sessionContext,
 			DatasetID: func() string {
 				if len(allDatasetIDs) > 0 {

--- a/Levara/internal/http/collections.go
+++ b/Levara/internal/http/collections.go
@@ -2,6 +2,8 @@
 package http
 
 import (
+	"strings"
+
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -57,6 +59,37 @@ func collectionDeleteHandler(cfg APIConfig) fiber.Handler {
 		}
 		cfg.Collections.Drop(name)
 		return c.SendStatus(204)
+	}
+}
+
+func collectionRenameHandler(cfg APIConfig) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		if cfg.Collections == nil {
+			return c.Status(503).JSON(fiber.Map{"detail": "collections not configured"})
+		}
+		oldName := c.Params("name")
+		var req struct {
+			NewName string `json:"new_name"`
+		}
+		if err := c.BodyParser(&req); err != nil || req.NewName == "" {
+			return c.Status(400).JSON(fiber.Map{"detail": "new_name required"})
+		}
+		if err := cfg.Collections.Rename(oldName, req.NewName); err != nil {
+			msg := err.Error()
+			// Map known classes of error to appropriate status codes so
+			// the migration runbook can distinguish "retry" from "stop".
+			switch {
+			case strings.Contains(msg, "not found"):
+				return c.Status(404).JSON(fiber.Map{"detail": msg})
+			case strings.Contains(msg, "already exists"), strings.Contains(msg, "identical"):
+				return c.Status(409).JSON(fiber.Map{"detail": msg})
+			case strings.Contains(msg, "invalid"), strings.Contains(msg, "must be non-empty"):
+				return c.Status(400).JSON(fiber.Map{"detail": msg})
+			default:
+				return c.Status(500).JSON(fiber.Map{"detail": msg})
+			}
+		}
+		return c.JSON(cfg.Collections.GetMeta(req.NewName))
 	}
 }
 

--- a/Levara/internal/http/collections_rename_test.go
+++ b/Levara/internal/http/collections_rename_test.go
@@ -1,0 +1,151 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stek0v/levara/internal/store"
+)
+
+// collections_rename_test.go — HTTP-surface coverage for
+// POST /collections/:name/rename. The underlying store.Rename behaviour
+// is covered by store/collections_test.go; this file pins the status-code
+// mapping the migration runbook relies on (404 → stop, 409 → name clash,
+// 400 → bad input, 200 → swapped).
+
+func newRenameApp(t *testing.T) (*fiber.App, *store.CollectionManager, func()) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "levara-http-rename-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	cm, err := store.NewCollectionManager(8, dir)
+	if err != nil {
+		os.RemoveAll(dir)
+		t.Fatalf("NewCollectionManager: %v", err)
+	}
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Post("/collections/:name/rename", collectionRenameHandler(APIConfig{Collections: cm}))
+	cleanup := func() {
+		_ = cm.Close()
+		os.RemoveAll(dir)
+	}
+	return app, cm, cleanup
+}
+
+func postRename(t *testing.T, app *fiber.App, name string, body any) (int, map[string]any) {
+	t.Helper()
+	var reader *bytes.Reader
+	if raw, ok := body.([]byte); ok {
+		reader = bytes.NewReader(raw)
+	} else {
+		b, _ := json.Marshal(body)
+		reader = bytes.NewReader(b)
+	}
+	r := httptest.NewRequest("POST", "/collections/"+name+"/rename", reader)
+	r.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(r, -1)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	buf, _ := io.ReadAll(resp.Body)
+	var out map[string]any
+	_ = json.Unmarshal(buf, &out)
+	return resp.StatusCode, out
+}
+
+func TestCollectionRenameHandler_HappyPath(t *testing.T) {
+	app, cm, cleanup := newRenameApp(t)
+	defer cleanup()
+
+	if err := cm.Create("orig"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	status, body := postRename(t, app, "orig", map[string]string{"new_name": "renamed"})
+	if status != 200 {
+		t.Fatalf("status=%d body=%v", status, body)
+	}
+	if name, _ := body["name"].(string); name != "renamed" {
+		t.Fatalf("response name=%v, want renamed", body["name"])
+	}
+	if !cm.Has("renamed") || cm.Has("orig") {
+		t.Fatalf("manager state wrong after rename: has renamed=%v has orig=%v",
+			cm.Has("renamed"), cm.Has("orig"))
+	}
+}
+
+func TestCollectionRenameHandler_NotFound(t *testing.T) {
+	app, _, cleanup := newRenameApp(t)
+	defer cleanup()
+
+	status, _ := postRename(t, app, "missing", map[string]string{"new_name": "whatever"})
+	if status != 404 {
+		t.Fatalf("status=%d, want 404", status)
+	}
+}
+
+func TestCollectionRenameHandler_Conflict(t *testing.T) {
+	app, cm, cleanup := newRenameApp(t)
+	defer cleanup()
+
+	_ = cm.Create("a")
+	_ = cm.Create("b")
+	status, _ := postRename(t, app, "a", map[string]string{"new_name": "b"})
+	if status != 409 {
+		t.Fatalf("status=%d, want 409", status)
+	}
+}
+
+func TestCollectionRenameHandler_IdenticalNames(t *testing.T) {
+	app, cm, cleanup := newRenameApp(t)
+	defer cleanup()
+
+	_ = cm.Create("same")
+	status, _ := postRename(t, app, "same", map[string]string{"new_name": "same"})
+	if status != 409 {
+		t.Fatalf("status=%d, want 409 for identical names", status)
+	}
+}
+
+func TestCollectionRenameHandler_InvalidName(t *testing.T) {
+	app, cm, cleanup := newRenameApp(t)
+	defer cleanup()
+
+	_ = cm.Create("src")
+	status, _ := postRename(t, app, "src", map[string]string{"new_name": "../escape"})
+	if status != 400 {
+		t.Fatalf("status=%d, want 400 for path-traversal name", status)
+	}
+}
+
+func TestCollectionRenameHandler_MissingNewName(t *testing.T) {
+	app, cm, cleanup := newRenameApp(t)
+	defer cleanup()
+
+	_ = cm.Create("src")
+	status, _ := postRename(t, app, "src", map[string]string{})
+	if status != 400 {
+		t.Fatalf("status=%d, want 400 for missing new_name", status)
+	}
+}
+
+func TestCollectionRenameHandler_NoCollections(t *testing.T) {
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Post("/collections/:name/rename", collectionRenameHandler(APIConfig{}))
+	r := httptest.NewRequest("POST", "/collections/foo/rename",
+		bytes.NewReader([]byte(`{"new_name":"bar"}`)))
+	r.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(r, -1)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	if resp.StatusCode != 503 {
+		t.Fatalf("status=%d, want 503 when Collections nil", resp.StatusCode)
+	}
+}

--- a/Levara/internal/http/reembed.go
+++ b/Levara/internal/http/reembed.go
@@ -4,6 +4,7 @@ package http
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -151,12 +152,18 @@ func reembedHandler(cfg APIConfig) fiber.Handler {
 			}
 			log.Printf("[reembed] %s → %s: %d records, model=%s", req.SourceCollection, req.TargetCollection, len(ids), model)
 
-			// 2. Extract text from metadata for re-embedding
+			// 2. Extract text from metadata for re-embedding.
+			// mem0 wraps payload as JSON-string of base64({"value":"…", …}). Without
+			// unwrapping, the shared envelope header dominates mean-pool embeddings
+			// (potion-code-16M) and distinct records collapse to near-identical vectors.
 			texts := make([]string, len(ids))
 			for i, meta := range metas {
+				if v, ok := unwrapMem0Envelope(meta); ok {
+					texts[i] = v
+					continue
+				}
 				var m map[string]any
 				if json.Unmarshal(meta, &m) == nil {
-					// Try common text fields
 					for _, key := range []string{"text", "name", "description", "content"} {
 						if v, ok := m[key].(string); ok && v != "" {
 							texts[i] = v
@@ -165,7 +172,7 @@ func reembedHandler(cfg APIConfig) fiber.Handler {
 					}
 				}
 				if texts[i] == "" {
-					texts[i] = string(meta) // fallback: raw metadata as text
+					texts[i] = string(meta)
 				}
 			}
 
@@ -287,4 +294,27 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// unwrapMem0Envelope returns the inner "value" field when meta is the
+// mem0 envelope shape: JSON-string-literal of base64 of
+// {"collection":"","key":"…","memory_id":"…","type":"…","value":"…"}.
+// Returns ok=false for any non-matching shape so the caller falls back
+// to the previous extraction path.
+func unwrapMem0Envelope(meta []byte) (string, bool) {
+	var b64 string
+	if err := json.Unmarshal(meta, &b64); err != nil {
+		return "", false
+	}
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return "", false
+	}
+	var env struct {
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil || env.Value == "" {
+		return "", false
+	}
+	return env.Value, true
 }

--- a/Levara/internal/http/reembed_test.go
+++ b/Levara/internal/http/reembed_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/stek0v/levara/internal/store"
@@ -149,5 +151,148 @@ func TestReembedStatus_UnknownRunReturns404(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != 404 {
 		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// fakeReembedEmbedServer mints deterministic dim=targetDim vectors for any
+// /v1/embeddings request. Pinned to OpenAI response shape so embed.Client
+// decodes cleanly. The vectors are non-zero and per-text distinguishable so
+// the test can later assert "target collection contains an embedding we
+// produced", not just "an embedding".
+func fakeReembedEmbedServer(t *testing.T, targetDim int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/embeddings" {
+			http.NotFound(w, r)
+			return
+		}
+		var req struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		var resp struct {
+			Data []struct {
+				Index     int       `json:"index"`
+				Embedding []float32 `json:"embedding"`
+			} `json:"data"`
+		}
+		for i, text := range req.Input {
+			vec := make([]float32, targetDim)
+			seed := float32(len(text) + i + 1)
+			for j := range vec {
+				vec[j] = seed + float32(j)/1000
+			}
+			resp.Data = append(resp.Data, struct {
+				Index     int       `json:"index"`
+				Embedding []float32 `json:"embedding"`
+			}{Index: i, Embedding: vec})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+// TestReembed_HappyPath_DimChange exercises the full async re-embed flow:
+// source coll has dim=8 records; reembed writes target with dim=4 from a
+// fake embed server. Verifies (a) target was created with the new dim,
+// (b) record count matches source, (c) source remains untouched (delete=false),
+// (d) status transitions RUNNING → COMPLETED with no failures.
+func TestReembed_HappyPath_DimChange(t *testing.T) {
+	const (
+		sourceDim = 8
+		targetDim = 4
+		numRecs   = 12
+	)
+
+	dir := t.TempDir()
+	cm, err := store.NewCollectionManager(sourceDim, dir)
+	if err != nil {
+		t.Fatalf("NewCollectionManager: %v", err)
+	}
+	defer cm.Close()
+
+	if err := cm.CreateWithMeta("src", "nomic-old", "cosine"); err != nil {
+		t.Fatalf("Create src: %v", err)
+	}
+	for i := 0; i < numRecs; i++ {
+		vec := make([]float32, sourceDim)
+		for j := range vec {
+			vec[j] = float32(i + 1)
+		}
+		meta := map[string]any{"text": "sample text " + string(rune('A'+i))}
+		metaBytes, _ := json.Marshal(meta)
+		if err := cm.Insert("src", "rec-"+string(rune('A'+i)), vec, json.RawMessage(metaBytes)); err != nil {
+			t.Fatalf("Insert rec-%d: %v", i, err)
+		}
+	}
+
+	srv := fakeReembedEmbedServer(t, targetDim)
+	defer srv.Close()
+
+	app := newReembedApp(t, APIConfig{
+		Collections:   cm,
+		EmbedEndpoint: srv.URL + "/v1/embeddings",
+		EmbedModel:    "potion-new",
+	})
+
+	status, body := reembedPost(t, app, reembedRequest{
+		SourceCollection: "src",
+		TargetCollection: "tgt",
+		BatchSize:        5,
+	})
+	if status != 200 {
+		t.Fatalf("POST /reembed status = %d, body=%v", status, body)
+	}
+	runID, _ := body["run_id"].(string)
+	if runID == "" {
+		t.Fatalf("missing run_id in response: %v", body)
+	}
+
+	// Poll status until COMPLETED or timeout.
+	deadline := time.Now().Add(5 * time.Second)
+	var final map[string]any
+	for time.Now().Before(deadline) {
+		resp, err := app.Test(httptest.NewRequest("GET", "/api/v1/reembed/"+runID+"/status", nil), -1)
+		if err != nil {
+			t.Fatalf("status GET: %v", err)
+		}
+		buf, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		_ = json.Unmarshal(buf, &final)
+		if s, _ := final["status"].(string); s == "COMPLETED" || s == "FAILED" {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	if got, _ := final["status"].(string); got != "COMPLETED" {
+		t.Fatalf("final status = %v, want COMPLETED; full=%v", got, final)
+	}
+	if got, _ := final["failed"].(float64); got != 0 {
+		t.Errorf("failed=%v, want 0", got)
+	}
+	if got, _ := final["processed"].(float64); int(got) != numRecs {
+		t.Errorf("processed=%v, want %d", got, numRecs)
+	}
+
+	if d := cm.Dim("tgt"); d != targetDim {
+		t.Errorf("target dim = %d, want %d", d, targetDim)
+	}
+	if d := cm.Dim("src"); d != sourceDim {
+		t.Errorf("source dim mutated: %d, want %d (delete_source=false)", d, sourceDim)
+	}
+	if !cm.Has("src") {
+		t.Errorf("source collection was dropped despite delete_source=false")
+	}
+
+	tgtIDs, _, _, err := cm.AllRecords("tgt")
+	if err != nil {
+		t.Fatalf("AllRecords tgt: %v", err)
+	}
+	if len(tgtIDs) != numRecs {
+		t.Errorf("target record count = %d, want %d", len(tgtIDs), numRecs)
 	}
 }

--- a/Levara/internal/http/reembed_test.go
+++ b/Levara/internal/http/reembed_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -140,6 +141,46 @@ func TestReembed_RequiresEmbedEndpointAndModel(t *testing.T) {
 	if status != 400 {
 		t.Errorf("status = %d, want 400", status)
 	}
+}
+
+func TestUnwrapMem0Envelope(t *testing.T) {
+	mkEnvelope := func(value string) []byte {
+		inner, _ := json.Marshal(map[string]string{
+			"collection": "", "key": "k", "memory_id": "id", "type": "t", "value": value,
+		})
+		b64 := base64.StdEncoding.EncodeToString(inner)
+		quoted, _ := json.Marshal(b64)
+		return quoted
+	}
+
+	t.Run("envelope with value extracts inner", func(t *testing.T) {
+		got, ok := unwrapMem0Envelope(mkEnvelope("hello world"))
+		if !ok || got != "hello world" {
+			t.Fatalf("got=%q ok=%v, want hello world/true", got, ok)
+		}
+	})
+	t.Run("empty value falls through", func(t *testing.T) {
+		if _, ok := unwrapMem0Envelope(mkEnvelope("")); ok {
+			t.Fatal("empty value must return ok=false")
+		}
+	})
+	t.Run("plain json object falls through", func(t *testing.T) {
+		if _, ok := unwrapMem0Envelope([]byte(`{"text":"hi"}`)); ok {
+			t.Fatal("plain map must return ok=false")
+		}
+	})
+	t.Run("plain string non-base64 falls through", func(t *testing.T) {
+		if _, ok := unwrapMem0Envelope([]byte(`"not base64!!"`)); ok {
+			t.Fatal("non-b64 string must return ok=false")
+		}
+	})
+	t.Run("base64 of non-envelope json falls through", func(t *testing.T) {
+		b64 := base64.StdEncoding.EncodeToString([]byte(`{"other":"x"}`))
+		quoted, _ := json.Marshal(b64)
+		if _, ok := unwrapMem0Envelope(quoted); ok {
+			t.Fatal("envelope without value must return ok=false")
+		}
+	})
 }
 
 func TestReembedStatus_UnknownRunReturns404(t *testing.T) {

--- a/Levara/internal/http/routes.go
+++ b/Levara/internal/http/routes.go
@@ -50,6 +50,7 @@ func RESTRouteInventory() []RouteSpec {
 		{Method: "DELETE", Path: "/collections/:name", Status: APICanonical, Group: "collections"},
 		{Method: "GET", Path: "/collections/:name/meta", Status: APICanonical, Group: "collections"},
 		{Method: "PUT", Path: "/collections/:name/meta", Status: APICanonical, Group: "collections"},
+		{Method: "POST", Path: "/collections/:name/rename", Status: APICanonical, Group: "collections"},
 		{Method: "GET", Path: "/models/rerank", Status: APICanonical, Group: "models"},
 		{Method: "POST", Path: "/reembed", Status: APICanonical, Group: "collections"},
 		{Method: "GET", Path: "/reembed/:runId/status", Status: APICanonical, Group: "collections"},

--- a/Levara/internal/store/collections.go
+++ b/Levara/internal/store/collections.go
@@ -230,6 +230,92 @@ func (cm *CollectionManager) Drop(name string) error {
 	return os.RemoveAll(colDir)
 }
 
+// Rename atomically renames a collection on disk. The collection is briefly
+// closed during the rename — readers/writers calling Get/Insert against the
+// old name during this window will see "not found" (the maps are updated
+// only after the on-disk rename + reopen succeeds). Used by the
+// blue-green embed-model migration (see docs/MIGRATION-EMBED-POTION.md
+// Phase 4.5) where the shadow collection is promoted to the live name
+// in a sub-second window.
+func (cm *CollectionManager) Rename(oldName, newName string) error {
+	if oldName == "" || newName == "" {
+		return fmt.Errorf("collection name must be non-empty")
+	}
+	if oldName == newName {
+		return fmt.Errorf("source and target names are identical: %q", oldName)
+	}
+	// Guard against path traversal. Collection names map directly to a
+	// directory under cm.basePath; a "../" or "/" in the name would let
+	// callers point Rename outside the collections root.
+	for _, n := range []string{oldName, newName} {
+		if strings.ContainsAny(n, "/\\") || n == "." || n == ".." || strings.Contains(n, "..") {
+			return fmt.Errorf("invalid collection name: %q", n)
+		}
+	}
+
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	db, exists := cm.collections[oldName]
+	if !exists {
+		return fmt.Errorf("collection %q not found", oldName)
+	}
+	if _, taken := cm.collections[newName]; taken {
+		return fmt.Errorf("target collection %q already exists", newName)
+	}
+
+	// Belt-and-braces: if the target directory exists on disk but isn't in
+	// our in-memory map, we'd happily clobber it with os.Rename. Refuse.
+	newDir := filepath.Join(cm.basePath, newName)
+	if _, err := os.Stat(newDir); err == nil {
+		return fmt.Errorf("target collection directory %q already exists on disk", newName)
+	}
+
+	// Close the live db to release WAL/disk file handles before renaming
+	// the directory. If reopen fails after rename, we restore the original
+	// state by renaming back — best-effort, since a failure here means the
+	// on-disk layout no longer matches the in-memory map.
+	if err := db.Close(); err != nil {
+		return fmt.Errorf("close source for rename: %w", err)
+	}
+	delete(cm.collections, oldName)
+
+	oldDir := filepath.Join(cm.basePath, oldName)
+	if err := os.Rename(oldDir, newDir); err != nil {
+		// Try to reopen the source under its old name so the manager isn't
+		// left with a dangling entry. If this fails too, the caller has a
+		// real on-disk problem and needs to restart.
+		dbPath := filepath.Join(oldDir, "meta.bin")
+		if reopened, rErr := NewLevara(db.dim, dbPath, cm.hnswCfg); rErr == nil {
+			cm.collections[oldName] = reopened
+		}
+		return fmt.Errorf("rename %q→%q on disk: %w", oldName, newName, err)
+	}
+
+	newDbPath := filepath.Join(newDir, "meta.bin")
+	reopened, err := NewLevara(db.dim, newDbPath, cm.hnswCfg)
+	if err != nil {
+		// Roll back the directory rename. If THAT fails, the collection is
+		// stranded under the new on-disk name but absent from the map —
+		// the operator will need to restart Levara so NewCollectionManager
+		// re-discovers it.
+		_ = os.Rename(newDir, oldDir)
+		return fmt.Errorf("reopen %q after rename: %w", newName, err)
+	}
+	cm.collections[newName] = reopened
+
+	// Update meta to reflect the new name. Old meta is removed from the
+	// map; the on-disk meta file is re-saved under the new directory.
+	if m, ok := cm.metas[oldName]; ok {
+		m.Name = newName
+		cm.metas[newName] = m
+		_ = saveCollectionMeta(newDir, m)
+	}
+	delete(cm.metas, oldName)
+
+	return nil
+}
+
 // List returns sorted collection names.
 func (cm *CollectionManager) List() []string {
 	cm.mu.RLock()

--- a/Levara/internal/store/collections_test.go
+++ b/Levara/internal/store/collections_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -117,6 +118,174 @@ func TestCollectionIsolation(t *testing.T) {
 	}
 	if len(movieResults) != 1 || movieResults[0].ID != "movie-1" {
 		t.Fatalf("movies search: got %v, want [movie-1]", movieResults)
+	}
+}
+
+func TestCollectionRename(t *testing.T) {
+	dir, _ := os.MkdirTemp("", "levara-rename-test-*")
+	defer os.RemoveAll(dir)
+
+	cm, err := NewCollectionManager(64, dir)
+	if err != nil {
+		t.Fatalf("NewCollectionManager: %v", err)
+	}
+	defer func() { _ = cm.Close() }()
+
+	if err := cm.Create("orig"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	vec := randVecForTest(64)
+	if err := cm.Insert("orig", "r1", vec, map[string]any{"text": "hello"}); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	// Happy path
+	if err := cm.Rename("orig", "renamed"); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	if cm.Has("orig") {
+		t.Fatal("old name should be gone after rename")
+	}
+	if !cm.Has("renamed") {
+		t.Fatal("new name should exist after rename")
+	}
+	results, err := cm.Search("renamed", vec, 10)
+	if err != nil {
+		t.Fatalf("Search renamed: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != "r1" {
+		t.Fatalf("Search after rename: got %v, want [r1]", results)
+	}
+	// On-disk directory moved (collections live under <dir>/collections/<name>)
+	if _, err := os.Stat(filepath.Join(dir, "collections", "orig")); !os.IsNotExist(err) {
+		t.Fatalf("old dir should be gone: err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "collections", "renamed")); err != nil {
+		t.Fatalf("new dir should exist: %v", err)
+	}
+	if meta := cm.GetMeta("renamed"); meta == nil || meta.Name != "renamed" {
+		t.Fatalf("meta.Name not updated: %+v", meta)
+	}
+
+	// Source not found
+	if err := cm.Rename("missing", "whatever"); err == nil {
+		t.Fatal("Rename of missing source should error")
+	}
+
+	// Target already exists (in-memory)
+	_ = cm.Create("other")
+	if err := cm.Rename("renamed", "other"); err == nil {
+		t.Fatal("Rename to existing target should error")
+	}
+
+	// Identical names
+	if err := cm.Rename("renamed", "renamed"); err == nil {
+		t.Fatal("Rename to identical name should error")
+	}
+
+	// Empty names
+	if err := cm.Rename("", "foo"); err == nil {
+		t.Fatal("Rename with empty source should error")
+	}
+	if err := cm.Rename("renamed", ""); err == nil {
+		t.Fatal("Rename with empty target should error")
+	}
+
+	// Path traversal
+	for _, bad := range []string{"../escape", "..", ".", "a/b", "a\\b"} {
+		if err := cm.Rename("renamed", bad); err == nil {
+			t.Fatalf("Rename to %q should error (path traversal guard)", bad)
+		}
+	}
+}
+
+func TestCollectionRenameSurvivesRestart(t *testing.T) {
+	dir, _ := os.MkdirTemp("", "levara-rename-restart-*")
+	defer os.RemoveAll(dir)
+
+	dim := 64
+
+	// Phase 1: create, insert, rename, close.
+	cm, err := NewCollectionManager(dim, dir)
+	if err != nil {
+		t.Fatalf("NewCollectionManager: %v", err)
+	}
+	if err := cm.Create("orig"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	vecs := make([][]float32, 10)
+	for i := 0; i < 10; i++ {
+		vecs[i] = randVecForTest(dim)
+		if err := cm.Insert("orig", fmt.Sprintf("rec-%d", i), vecs[i],
+			map[string]any{"index": i, "src": "orig"}); err != nil {
+			t.Fatalf("Insert %d: %v", i, err)
+		}
+	}
+	if err := cm.Rename("orig", "renamed"); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	if err := cm.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Phase 2: reopen — simulates Levara restart after a rename.
+	cm2, err := NewCollectionManager(dim, dir)
+	if err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	defer cm2.Close()
+
+	if !cm2.Has("renamed") {
+		t.Fatal("renamed collection should be loaded after restart")
+	}
+	if cm2.Has("orig") {
+		t.Fatal("orig collection should NOT come back after rename + restart")
+	}
+	db, err := cm2.Get("renamed")
+	if err != nil {
+		t.Fatalf("Get(renamed) failed after restart: %v", err)
+	}
+	if len(db.index) != 10 {
+		t.Fatalf("record count after restart: got %d, want 10", len(db.index))
+	}
+	// Every original vector should still be retrievable by ID via search.
+	for i := 0; i < 10; i++ {
+		results, err := cm2.Search("renamed", vecs[i], 1)
+		if err != nil {
+			t.Fatalf("Search rec-%d: %v", i, err)
+		}
+		if len(results) == 0 || results[0].ID != fmt.Sprintf("rec-%d", i) {
+			t.Fatalf("rec-%d: got %+v", i, results)
+		}
+	}
+	// Meta survived under the new name.
+	meta := cm2.GetMeta("renamed")
+	if meta == nil || meta.Name != "renamed" {
+		t.Fatalf("meta after restart: %+v", meta)
+	}
+}
+
+func TestCollectionRenameTargetDirOnDisk(t *testing.T) {
+	dir, _ := os.MkdirTemp("", "levara-rename-disk-test-*")
+	defer os.RemoveAll(dir)
+
+	cm, err := NewCollectionManager(64, dir)
+	if err != nil {
+		t.Fatalf("NewCollectionManager: %v", err)
+	}
+	defer func() { _ = cm.Close() }()
+
+	_ = cm.Create("src")
+	// Pre-existing target directory not tracked by the manager
+	if err := os.MkdirAll(filepath.Join(dir, "collections", "stale"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := cm.Rename("src", "stale"); err == nil {
+		t.Fatal("Rename should refuse to clobber existing on-disk directory")
+	}
+	// Source must remain functional after the refusal
+	if !cm.Has("src") {
+		t.Fatal("source should still exist after refused rename")
 	}
 }
 

--- a/Levara/pkg/orchestrator/pipeline.go
+++ b/Levara/pkg/orchestrator/pipeline.go
@@ -23,6 +23,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/stek0v/levara/pkg/chunker"
 	"github.com/stek0v/levara/pkg/bm25"
 	"github.com/stek0v/levara/pkg/classify"
@@ -211,12 +213,22 @@ func Run(ctx context.Context, texts []string, cfg Config, progressCh chan<- Prog
 
 	snapSentence := cfg.SnapToSentence == nil || *cfg.SnapToSentence // default true
 
+	// When the caller doesn't set DocumentID, derive a per-run prefix so
+	// chunk IDs from independent /cognify calls can't collide on the
+	// deterministic uuid5("doc-{i}-{chunkIndex}") path. Without this, two
+	// batches of N texts both produce docIDs "doc-0".."doc-N-1" and the
+	// HNSW upsert silently dedupes the second batch.
+	runPrefix := ""
+	if cfg.DocumentID == "" {
+		runPrefix = uuid.New().String()
+	}
+
 	var allChunks []indexedChunk
 	var allParentChunks []indexedChunk // parent chunks for parent-child mode
 	for i, text := range texts {
 		docID := cfg.DocumentID
 		if docID == "" {
-			docID = fmt.Sprintf("doc-%d", i)
+			docID = fmt.Sprintf("%s-doc-%d", runPrefix, i)
 		}
 
 		// Detect sections in source text

--- a/Raspberry/levara.service
+++ b/Raspberry/levara.service
@@ -1,53 +1,27 @@
+# Реальный деплой на Pi (10.23.0.53), node-id=pi1, проверено 2026-05-27.
+# Установка: /etc/systemd/system/levara.service (+ drop-in levara.service.d/rerank.conf).
 [Unit]
-Description=Levara Memory Server
-Documentation=https://github.com/stek0v/levara
+Description=Levara MCP Knowledge Engine
 After=network-online.target ollama.service
-Wants=network-online.target
-Requires=ollama.service
+Wants=network-online.target ollama.service
 
 [Service]
 Type=simple
-User=levara
-Group=levara
-
-EnvironmentFile=/etc/levara/levara.env
-
-ExecStart=/usr/local/bin/levara \
-    -standalone=true \
-    -dim=768 \
-    -shards=1 \
-    -port=8080 \
-    -grpc-port=0 \
-    -data-dir=/var/lib/levara/data
-
-ExecStartPost=/bin/sh -c 'sleep 3 && curl -sf http://localhost:8080/health > /dev/null || exit 1'
-
+User=stek0v
+WorkingDirectory=/home/stek0v/levara
+Environment=DB_PROVIDER=sqlite
+Environment=DB_PATH=/home/stek0v/levara/data/levara.db
+Environment=EMBEDDING_ENDPOINT=http://localhost:11434/v1/embeddings
+Environment=EMBEDDING_MODEL=nomic-embed-text-v2-moe
+Environment=LLM_PROVIDER=openai
+Environment=LLM_ENDPOINT=http://localhost:11434/v1
+Environment=LLM_MODEL=qwen3:0.6b
+Environment=VISION_ENDPOINT=http://10.23.0.101:8081/api/v1/ocr
+Environment=LOG_LEVEL=INFO
+ExecStartPre=/bin/sleep 5
+ExecStart=/home/stek0v/levara/levara -standalone=true -dim=768 -shards=1 -port=8090 -grpc-port=0 -data-dir=/home/stek0v/levara/data -node-id=pi1
 Restart=always
 RestartSec=5
-StartLimitIntervalSec=300
-StartLimitBurst=5
-
-# Watchdog
-WatchdogSec=30
-
-# Resource limits
-MemoryMax=2G
-MemoryHigh=1536M
-CPUQuota=300%
-LimitNOFILE=65536
-
-# Security hardening
-WorkingDirectory=/var/lib/levara
-ReadWritePaths=/var/lib/levara /var/log/levara
-ProtectSystem=strict
-ProtectHome=true
-PrivateTmp=true
-NoNewPrivileges=true
-
-# Logging
-StandardOutput=journal
-StandardError=journal
-SyslogIdentifier=levara
 
 [Install]
 WantedBy=multi-user.target

--- a/Raspberry/levara.service.d/rerank.conf
+++ b/Raspberry/levara.service.d/rerank.conf
@@ -1,0 +1,7 @@
+# Drop-in: /etc/systemd/system/levara.service.d/rerank.conf (живёт на Pi, проверено 2026-05-27).
+# Подключает reranker (mmini-L12-int8) к Levara.
+[Service]
+Environment=RERANK_ENDPOINT=http://localhost:9100/rerank
+Environment=RERANK_MODEL=mmini-L12-int8
+Environment=RERANK_BUDGET_MS=5000
+Environment=RERANK_TIMEOUT_MS=5000

--- a/deploy/bench/README.md
+++ b/deploy/bench/README.md
@@ -1,0 +1,86 @@
+# Bench stack on Pi (10.23.0.53)
+
+Isolated from production `levara.service` on :8090. Lifecycle controlled by
+`scripts/load-profiles/run_all_models.sh`.
+
+## Architecture
+
+| Service | Port | Notes |
+|---------|------|-------|
+| `embed-bench` | 9101 | FastAPI sidecar; serves `/v1/embeddings` for whatever model drop-in selects |
+| `levara-bench` | 8091 | Levara in sqlite mode; consumes embed-bench |
+
+`embed-bench` runs from `WorkingDirectory=/home/stek0v/embed-bench/scripts/load-profiles`
+so that `embed_bench` (the actual Python package directory) is importable directly.
+The uvicorn invocation is `uvicorn embed_bench.server:app` — **not**
+`scripts.load_profiles.embed_bench.server:app` (the latter would fail because
+`load-profiles` contains a hyphen and cannot be a Python package name).
+
+## One-time setup
+
+1. Sync the repo to the Pi:
+   ```bash
+   rsync -a --delete /Users/stek0v/src/levara/ stek0v@10.23.0.53:/home/stek0v/levara-source/
+   ```
+
+2. Cross-compile the Levara binary for arm64 and place it on the Pi:
+   ```bash
+   GOOS=linux GOARCH=arm64 go build -o levara-arm64 ./Levara/cmd/server
+   scp levara-arm64 stek0v@10.23.0.53:/home/stek0v/levara-bench/levara
+   ```
+
+3. Run the setup script (idempotent):
+   ```bash
+   ssh stek0v@10.23.0.53 bash -s < deploy/bench/setup_pi.sh
+   ```
+
+   The script:
+   - Creates `$EMBED_DIR/hf-cache` and `$BENCH_DIR/data`
+   - Creates a venv and installs `embed_bench/requirements.txt`
+   - Syncs `scripts/` into `$EMBED_DIR/scripts/`
+   - Generates a random `JWT_SECRET` drop-in for `levara-bench` (once)
+   - Installs both `.service` files and reloads systemd
+
+## Per-model run (three drop-ins)
+
+For each model under test, create three drop-ins then restart both units:
+
+```bash
+# 1. Tell embed-bench which model to load
+sudo mkdir -p /etc/systemd/system/embed-bench.service.d
+sudo tee /etc/systemd/system/embed-bench.service.d/model.conf >/dev/null <<EOF
+[Service]
+Environment=EMBED_BENCH_MODEL=nomic-ai/nomic-embed-text-v2-moe
+EOF
+
+# 2. Tell levara-bench which embedding model name to advertise
+sudo tee /etc/systemd/system/levara-bench.service.d/embed.conf >/dev/null <<EOF
+[Service]
+Environment=EMBEDDING_MODEL=nomic-embed-text-v2-moe
+EOF
+
+# 3. Override vector dimension if the model differs from the default
+sudo tee /etc/systemd/system/levara-bench.service.d/dim.conf >/dev/null <<EOF
+[Service]
+ExecStart=
+ExecStart=/home/stek0v/levara-bench/levara -standalone=true -port=8091 -grpc-port=0 -data-dir=/home/stek0v/levara-bench/data -node-id=pi-bench -dim=768
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl restart embed-bench levara-bench
+```
+
+Wait for embed-bench to finish downloading the model weights (check
+`journalctl -u embed-bench -f`) before running the benchmark suite.
+
+## Cleanup
+
+Stop both units to free memory:
+```bash
+sudo systemctl stop embed-bench levara-bench
+```
+
+Data persists in `/home/stek0v/levara-bench/data`. Remove manually for a fresh start:
+```bash
+rm -rf /home/stek0v/levara-bench/data && mkdir -p /home/stek0v/levara-bench/data
+```

--- a/deploy/bench/embed-bench.service
+++ b/deploy/bench/embed-bench.service
@@ -8,7 +8,7 @@ User=stek0v
 WorkingDirectory=/home/stek0v/embed-bench/scripts/load-profiles
 Environment=PYTHONUNBUFFERED=1
 Environment=HF_HOME=/home/stek0v/embed-bench/hf-cache
-ExecStart=/home/stek0v/embed-bench/venv/bin/uvicorn embed_bench.server:app --host 127.0.0.1 --port 9101 --workers 1
+ExecStart=/home/stek0v/embed-bench/venv/bin/uvicorn embed_bench.server:app --host 0.0.0.0 --port 9101 --workers 1
 Restart=on-failure
 RestartSec=3
 

--- a/deploy/bench/embed-bench.service
+++ b/deploy/bench/embed-bench.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Embed-bench sidecar (Levara load-profile model swap)
+After=network-online.target
+
+[Service]
+Type=simple
+User=stek0v
+WorkingDirectory=/home/stek0v/embed-bench/scripts/load-profiles
+Environment=PYTHONUNBUFFERED=1
+Environment=HF_HOME=/home/stek0v/embed-bench/hf-cache
+ExecStart=/home/stek0v/embed-bench/venv/bin/uvicorn embed_bench.server:app --host 127.0.0.1 --port 9101 --workers 1
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/bench/levara-bench.service
+++ b/deploy/bench/levara-bench.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Levara bench instance (model calibration)
+After=network-online.target embed-bench.service ollama.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=stek0v
+WorkingDirectory=/home/stek0v/levara-bench
+Environment=DB_PROVIDER=sqlite
+Environment=DB_PATH=/home/stek0v/levara-bench/data/levara.db
+Environment=EMBEDDING_ENDPOINT=http://127.0.0.1:9101/v1/embeddings
+Environment=LLM_PROVIDER=openai
+Environment=LLM_ENDPOINT=http://127.0.0.1:11434/v1
+Environment=LLM_MODEL=qwen3:0.6b
+Environment=RERANK_ENDPOINT=http://127.0.0.1:9100/rerank
+Environment=RERANK_MODEL=mmini-L12-int8
+Environment=RERANK_BUDGET_MS=5000
+Environment=LOG_LEVEL=INFO
+ExecStart=/home/stek0v/levara-bench/levara -standalone=true -port=8091 -grpc-port=0 -data-dir=/home/stek0v/levara-bench/data -node-id=pi-bench
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/bench/setup_pi.sh
+++ b/deploy/bench/setup_pi.sh
@@ -19,7 +19,7 @@ rsync -a --delete "$REPO_DIR/scripts/" "$EMBED_DIR/scripts/"
 
 JWT_FILE=/etc/systemd/system/levara-bench.service.d/jwt.conf
 if [ ! -f "$JWT_FILE" ]; then
-  SECRET=$(head -c 32 /dev/urandom | xxd -p -c 32)
+  SECRET=$(openssl rand -hex 32)
   sudo mkdir -p "$(dirname "$JWT_FILE")"
   sudo tee "$JWT_FILE" >/dev/null <<EOF
 [Service]

--- a/deploy/bench/setup_pi.sh
+++ b/deploy/bench/setup_pi.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# One-time Pi setup. Idempotent.
+# Usage: ssh stek0v@10.23.0.53 bash -s < deploy/bench/setup_pi.sh
+set -euo pipefail
+
+EMBED_DIR=/home/stek0v/embed-bench
+BENCH_DIR=/home/stek0v/levara-bench
+REPO_DIR=/home/stek0v/levara-source
+
+mkdir -p "$EMBED_DIR/hf-cache" "$BENCH_DIR/data"
+
+if [ ! -d "$EMBED_DIR/venv" ]; then
+  python3 -m venv "$EMBED_DIR/venv"
+fi
+"$EMBED_DIR/venv/bin/pip" install --upgrade pip
+"$EMBED_DIR/venv/bin/pip" install -r "$REPO_DIR/scripts/load-profiles/embed_bench/requirements.txt"
+
+rsync -a --delete "$REPO_DIR/scripts/" "$EMBED_DIR/scripts/"
+
+JWT_FILE=/etc/systemd/system/levara-bench.service.d/jwt.conf
+if [ ! -f "$JWT_FILE" ]; then
+  SECRET=$(head -c 32 /dev/urandom | xxd -p -c 32)
+  sudo mkdir -p "$(dirname "$JWT_FILE")"
+  sudo tee "$JWT_FILE" >/dev/null <<EOF
+[Service]
+Environment=JWT_SECRET=$SECRET
+EOF
+fi
+
+sudo install -m 0644 "$REPO_DIR/deploy/bench/embed-bench.service"  /etc/systemd/system/
+sudo install -m 0644 "$REPO_DIR/deploy/bench/levara-bench.service" /etc/systemd/system/
+sudo systemctl daemon-reload
+
+echo "[setup_pi.sh] OK. embed-bench + levara-bench installed (not enabled)."

--- a/docs/MIGRATION-EMBED-POTION.md
+++ b/docs/MIGRATION-EMBED-POTION.md
@@ -1,0 +1,365 @@
+# Migration runbook — embed model nomic-v2-moe → potion-code-16M
+
+**Target hosts:** prod Levara :8090 (71 collections), Pi 5 :8091 (bench).
+**Coexists with:** existing Qwen3 rerank stack on 10.23.0.64 (unchanged).
+**Decision basis:** Pi 5 calibration sweep, 2026-05-26.
+See [decision_embed_model_potion](../.claude/projects/-Users-stek0v-src-levara/memory/decision_embed_model_potion.md)
+and [load-profile-analysis-pi-multimodel.md](load-profile-analysis-pi-multimodel.md).
+
+Migrate the prod Levara embed model from `nomic-embed-text-v2-moe` (768d,
+torch+MoE) to `potion-code-16M` (256d, model2vec). Re-embed all 71 prod
+collections from chunk text stored in Postgres. **Blue-green per
+collection**: old `X` stays live while shadow `X__potion` is built and
+verified; cutover is atomic at the routing layer; old data retained 7
+days for rollback.
+
+Rollback at every step is explicit. **Nothing below modifies prod data
+irreversibly until Phase 4 step 5.**
+
+---
+
+## Why this migration
+
+| | nomic-v2-moe (current) | potion-code-16M (target) |
+|---|---|---|
+| dim | 768 | 256 |
+| params | 475M (MoE) | 16M |
+| backend | torch + transformers + einops | model2vec (pure numpy) |
+| works on Pi 5 8GB | no (systemd timeout on load) | yes (verified, sidecar :9101) |
+| p3 code corpus | n/a (not tested on Pi) | gap p50=0.079, zero_hits=0 |
+| p4/p5 NL corpus | n/a (not tested on Pi) | gap p50=0.050, top1 p50=0.30 |
+| HNSW memory | baseline | ~3× lower (dim ratio) |
+
+**Granite-97m was tested in the same sweep and returns zero hits on
+code corpora — disqualified for any prod role.** Don't substitute it.
+
+---
+
+## Phase 0 — Inventory + sanity (no writes anywhere)
+
+Before touching anything, snapshot prod state. All commands here are
+read-only against :8090.
+
+### 0.1 List collections + record counts
+
+```bash
+TOKEN=$(cat ~/.levara/prod-token)  # NEVER cat over SSH
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8090/api/v1/collections | jq '.[] | {name, record_count, embedding_model, embedding_dim}' \
+  > inventory-pre-migration.json
+```
+
+Verify: 71 entries, all with `embedding_dim: 768` and `embedding_model: nomic-*`.
+If any collection already has a non-768 dim, it pre-dates this migration
+and must be flagged out of scope.
+
+### 0.2 Smallest-first ordering
+
+```bash
+jq -r 'sort_by(.record_count) | .[] | "\(.record_count)\t\(.name)"' inventory-pre-migration.json
+```
+
+Migrate in ascending order of `record_count`. The first collection is
+the smoke-test; the largest is the last, when the runbook is proven.
+
+### 0.3 Pin a baseline query set per collection
+
+For each collection, save 10 representative queries + their current
+top-10 results from `POST /api/v1/search`. This is the **parity
+baseline** — Phase 3 will re-run them against the shadow collection.
+
+```bash
+mkdir -p baselines/
+for coll in $(jq -r '.[].name' inventory-pre-migration.json); do
+  ./scripts/reembed/snapshot_baseline.sh "$coll" > "baselines/${coll}.json"
+done
+```
+
+(Script needs to exist — see [Phase 1 deliverables](#phase-1-deliverables).
+It's read-only against prod.)
+
+---
+
+## Phase 1 — Build + verify on bench (no prod touch)
+
+Done locally and on Pi 5 :8091. Nothing here touches :8090.
+
+### 1.1 Deliverables (status)
+
+| | what | status |
+|---|---|---|
+| 1.1.a | `POST /api/v1/reembed` endpoint (read source → embed → write target) | ✅ exists, `internal/http/reembed.go` |
+| 1.1.b | Happy-path integration test (dim change, fake embed server) | ✅ done 2026-05-26, `internal/http/reembed_test.go::TestReembed_HappyPath_DimChange` |
+| 1.1.c | Parity-check script — `scripts/reembed/parity_check.py` | ✅ done 2026-05-26 |
+| 1.1.d | Baseline snapshot script — `scripts/reembed/snapshot_baseline.py` | ✅ done 2026-05-26 |
+| 1.1.e | Atomic rename support in Levara (see §1.3) | ✅ done 2026-05-26 — `POST /collections/:name/rename` (option A), store + handler tests green |
+| 1.1.f | Potion embed-server on prod-class host | ⏳ pending host decision |
+| 1.1.g | Real-data smoke via pg_dump of one prod collection | ⏳ pending user GO |
+
+### 1.2 Potion embed-server host
+
+Default per user decision 2026-05-26: amd64 prod host, model2vec
+backend, OpenAI-compatible `/v1/embeddings` interface (so existing
+`pkg/embed.Client` works unchanged). Sidecar service, separate port
+from prod Levara. Concrete deployment recipe TBD when host is
+provisioned.
+
+Pi 5 sidecar at :9101 stays as it is — useful for bench validation,
+not in the prod path.
+
+### 1.3 **BLOCKER**: atomic collection rename
+
+Phase 4 step 5 ("cutover") requires `rename(X__potion → X)` to be
+atomic. **Levara today has no rename endpoint.** Available collection
+ops:
+
+```
+GET    /api/v1/collections
+POST   /api/v1/collections
+DELETE /api/v1/collections/:name
+GET    /api/v1/collections/:name/meta
+PUT    /api/v1/collections/:name/meta
+POST   /api/v1/reembed
+```
+
+Three options to unblock:
+
+| option | what | cost | risk |
+|---|---|---|---|
+| **A. Add rename endpoint** | `POST /collections/:name/rename` → close Levara struct, `os.Rename` data dir, update metas map, reopen | 4-8h impl + tests; cleanest | rename-during-write races (need write lock) |
+| **B. Client-side alias** | Every consumer (mem0, cognee-plugin, MCP) gets new collection name `X__potion`. Old `X` retained read-only. No rename ever. | 0h Levara work, but N clients each need a config flip | fragile — easy to miss a consumer, drift across clients |
+| **C. Drop + recreate** | `DELETE X` then `reembed(source=X__potion → X)` — but source = old `X` is already gone. So really: copy `X__potion` records back into a new `X`. Not atomic — brief 404 window. | 1h | reads fail during gap; double the disk during overlap |
+
+**Recommendation: A.** B leaves the prod surface in a permanently
+inconsistent state (some collections suffixed, some not) and forces
+every future client to learn the convention. C is unsafe for live
+reads.
+
+A is a hard dependency for Phase 4 — must land + test before any
+prod cutover. Spec it as a separate PR.
+
+### 1.4 Parity threshold
+
+Each shadow collection must clear these thresholds vs the same
+queries against the live collection, or the cutover is blocked:
+
+| metric | threshold | rationale |
+|---|---|---|
+| Jaccard@10 | ≥ 0.6 | At least 6/10 top hits must overlap. Below this the search experience demonstrably changes — needs human review, not auto-migrate. |
+| Top-1 stability | ≥ 0.5 | At least half the queries return the same #1 hit. |
+| Empty-result rate | ≤ 5% | No more than 5% of queries return zero hits on the shadow (granite's failure mode — guard against unknown future regressions). |
+| p50 vector latency | ≤ 1.2× baseline | Potion should actually be **faster**; >1.2× means deploy regression. |
+
+These are starting points. After the first 3-4 collections clear them
+cleanly, revisit and tighten if everything is sailing through.
+
+---
+
+## Phase 2 — Pre-flight on prod (one read-only operation)
+
+### 2.1 pg_dump of one collection (requires user GO)
+
+Pick the smallest collection from §0.2. On prod host:
+
+```bash
+ssh prod 'pg_dump -Fc -t "<chunks_table>" \
+  --where="collection=\"<smallest_coll>\"" \
+  -U cognee cognee_db > /tmp/<coll>.dump'
+scp prod:/tmp/<coll>.dump bench:/tmp/
+ssh bench 'pg_restore --data-only --table=<chunks_table> /tmp/<coll>.dump'
+```
+
+This is the **only** prod operation in Phase 2 and is strictly
+read-only on prod.
+
+### 2.2 Smoke on real-shaped data
+
+On bench :8091, run the full Phase 4 sequence (sub-phases below) against
+the restored collection. Pass = parity thresholds clear. Fail = stop,
+debug, do not proceed to Phase 3.
+
+---
+
+## Phase 3 — Stage potion embed-server on prod host
+
+Deploy potion sidecar on the chosen amd64 prod host. Does **not**
+touch Levara :8090.
+
+```bash
+# On prod-amd64 host:
+systemctl start potion-embed.service  # binds :9102 (TBD)
+curl localhost:9102/v1/embeddings -d '{"input":["test"], "model":"potion-code-16M"}'
+# expect dim=256 vector
+```
+
+Gate: sidecar serves /v1/embeddings @ p50 < 50ms for batch=32 on
+prod-shaped text.
+
+---
+
+## Phase 4 — Per-collection migration (loop)
+
+For each collection in ascending record_count order, in a separate
+window with sign-off:
+
+### 4.1 Pre-flight
+
+```bash
+COLL=<name>
+SHADOW=${COLL}__potion
+ARCHIVE=${COLL}__nomic_archive_$(date +%Y%m%d)
+
+# Baseline snapshot
+./scripts/reembed/snapshot_baseline.sh "$COLL" > "baselines/${COLL}.json"
+
+# Confirm record count
+PRE_COUNT=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8090/api/v1/collections/${COLL}/meta | jq .record_count)
+```
+
+### 4.2 Reembed into shadow
+
+```bash
+RUN=$(curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8090/api/v1/reembed \
+  -d "{
+    \"source_collection\": \"${COLL}\",
+    \"target_collection\": \"${SHADOW}\",
+    \"target_model\": \"potion-code-16M\",
+    \"target_endpoint\": \"http://prod-amd64:9102/v1/embeddings\",
+    \"batch_size\": 64,
+    \"delete_source\": false
+  }" | jq -r .run_id)
+
+# Poll
+while true; do
+  STATUS=$(curl -s -H "Authorization: Bearer $TOKEN" \
+    http://localhost:8090/api/v1/reembed/${RUN}/status | jq -r .status)
+  [ "$STATUS" = "COMPLETED" ] && break
+  [ "$STATUS" = "FAILED" ] && { echo "REEMBED FAILED"; exit 1; }
+  sleep 5
+done
+```
+
+### 4.3 Validate shadow
+
+```bash
+SHADOW_COUNT=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8090/api/v1/collections/${SHADOW}/meta | jq .record_count)
+[ "$SHADOW_COUNT" = "$PRE_COUNT" ] || { echo "COUNT MISMATCH"; exit 1; }
+
+SHADOW_DIM=$(curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8090/api/v1/collections/${SHADOW}/meta | jq .embedding_dim)
+[ "$SHADOW_DIM" = "256" ] || { echo "DIM MISMATCH"; exit 1; }
+```
+
+### 4.4 Parity check
+
+```bash
+./scripts/reembed/parity_check.py \
+  --baseline "baselines/${COLL}.json" \
+  --shadow "${SHADOW}" \
+  --thresholds jaccard10=0.6,top1=0.5,empty=0.05 \
+  --target http://localhost:8090
+```
+
+Pass = Phase 4.5. Fail = stop, do not cut over, file issue with the
+diff report. Do NOT auto-rollback the shadow; keep it for inspection.
+
+### 4.5 Atomic cutover (requires §1.3 option A)
+
+```bash
+# Step 1: archive the current live collection
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8090/api/v1/collections/${COLL}/rename \
+  -d "{\"new_name\": \"${ARCHIVE}\"}"
+
+# Step 2: promote shadow to live
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8090/api/v1/collections/${SHADOW}/rename \
+  -d "{\"new_name\": \"${COLL}\"}"
+
+# Step 3: smoke 3 baseline queries against the new live collection
+./scripts/reembed/smoke.sh "${COLL}"
+```
+
+The window between step 1 and step 2 is the only moment when reads of
+`${COLL}` fail. Rename is local file-system level — sub-second.
+
+### 4.6 Post-cutover
+
+- Mark `${ARCHIVE}` with metadata `retention_until=NOW+7d` via `PUT
+  /collections/:name/meta`.
+- Update tracking doc with migration timestamp + parity numbers.
+
+### 4.7 Rollback (within 7 days of any single collection)
+
+```bash
+# Swap back
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8090/api/v1/collections/${COLL}/rename \
+  -d "{\"new_name\": \"${COLL}__potion_failed\"}"
+
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8090/api/v1/collections/${ARCHIVE}/rename \
+  -d "{\"new_name\": \"${COLL}\"}"
+```
+
+`${COLL}__potion_failed` retained for forensics.
+
+---
+
+## Phase 5 — System flip + cleanup
+
+After all 71 collections cleared Phase 4:
+
+1. Flip Levara `EMBEDDING_MODEL=potion-code-16M` and
+   `EMBEDDING_ENDPOINT=http://prod-amd64:9102/v1/embeddings` env on
+   the server's systemd drop-in. Restart prod :8090.
+   - New cognify writes will use potion.
+   - Old cognify scratch state migration: see §5.1.
+2. After 7 days of post-cutover stability, drop all
+   `*__nomic_archive_*` collections.
+3. Update `CLAUDE.md` Stack table to reflect potion as default.
+4. Update `pkg/embed/client.go` default model constant if it's hard-coded
+   anywhere (currently is — `text-embedding-3-small`; reembed migration
+   doesn't depend on it but new deploy templates should).
+5. Decommission nomic-v2-moe from amd64 host. Keep it in
+   `scripts/load-profiles/embed_bench/recipes.py` for future testing
+   only (e.g. when comparing against next-gen models).
+
+### 5.1 Cognify in-flight runs
+
+Cognify is async — there may be runs in flight when EMBEDDING_MODEL is
+flipped. Pre-flip:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8090/api/v1/cognify/runs | jq '.[] | select(.status=="RUNNING")'
+```
+
+Drain to zero before restart. Failed in-flight runs are recoverable
+via re-cognify after the flip.
+
+---
+
+## What's *not* in this runbook
+
+- mem0 + memoryfs client-side changes: they read collection names
+  unchanged thanks to §1.3 option A. If we pick B instead, those need
+  their own coordinated rollout.
+- Postgres schema changes: there are none — the dim change lives
+  entirely in Levara's HNSW data dir + metadata, chunks stay 1:1.
+- Multi-region: not in scope; prod is single-host today.
+
+---
+
+## Pre-Phase-2 checklist (must all be ✅ before any prod touch)
+
+- [x] §1.3 atomic rename endpoint shipped + tested (2026-05-26)
+- [x] §1.1.c parity script written (2026-05-26) — dry-run on bench data pending
+- [x] §1.1.d baseline snapshot script written (2026-05-26) — dry-run on bench data pending
+- [ ] §1.1.f potion embed-server reachable from prod Levara
+- [ ] §1.1.g user GO on pg_dump of one prod collection
+- [ ] §1.4 parity thresholds reviewed by user
+- [ ] Phase 2 smoke on real-data passes thresholds

--- a/docs/MIGRATION-EMBED-POTION.md
+++ b/docs/MIGRATION-EMBED-POTION.md
@@ -93,19 +93,35 @@ Done locally and on Pi 5 :8091. Nothing here touches :8090.
 | 1.1.c | Parity-check script — `scripts/reembed/parity_check.py` | ✅ done 2026-05-26 |
 | 1.1.d | Baseline snapshot script — `scripts/reembed/snapshot_baseline.py` | ✅ done 2026-05-26 |
 | 1.1.e | Atomic rename support in Levara (see §1.3) | ✅ done 2026-05-26 — `POST /collections/:name/rename` (option A), store + handler tests green |
-| 1.1.f | Potion embed-server on prod-class host | ⏳ pending host decision |
-| 1.1.g | Real-data smoke via pg_dump of one prod collection | ⏳ pending user GO |
+| 1.1.f | Potion embed-server on prod-class host | ✅ done 2026-05-26 — Pi :9101, systemd `embed-potion.service`, model2vec/potion-code-16M, 235MB RSS |
+| 1.1.g | Real-data smoke via pg_dump of one prod collection | ✅ done 2026-05-26 — see §2.1 (path adapted: Levara isn't pg-backed for vectors, smoke is HTTP-only) |
 
 ### 1.2 Potion embed-server host
 
-Default per user decision 2026-05-26: amd64 prod host, model2vec
-backend, OpenAI-compatible `/v1/embeddings` interface (so existing
-`pkg/embed.Client` works unchanged). Sidecar service, separate port
-from prod Levara. Concrete deployment recipe TBD when host is
-provisioned.
+**Decision 2026-05-26 (revised):** Pi 5 (`10.23.0.53:9101`).
+model2vec backend, OpenAI-compatible `/v1/embeddings`, same recipe
+as the Mac sidecar (`scripts/load-profiles/embed_bench/`). Pi already
+runs prod Levara :8090, so embed sidecar lives co-located on the same
+host — no network hop between Levara and the embedder during re-embed.
 
-Pi 5 sidecar at :9101 stays as it is — useful for bench validation,
-not in the prod path.
+Why Pi and not a separate amd64 host:
+- arm64 + model2vec works (verified on Mac arm64); single matmul, no
+  GPU needed.
+- Resident set ~270MB — fits Pi 5 RAM budget alongside Levara + mem0.
+- Existing rerank sidecar at :9100 establishes the pattern.
+- Avoids provisioning a new host for what is, post-migration, a steady
+  low-QPS service.
+
+Deployment recipe (executed 2026-05-26):
+1. `tar czf embed_bench-pi.tgz scripts/load-profiles/embed_bench/` (sans `.venv*` and `__pycache__`) + `scp` to Pi → extract at `~/embed_bench/`.
+2. On Pi: `python3 -m venv ~/embed_bench/.venv-potion && pip install fastapi==0.115.0 uvicorn==0.32.0 model2vec==0.4.0 numpy==1.26.4 pydantic==2.9.2` (pip CLI for uvicorn isn't dropped by default; service uses `python -m uvicorn`).
+3. Pre-warm: `python -c "from model2vec import StaticModel; StaticModel.from_pretrained('minishlab/potion-code-16M')"` (~1m HF download, cached in `~/.cache/huggingface`).
+4. systemd unit `/etc/systemd/system/embed-potion.service` — see §3.6. Loopback bind, `EMBED_BENCH_MODEL=potion`, `Restart=on-failure`, logs to `/var/log/embed-potion.log`, sandboxed (`ProtectSystem=strict`, `ProtectHome=read-only`, RW only on HF cache + log).
+5. Smoke verified: `curl 127.0.0.1:9101/health` on Pi → `{"model":"potion-code-16M","dim":256,"ram_mb":235,"backend":"model2vec"}`; `/v1/embeddings` returns 256-d vector.
+
+**Constraint:** sidecar MUST NOT share env or ports with Levara :8090.
+Independent process, independent systemd unit, independent venv. If
+the embedder OOMs or crashes loop, Levara stays untouched.
 
 ### 1.3 **BLOCKER**: atomic collection rename
 
@@ -157,20 +173,47 @@ cleanly, revisit and tighten if everything is sailing through.
 
 ## Phase 2 — Pre-flight on prod (one read-only operation)
 
-### 2.1 pg_dump of one collection (requires user GO)
+### 2.1 Real-data embed smoke (executed 2026-05-26)
 
-Pick the smallest collection from §0.2. On prod host:
+**Architecture correction:** the original pg_dump → pg_restore recipe
+doesn't apply — Levara stores vector data as arena/WAL/HNSW files on
+disk, not in a Postgres chunks table. The Postgres on 5433 holds only
+metadata (datasets, users, settings). Replacement smoke is HTTP-only:
 
 ```bash
-ssh prod 'pg_dump -Fc -t "<chunks_table>" \
-  --where="collection=\"<smallest_coll>\"" \
-  -U cognee cognee_db > /tmp/<coll>.dump'
-scp prod:/tmp/<coll>.dump bench:/tmp/
-ssh bench 'pg_restore --data-only --table=<chunks_table> /tmp/<coll>.dump'
+# 1. Inventory (read-only)
+curl http://10.23.0.53:8090/api/v1/collections | jq 'sort_by(.record_count)'
+
+# 2. Export smallest non-trivial collection (read-only on prod)
+curl http://10.23.0.53:8090/api/v1/sync/export/collection/_memories_default \
+  > mem-export.json
+
+# 3. Decode the corpus texts and embed via Pi:9101 (over SSH tunnel from Mac):
+ssh -fN -L 19101:127.0.0.1:9101 stek0v@10.23.0.53
+curl -X POST http://127.0.0.1:19101/v1/embeddings \
+  -d '{"input":[...10 decoded texts...],"model":"potion-code-16M"}'
 ```
 
-This is the **only** prod operation in Phase 2 and is strictly
-read-only on prod.
+**Smoke pass criteria (all green 2026-05-26 against `_memories_default`, 10 records):**
+- dim == 256 on every vector ✓
+- all values finite, L2 == 1.0 (model2vec normalises output) ✓
+- batch=10 latency 45.6ms (≈4.56ms/embed on arm64 Pi 5) ✓
+- distinct texts → distinct vectors (cos in [0.54, 0.88], no collapse) ✓
+- identical text twice → cos == 1.000000 (deterministic) ✓
+- duplicate records in source → identical embeddings ✓
+
+**Prod side-effects:** none. Source `_memories_default` unmodified;
+no shadow collection left behind.
+
+**Gotcha caught during smoke (`[[discovery-reembed-field-names]]`):**
+`/reembed` reads `target_model`, `target_endpoint`, `target_dim` —
+NOT `target_embedding_*`. Wrong field names silently fall back to the
+server's global embed config and produce a successful-looking run with
+the **original** model. Always verify the response payload's
+`target_model` and `dim 768→…` substring before trusting the run.
+
+This is the **only** prod operation in Phase 2 (export endpoint is
+read-only on prod).
 
 ### 2.2 Smoke on real-shaped data
 
@@ -359,7 +402,7 @@ via re-cognify after the flip.
 - [x] §1.3 atomic rename endpoint shipped + tested (2026-05-26)
 - [x] §1.1.c parity script written (2026-05-26) — dry-run on bench data pending
 - [x] §1.1.d baseline snapshot script written (2026-05-26) — dry-run on bench data pending
-- [ ] §1.1.f potion embed-server reachable from prod Levara
-- [ ] §1.1.g user GO on pg_dump of one prod collection
+- [x] §1.1.f potion embed-server reachable from prod Levara (Pi `127.0.0.1:9101`, systemd, 2026-05-26)
+- [x] §1.1.g real-data smoke on one prod collection (2026-05-26, HTTP path; pg_dump approach retired — see §2.1)
 - [ ] §1.4 parity thresholds reviewed by user
 - [ ] Phase 2 smoke on real-data passes thresholds

--- a/docs/load-profile-analysis-pi-multimodel.md
+++ b/docs/load-profile-analysis-pi-multimodel.md
@@ -1,0 +1,119 @@
+
+=== p4@bench (n=360) ===
+  zero_hits=0  top_changed=255 (71%)
+  score_gap_top_bottom: p25=0.0119 p50=0.0201 p75=0.0356 p90=0.0748 min=0.0072 max=0.1128
+  score_gap_top1_top2 : p25=0.0019 p50=0.0054 p75=0.0088 p90=0.0350 min=0.0001 max=0.0450
+  score_top1          : p25=0.691 p50=0.731 p75=0.760 p90=0.808 min=0.382 max=0.855
+  latency_ms no/with: p50 130/229  p95 169/289
+  rerank_outcome: {'reranked': 360}
+  query_kind: {'broad': 90, 'sharp': 60, 'ambiguous': 60, 'paraphrase': 60, 'incident': 30, 'ooc': 60}
+
+=== p5@bench (n=360) ===
+  zero_hits=0  top_changed=285 (79%)
+  score_gap_top_bottom: p25=0.0116 p50=0.0186 p75=0.0352 p90=0.0542 min=0.0051 max=0.0775
+  score_gap_top1_top2 : p25=0.0013 p50=0.0044 p75=0.0095 p90=0.0189 min=0.0002 max=0.0232
+  score_top1          : p25=0.650 p50=0.708 p75=0.751 p90=0.807 min=0.515 max=0.817
+  latency_ms no/with: p50 130/227  p95 203/313
+  rerank_outcome: {'reranked': 360}
+  query_kind: {'on-topic': 195, 'off-topic': 90, 'broad-room': 75}
+
+=== threshold sweep: %% of traffic where gap > T (rerank skipped) ===
+  T         p4@bench    p5@bench
+   0.020         50%         50%
+   0.030         33%         33%
+   0.040         21%         21%
+   0.050         21%         12%
+   0.060         12%          4%
+   0.070         12%          4%
+   0.080          4%          0%
+   0.100          4%          0%
+   0.130          0%          0%
+   0.160          0%          0%
+   0.200          0%          0%
+
+=== gate-wrong rate at T: %% of skipped queries where rerank WOULD have changed top ===
+  T             p4@bench        p5@bench
+   0.020  105/180 ( 58%)  135/180 ( 75%)
+   0.030   45/120 ( 38%)  105/120 ( 88%)
+   0.040   15/75  ( 20%)   60/75  ( 80%)
+   0.050   15/75  ( 20%)   45/45  (100%)
+   0.060   15/45  ( 33%)   15/15  (100%)
+   0.070   15/45  ( 33%)   15/15  (100%)
+   0.080    0/15  (  0%)               -
+   0.100    0/15  (  0%)               -
+   0.130               -               -
+   0.160               -               -
+   0.200               -               -
+
+=== recommendation scan ===
+       T   avg_skip%   avg_wrong%
+   0.020       50.0%        66.7%
+   0.030       33.3%        62.5%
+   0.040       20.8%        50.0%
+   0.050       16.7%        60.0%
+   0.060        8.3%        66.7%
+   0.070        8.3%        66.7%
+   0.080        2.1%         0.0%
+   0.100        2.1%         0.0%
+   0.130        0.0%         0.0%
+   0.160        0.0%         0.0%
+   0.200        0.0%         0.0%
+
+  no threshold meets both targets (skip>30%, wrong<25%) — leave gate off or widen the corpus
+
+=== model: granite (n=720) ===
+
+=== granite (n=720) ===
+  zero_hits=0  top_changed=540 (75%)
+  score_gap_top_bottom: p25=0.0117 p50=0.0201 p75=0.0353 p90=0.0560 min=0.0051 max=0.1128
+  score_gap_top1_top2 : p25=0.0013 p50=0.0045 p75=0.0092 p90=0.0229 min=0.0001 max=0.0450
+  score_top1          : p25=0.670 p50=0.719 p75=0.757 p90=0.808 min=0.382 max=0.855
+  latency_ms no/with: p50 130/228  p95 177/302
+  rerank_outcome: {'reranked': 720}
+  query_kind: {'broad': 90, 'sharp': 60, 'ambiguous': 60, 'paraphrase': 60, 'incident': 30, 'ooc': 60, 'on-topic': 195, 'off-topic': 90, 'broad-room': 75}
+
+=== threshold sweep: %% of traffic where gap > T (rerank skipped) ===
+  T          granite
+   0.020         50%
+   0.030         33%
+   0.040         21%
+   0.050         17%
+   0.060          8%
+   0.070          8%
+   0.080          2%
+   0.100          2%
+   0.130          0%
+   0.160          0%
+   0.200          0%
+
+=== model: potion (n=720) ===
+
+=== potion (n=720) ===
+  zero_hits=0  top_changed=495 (69%)
+  score_gap_top_bottom: p25=0.0293 p50=0.0505 p75=0.0881 p90=0.1087 min=0.0039 max=0.1764
+  score_gap_top1_top2 : p25=0.0063 p50=0.0171 p75=0.0326 p90=0.0665 min=0.0003 max=0.1262
+  score_top1          : p25=0.246 p50=0.299 p75=0.417 p90=0.535 min=0.023 max=0.737
+  latency_ms no/with: p50 51/167  p95 107/369
+  rerank_outcome: {'reranked': 720}
+  query_kind: {'broad': 90, 'sharp': 60, 'ambiguous': 60, 'paraphrase': 60, 'incident': 30, 'ooc': 60, 'on-topic': 195, 'off-topic': 90, 'broad-room': 75}
+
+=== threshold sweep: %% of traffic where gap > T (rerank skipped) ===
+  T           potion
+   0.020         85%
+   0.030         73%
+   0.040         62%
+   0.050         54%
+   0.060         46%
+   0.070         40%
+   0.080         27%
+   0.100         21%
+   0.130          6%
+   0.160          4%
+   0.200          0%
+
+## Cross-model comparison
+
+| model | n | mean_recall_top5 | top1_keyword_hit_rate | p50 gap | p50 lat_no_rerank_ms | p50 lat_with_rerank_ms |
+|---|---|---|---|---|---|---|
+| granite | 720 | 0.000 | 0.000 | 0.0201 | 130.0 | 228.0 |
+| potion | 720 | 0.000 | 0.000 | 0.0505 | 51.0 | 167.0 |

--- a/docs/load-profile-analysis-pi-multimodel.md
+++ b/docs/load-profile-analysis-pi-multimodel.md
@@ -1,10 +1,19 @@
 
+=== p3@bench (n=240) ===
+  zero_hits=240  top_changed=0 (0%)
+  score_gap_top_bottom: (no data)
+  score_gap_top1_top2 : (no data)
+  score_top1          : (no data)
+  latency_ms no/with: p50 159/159  p95 850/850
+  rerank_outcome: {'no_results': 240}
+  query_kind: {'code-precise': 60, 'concept-paraphrase': 60, 'mixed': 60, 'adversarial': 20, 'ooc': 40}
+
 === p4@bench (n=360) ===
   zero_hits=0  top_changed=255 (71%)
   score_gap_top_bottom: p25=0.0119 p50=0.0201 p75=0.0356 p90=0.0748 min=0.0072 max=0.1128
   score_gap_top1_top2 : p25=0.0019 p50=0.0054 p75=0.0088 p90=0.0350 min=0.0001 max=0.0450
   score_top1          : p25=0.691 p50=0.731 p75=0.760 p90=0.808 min=0.382 max=0.855
-  latency_ms no/with: p50 130/229  p95 169/289
+  latency_ms no/with: p50 161/271  p95 318/474
   rerank_outcome: {'reranked': 360}
   query_kind: {'broad': 90, 'sharp': 60, 'ambiguous': 60, 'paraphrase': 60, 'incident': 30, 'ooc': 60}
 
@@ -13,37 +22,37 @@
   score_gap_top_bottom: p25=0.0116 p50=0.0186 p75=0.0352 p90=0.0542 min=0.0051 max=0.0775
   score_gap_top1_top2 : p25=0.0013 p50=0.0044 p75=0.0095 p90=0.0189 min=0.0002 max=0.0232
   score_top1          : p25=0.650 p50=0.708 p75=0.751 p90=0.807 min=0.515 max=0.817
-  latency_ms no/with: p50 130/227  p95 203/313
+  latency_ms no/with: p50 156/257  p95 204/323
   rerank_outcome: {'reranked': 360}
   query_kind: {'on-topic': 195, 'off-topic': 90, 'broad-room': 75}
 
 === threshold sweep: %% of traffic where gap > T (rerank skipped) ===
-  T         p4@bench    p5@bench
-   0.020         50%         50%
-   0.030         33%         33%
-   0.040         21%         21%
-   0.050         21%         12%
-   0.060         12%          4%
-   0.070         12%          4%
-   0.080          4%          0%
-   0.100          4%          0%
-   0.130          0%          0%
-   0.160          0%          0%
-   0.200          0%          0%
+  T         p3@bench    p4@bench    p5@bench
+   0.020           -         50%         50%
+   0.030           -         33%         33%
+   0.040           -         21%         21%
+   0.050           -         21%         12%
+   0.060           -         12%          4%
+   0.070           -         12%          4%
+   0.080           -          4%          0%
+   0.100           -          4%          0%
+   0.130           -          0%          0%
+   0.160           -          0%          0%
+   0.200           -          0%          0%
 
 === gate-wrong rate at T: %% of skipped queries where rerank WOULD have changed top ===
-  T             p4@bench        p5@bench
-   0.020  105/180 ( 58%)  135/180 ( 75%)
-   0.030   45/120 ( 38%)  105/120 ( 88%)
-   0.040   15/75  ( 20%)   60/75  ( 80%)
-   0.050   15/75  ( 20%)   45/45  (100%)
-   0.060   15/45  ( 33%)   15/15  (100%)
-   0.070   15/45  ( 33%)   15/15  (100%)
-   0.080    0/15  (  0%)               -
-   0.100    0/15  (  0%)               -
-   0.130               -               -
-   0.160               -               -
-   0.200               -               -
+  T             p3@bench        p4@bench        p5@bench
+   0.020               -  105/180 ( 58%)  135/180 ( 75%)
+   0.030               -   45/120 ( 38%)  105/120 ( 88%)
+   0.040               -   15/75  ( 20%)   60/75  ( 80%)
+   0.050               -   15/75  ( 20%)   45/45  (100%)
+   0.060               -   15/45  ( 33%)   15/15  (100%)
+   0.070               -   15/45  ( 33%)   15/15  (100%)
+   0.080               -    0/15  (  0%)               -
+   0.100               -    0/15  (  0%)               -
+   0.130               -               -               -
+   0.160               -               -               -
+   0.200               -               -               -
 
 === recommendation scan ===
        T   avg_skip%   avg_wrong%
@@ -61,16 +70,16 @@
 
   no threshold meets both targets (skip>30%, wrong<25%) — leave gate off or widen the corpus
 
-=== model: granite (n=720) ===
+=== model: granite (n=960) ===
 
-=== granite (n=720) ===
-  zero_hits=0  top_changed=540 (75%)
+=== granite (n=960) ===
+  zero_hits=240  top_changed=540 (56%)
   score_gap_top_bottom: p25=0.0117 p50=0.0201 p75=0.0353 p90=0.0560 min=0.0051 max=0.1128
   score_gap_top1_top2 : p25=0.0013 p50=0.0045 p75=0.0092 p90=0.0229 min=0.0001 max=0.0450
   score_top1          : p25=0.670 p50=0.719 p75=0.757 p90=0.808 min=0.382 max=0.855
-  latency_ms no/with: p50 130/228  p95 177/302
-  rerank_outcome: {'reranked': 720}
-  query_kind: {'broad': 90, 'sharp': 60, 'ambiguous': 60, 'paraphrase': 60, 'incident': 30, 'ooc': 60, 'on-topic': 195, 'off-topic': 90, 'broad-room': 75}
+  latency_ms no/with: p50 159/252  p95 252/378
+  rerank_outcome: {'no_results': 240, 'reranked': 720}
+  query_kind: {'code-precise': 60, 'concept-paraphrase': 60, 'mixed': 60, 'adversarial': 20, 'ooc': 100, 'broad': 90, 'sharp': 60, 'ambiguous': 60, 'paraphrase': 60, 'incident': 30, 'on-topic': 195, 'off-topic': 90, 'broad-room': 75}
 
 === threshold sweep: %% of traffic where gap > T (rerank skipped) ===
   T          granite
@@ -86,34 +95,34 @@
    0.160          0%
    0.200          0%
 
-=== model: potion (n=720) ===
+=== model: potion (n=960) ===
 
-=== potion (n=720) ===
-  zero_hits=0  top_changed=495 (69%)
-  score_gap_top_bottom: p25=0.0293 p50=0.0505 p75=0.0881 p90=0.1087 min=0.0039 max=0.1764
-  score_gap_top1_top2 : p25=0.0063 p50=0.0171 p75=0.0326 p90=0.0665 min=0.0003 max=0.1262
-  score_top1          : p25=0.246 p50=0.299 p75=0.417 p90=0.535 min=0.023 max=0.737
-  latency_ms no/with: p50 51/167  p95 107/369
-  rerank_outcome: {'reranked': 720}
-  query_kind: {'broad': 90, 'sharp': 60, 'ambiguous': 60, 'paraphrase': 60, 'incident': 30, 'ooc': 60, 'on-topic': 195, 'off-topic': 90, 'broad-room': 75}
+=== potion (n=960) ===
+  zero_hits=0  top_changed=630 (66%)
+  score_gap_top_bottom: p25=0.0298 p50=0.0678 p75=0.1032 p90=0.1379 min=0.0030 max=0.2455
+  score_gap_top1_top2 : p25=0.0099 p50=0.0236 p75=0.0453 p90=0.0661 min=0.0003 max=0.1838
+  score_top1          : p25=0.221 p50=0.299 p75=0.416 p90=0.535 min=-0.047 max=0.737
+  latency_ms no/with: p50 81/243  p95 265/1346
+  rerank_outcome: {'reranked': 960}
+  query_kind: {'code-precise': 60, 'concept-paraphrase': 60, 'mixed': 60, 'adversarial': 20, 'ooc': 100, 'broad': 90, 'sharp': 60, 'ambiguous': 60, 'paraphrase': 60, 'incident': 30, 'on-topic': 195, 'off-topic': 90, 'broad-room': 75}
 
 === threshold sweep: %% of traffic where gap > T (rerank skipped) ===
   T           potion
-   0.020         85%
-   0.030         73%
-   0.040         62%
-   0.050         54%
-   0.060         46%
-   0.070         40%
-   0.080         27%
-   0.100         21%
-   0.130          6%
-   0.160          4%
-   0.200          0%
+   0.020         86%
+   0.030         75%
+   0.040         67%
+   0.050         58%
+   0.060         53%
+   0.070         45%
+   0.080         36%
+   0.100         27%
+   0.130         12%
+   0.160          5%
+   0.200          2%
 
 ## Cross-model comparison
 
 | model | n | mean_recall_top5 | top1_keyword_hit_rate | p50 gap | p50 lat_no_rerank_ms | p50 lat_with_rerank_ms |
 |---|---|---|---|---|---|---|
-| granite | 720 | 0.000 | 0.000 | 0.0201 | 130.0 | 228.0 |
-| potion | 720 | 0.000 | 0.000 | 0.0505 | 51.0 | 167.0 |
+| granite | 960 | 0.000 | 0.000 | 0.0124 | 159.0 | 252.0 |
+| potion | 960 | 0.000 | 0.000 | 0.0678 | 81.0 | 243.5 |

--- a/docs/superpowers/plans/2026-05-26-pi-embed-model-calibration-plan.md
+++ b/docs/superpowers/plans/2026-05-26-pi-embed-model-calibration-plan.md
@@ -1,0 +1,1681 @@
+# Pi 3-Embed-Model Honest Calibration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run granite-97m, jina-omni-nano, and potion-code-16M through the full Levara cognify pipeline on an isolated Pi bench instance, sequentially, to produce comparable calibration + retrieval-quality data.
+
+**Architecture:** New `embed-bench` FastAPI sidecar on Pi:9101 (one model loaded at a time). New `levara-bench` systemd unit on Pi:8091 (separate data-dir, separate JWT, drop-in `EMBEDDING_*` + `-dim` per model). Existing load-profile harness (`runner.py`, `seed/`, `analyze.py`) gets a `--model` axis. A `seed_one.py` helper seeds one collection via the full cognify pipeline. Orchestrator shell script sequences: stop → drop-in → start → preflight → seed → P4 + P5 runs → stop. After all three models complete, `analyze.py --by-model` writes the comparison doc.
+
+**Tech Stack:** Python 3.11 (FastAPI, transformers, model2vec, pytest), Bash (orchestration), systemd (services), Levara Go binary (unchanged from PR #85), ssh/scp (deployment), Ollama (LLM for cognify), qwen3:0.6b (entity extraction).
+
+---
+
+## File map
+
+**Create:**
+- `scripts/load-profiles/embed_bench/__init__.py`
+- `scripts/load-profiles/embed_bench/recipes.py`
+- `scripts/load-profiles/embed_bench/backends.py`
+- `scripts/load-profiles/embed_bench/server.py`
+- `scripts/load-profiles/embed_bench/requirements.txt`
+- `scripts/load-profiles/embed_bench/tests/__init__.py`
+- `scripts/load-profiles/embed_bench/tests/test_recipes.py`
+- `scripts/load-profiles/embed_bench/tests/test_backends.py`
+- `scripts/load-profiles/embed_bench/tests/test_server.py`
+- `scripts/load-profiles/preflight_model.py`
+- `scripts/load-profiles/seed_one.py`
+- `scripts/load-profiles/run_all_models.sh`
+- `scripts/load-profiles/tests/__init__.py`
+- `scripts/load-profiles/tests/test_preflight.py`
+- `scripts/load-profiles/tests/test_keyword_metrics.py`
+- `scripts/load-profiles/tests/test_analyze_by_model.py`
+- `deploy/bench/embed-bench.service`
+- `deploy/bench/levara-bench.service`
+- `deploy/bench/setup_pi.sh`
+- `deploy/bench/README.md`
+
+**Modify:**
+- `scripts/load-profiles/runner.py` — keyword_metrics() helper
+- `scripts/load-profiles/p4_memory_palace.py` — `--model`, `--embed-dim`, `--collection-override`
+- `scripts/load-profiles/p5_filtered_search.py` — same flags
+- `scripts/load-profiles/seed/code_corpus.py` — `seed_via_cognify()` pathway
+- `scripts/load-profiles/analyze.py` — `--by-model` group
+
+---
+
+## Task 1: Recipes registry (TDD)
+
+The recipe maps a short model name → `{repo, backend, dim, openai_name}`. Drives the sidecar and orchestrator.
+
+**Files:**
+- Create: `scripts/load-profiles/embed_bench/__init__.py`
+- Create: `scripts/load-profiles/embed_bench/recipes.py`
+- Create: `scripts/load-profiles/embed_bench/tests/__init__.py`
+- Create: `scripts/load-profiles/embed_bench/tests/test_recipes.py`
+
+- [ ] **Step 1: Create empty package markers**
+
+```bash
+mkdir -p scripts/load-profiles/embed_bench/tests
+touch scripts/load-profiles/embed_bench/__init__.py
+touch scripts/load-profiles/embed_bench/tests/__init__.py
+```
+
+- [ ] **Step 2: Write failing test**
+
+Create `scripts/load-profiles/embed_bench/tests/test_recipes.py`:
+
+```python
+import pytest
+
+from scripts.load_profiles.embed_bench.recipes import RECIPES, get_recipe
+
+
+def test_three_recipes_present():
+    assert set(RECIPES.keys()) == {"potion", "granite", "jina"}
+
+
+def test_potion_recipe_shape():
+    r = get_recipe("potion")
+    assert r.repo == "minishlab/potion-code-16M"
+    assert r.backend == "model2vec"
+    assert r.dim == 256
+    assert r.openai_name == "potion-code-16M"
+
+
+def test_granite_recipe_shape():
+    r = get_recipe("granite")
+    assert r.repo == "ibm-granite/granite-embedding-97m-multilingual-r2"
+    assert r.backend == "transformers"
+    assert r.dim == 384
+    assert r.openai_name == "granite-97m-multilingual-r2"
+
+
+def test_jina_recipe_shape():
+    r = get_recipe("jina")
+    assert r.repo == "jinaai/jina-embeddings-v5-omni-nano"
+    assert r.backend == "transformers"
+    assert r.dim == 512
+    assert r.openai_name == "jina-omni-nano"
+    assert r.trust_remote_code is True
+
+
+def test_unknown_recipe_raises():
+    with pytest.raises(KeyError):
+        get_recipe("nope")
+```
+
+- [ ] **Step 3: Run test, verify FAIL**
+
+Run: `python -m pytest scripts/load-profiles/embed_bench/tests/test_recipes.py -v`
+Expected: FAIL with ModuleNotFoundError.
+
+- [ ] **Step 4: Implement**
+
+Create `scripts/load-profiles/embed_bench/recipes.py`:
+
+```python
+"""Model recipes for the embed-bench sidecar.
+
+Each recipe records the HuggingFace repo, the backend name (consumed by
+backends.py), the expected output dimension (consumed by preflight and
+collection creation), and the model name to advertise in OpenAI-style
+embedding responses (so cognify accepts our /v1/embeddings).
+"""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Recipe:
+    short: str
+    repo: str
+    backend: str  # "transformers" | "model2vec"
+    dim: int
+    openai_name: str
+    trust_remote_code: bool = False
+
+
+RECIPES: dict[str, Recipe] = {
+    "potion": Recipe(
+        short="potion",
+        repo="minishlab/potion-code-16M",
+        backend="model2vec",
+        dim=256,
+        openai_name="potion-code-16M",
+    ),
+    "granite": Recipe(
+        short="granite",
+        repo="ibm-granite/granite-embedding-97m-multilingual-r2",
+        backend="transformers",
+        dim=384,
+        openai_name="granite-97m-multilingual-r2",
+    ),
+    "jina": Recipe(
+        short="jina",
+        repo="jinaai/jina-embeddings-v5-omni-nano",
+        backend="transformers",
+        dim=512,
+        openai_name="jina-omni-nano",
+        trust_remote_code=True,
+    ),
+}
+
+
+def get_recipe(short: str) -> Recipe:
+    if short not in RECIPES:
+        raise KeyError(f"unknown model short name: {short!r}; known: {sorted(RECIPES)}")
+    return RECIPES[short]
+```
+
+Note on dims: dims are best-effort from model cards. The dim probe in `backends.py` (Task 2) raises if reality disagrees — fix the recipe and re-run.
+
+- [ ] **Step 5: Run test, verify PASS**
+
+Run: `python -m pytest scripts/load-profiles/embed_bench/tests/test_recipes.py -v`
+Expected: 5 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/load-profiles/embed_bench/__init__.py \
+        scripts/load-profiles/embed_bench/tests/__init__.py \
+        scripts/load-profiles/embed_bench/recipes.py \
+        scripts/load-profiles/embed_bench/tests/test_recipes.py
+git commit -m "feat(embed-bench): add model recipe registry"
+```
+
+---
+
+## Task 2: Backend protocol (Transformers + Model2Vec) (TDD)
+
+Two backends behind a shared protocol exposing `dim` + `embed(list[str]) -> list[list[float]]`.
+
+**Files:**
+- Create: `scripts/load-profiles/embed_bench/backends.py`
+- Create: `scripts/load-profiles/embed_bench/requirements.txt`
+- Create: `scripts/load-profiles/embed_bench/tests/test_backends.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `scripts/load-profiles/embed_bench/tests/test_backends.py`:
+
+```python
+"""Backend tests. Skipped when the HF cache lacks the model files."""
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.load_profiles.embed_bench.backends import make_backend
+from scripts.load_profiles.embed_bench.recipes import get_recipe
+
+
+def _cache_has(repo: str) -> bool:
+    hf_home = Path(os.environ.get("HF_HOME", Path.home() / ".cache" / "huggingface"))
+    safe = repo.replace("/", "--")
+    return (hf_home / "hub" / f"models--{safe}").exists()
+
+
+@pytest.mark.parametrize("short", ["potion", "granite", "jina"])
+def test_backend_dim_matches_recipe(short):
+    recipe = get_recipe(short)
+    if not _cache_has(recipe.repo):
+        pytest.skip(f"HF cache missing for {recipe.repo}")
+    backend = make_backend(recipe)
+    assert backend.dim == recipe.dim
+
+
+@pytest.mark.parametrize("short", ["potion", "granite", "jina"])
+def test_backend_embed_returns_correct_shape(short):
+    recipe = get_recipe(short)
+    if not _cache_has(recipe.repo):
+        pytest.skip(f"HF cache missing for {recipe.repo}")
+    backend = make_backend(recipe)
+    out = backend.embed(["hello world", "another query"])
+    assert len(out) == 2
+    assert len(out[0]) == recipe.dim
+    assert all(isinstance(x, float) for x in out[0])
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+Run: `python -m pytest scripts/load-profiles/embed_bench/tests/test_backends.py -v`
+Expected: ModuleNotFoundError.
+
+- [ ] **Step 3: Implement**
+
+Create `scripts/load-profiles/embed_bench/backends.py`:
+
+```python
+"""Embedding backends.
+
+TransformersBackend: HuggingFace AutoModel + AutoTokenizer; mean-pools the
+last hidden state with attention mask, then L2-normalizes.
+
+Model2VecBackend: minishlab/model2vec StaticModel (single matmul, sub-ms).
+"""
+from __future__ import annotations
+
+from typing import Protocol
+
+import numpy as np
+
+from .recipes import Recipe
+
+
+class Backend(Protocol):
+    dim: int
+
+    def embed(self, texts: list[str]) -> list[list[float]]: ...
+
+
+class TransformersBackend:
+    def __init__(self, recipe: Recipe):
+        from transformers import AutoModel, AutoTokenizer
+        import torch
+
+        self._torch = torch
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            recipe.repo, trust_remote_code=recipe.trust_remote_code
+        )
+        self.model = AutoModel.from_pretrained(
+            recipe.repo, trust_remote_code=recipe.trust_remote_code
+        )
+        self.model.eval()
+        with torch.no_grad():
+            inputs = self.tokenizer(["dim probe"], padding=True, truncation=True, return_tensors="pt")
+            out = self.model(**inputs)
+            pooled = self._mean_pool(out.last_hidden_state, inputs["attention_mask"])
+            self.dim = pooled.shape[-1]
+        if self.dim != recipe.dim:
+            raise ValueError(
+                f"recipe dim mismatch: {recipe.repo} produced {self.dim}-d, "
+                f"recipe said {recipe.dim}"
+            )
+
+    def _mean_pool(self, last_hidden_state, attention_mask):
+        mask = attention_mask.unsqueeze(-1).float()
+        summed = (last_hidden_state * mask).sum(dim=1)
+        counts = mask.sum(dim=1).clamp(min=1e-9)
+        return summed / counts
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        with self._torch.no_grad():
+            inputs = self.tokenizer(
+                texts, padding=True, truncation=True, max_length=512, return_tensors="pt"
+            )
+            out = self.model(**inputs)
+            pooled = self._mean_pool(out.last_hidden_state, inputs["attention_mask"])
+            normed = self._torch.nn.functional.normalize(pooled, p=2, dim=1)
+            return normed.cpu().tolist()
+
+
+class Model2VecBackend:
+    def __init__(self, recipe: Recipe):
+        from model2vec import StaticModel
+
+        self.model = StaticModel.from_pretrained(recipe.repo)
+        probe = self.model.encode(["dim probe"])
+        self.dim = int(np.asarray(probe).shape[-1])
+        if self.dim != recipe.dim:
+            raise ValueError(
+                f"recipe dim mismatch: {recipe.repo} produced {self.dim}-d, "
+                f"recipe said {recipe.dim}"
+            )
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        arr = self.model.encode(texts)
+        return np.asarray(arr).astype(float).tolist()
+
+
+def make_backend(recipe: Recipe) -> Backend:
+    if recipe.backend == "transformers":
+        return TransformersBackend(recipe)
+    if recipe.backend == "model2vec":
+        return Model2VecBackend(recipe)
+    raise ValueError(f"unknown backend {recipe.backend!r}")
+```
+
+- [ ] **Step 4: Create requirements.txt**
+
+Create `scripts/load-profiles/embed_bench/requirements.txt`:
+
+```
+fastapi==0.115.0
+uvicorn[standard]==0.32.0
+transformers==4.46.0
+torch==2.4.1
+model2vec==0.4.0
+numpy==1.26.4
+pydantic==2.9.2
+```
+
+- [ ] **Step 5: Run test, verify PASS (or skip cleanly)**
+
+Run: `python -m pytest scripts/load-profiles/embed_bench/tests/test_backends.py -v`
+Expected (dev box without HF cache): 6 SKIPPED. On Pi after prefetch: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/load-profiles/embed_bench/backends.py \
+        scripts/load-profiles/embed_bench/tests/test_backends.py \
+        scripts/load-profiles/embed_bench/requirements.txt
+git commit -m "feat(embed-bench): transformers + model2vec backends with dim probe"
+```
+
+---
+
+## Task 3: FastAPI sidecar server (TDD)
+
+OpenAI-compatible `POST /v1/embeddings` + `GET /health`. Loads ONE recipe from `EMBED_BENCH_MODEL` at startup.
+
+**Files:**
+- Create: `scripts/load-profiles/embed_bench/server.py`
+- Create: `scripts/load-profiles/embed_bench/tests/test_server.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `scripts/load-profiles/embed_bench/tests/test_server.py`:
+
+```python
+"""Server tests use a fake backend; no model files needed."""
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ["EMBED_BENCH_FAKE_DIM"] = "8"
+os.environ["EMBED_BENCH_MODEL"] = "_fake"
+
+from scripts.load_profiles.embed_bench.server import build_app  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    return TestClient(build_app())
+
+
+def test_health_returns_model_dim_backend(client):
+    r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["model"] == "_fake"
+    assert body["dim"] == 8
+    assert body["backend"] == "fake"
+    assert isinstance(body["ram_mb"], int)
+
+
+def test_embeddings_returns_openai_shape(client):
+    r = client.post("/v1/embeddings", json={"input": ["a", "b"], "model": "_fake"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["model"] == "_fake"
+    assert len(body["data"]) == 2
+    assert len(body["data"][0]["embedding"]) == 8
+    assert body["data"][0]["index"] == 0
+
+
+def test_embeddings_accepts_single_string(client):
+    r = client.post("/v1/embeddings", json={"input": "single", "model": "_fake"})
+    assert r.status_code == 200
+    assert len(r.json()["data"]) == 1
+
+
+def test_embeddings_empty_input_returns_400(client):
+    r = client.post("/v1/embeddings", json={"input": [], "model": "_fake"})
+    assert r.status_code == 400
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+Run: `python -m pytest scripts/load-profiles/embed_bench/tests/test_server.py -v`
+
+- [ ] **Step 3: Implement**
+
+Create `scripts/load-profiles/embed_bench/server.py`:
+
+```python
+"""Embed-bench FastAPI sidecar.
+
+Reads EMBED_BENCH_MODEL at startup (e.g. "potion" | "granite" | "jina"),
+resolves the recipe, instantiates the backend, exposes:
+
+  GET  /health           -> {model, dim, ram_mb, backend}
+  POST /v1/embeddings    -> OpenAI-compatible
+
+Fake mode (unit tests only): EMBED_BENCH_MODEL=_fake + EMBED_BENCH_FAKE_DIM=N.
+"""
+from __future__ import annotations
+
+import os
+import resource
+from typing import Union
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .backends import make_backend
+from .recipes import get_recipe
+
+
+class EmbedRequest(BaseModel):
+    input: Union[str, list[str]]
+    model: str | None = None
+
+
+def _ram_mb() -> int:
+    return int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
+
+
+class _FakeBackend:
+    def __init__(self, dim: int):
+        self.dim = dim
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[float((hash(t) + i) % 7) / 7.0 for i in range(self.dim)] for t in texts]
+
+
+def build_app() -> FastAPI:
+    model_short = os.environ.get("EMBED_BENCH_MODEL", "")
+    if not model_short:
+        raise RuntimeError("EMBED_BENCH_MODEL env required")
+
+    if model_short == "_fake":
+        backend = _FakeBackend(int(os.environ.get("EMBED_BENCH_FAKE_DIM", "8")))
+        openai_name = "_fake"
+        backend_name = "fake"
+    else:
+        recipe = get_recipe(model_short)
+        backend = make_backend(recipe)
+        openai_name = recipe.openai_name
+        backend_name = recipe.backend
+
+    app = FastAPI(title="embed-bench", version="1")
+
+    @app.get("/health")
+    def health() -> dict:
+        return {
+            "model": openai_name,
+            "dim": backend.dim,
+            "ram_mb": _ram_mb(),
+            "backend": backend_name,
+        }
+
+    @app.post("/v1/embeddings")
+    def embeddings(req: EmbedRequest) -> dict:
+        texts = [req.input] if isinstance(req.input, str) else req.input
+        if not texts:
+            raise HTTPException(status_code=400, detail="input must not be empty")
+        vectors = backend.embed(texts)
+        return {
+            "model": openai_name,
+            "data": [{"embedding": v, "index": i} for i, v in enumerate(vectors)],
+            "object": "list",
+        }
+
+    return app
+
+
+app = build_app() if os.environ.get("EMBED_BENCH_MODEL") else None
+```
+
+- [ ] **Step 4: Run test, verify PASS**
+
+Run: `python -m pytest scripts/load-profiles/embed_bench/tests/test_server.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/load-profiles/embed_bench/server.py \
+        scripts/load-profiles/embed_bench/tests/test_server.py
+git commit -m "feat(embed-bench): FastAPI sidecar with OpenAI /v1/embeddings"
+```
+
+---
+
+## Task 4: Pi deployment artifacts
+
+Two systemd units + setup script. No unit tests — validated by Task 11 smoke.
+
+**Files:**
+- Create: `deploy/bench/embed-bench.service`
+- Create: `deploy/bench/levara-bench.service`
+- Create: `deploy/bench/setup_pi.sh`
+- Create: `deploy/bench/README.md`
+
+- [ ] **Step 1: Create embed-bench systemd unit**
+
+Create `deploy/bench/embed-bench.service`:
+
+```ini
+[Unit]
+Description=Embed-bench sidecar (Levara load-profile model swap)
+After=network-online.target
+
+[Service]
+Type=simple
+User=stek0v
+WorkingDirectory=/home/stek0v/embed-bench
+Environment=PYTHONUNBUFFERED=1
+Environment=HF_HOME=/home/stek0v/embed-bench/hf-cache
+ExecStart=/home/stek0v/embed-bench/venv/bin/uvicorn \
+  scripts.load_profiles.embed_bench.server:app \
+  --host 127.0.0.1 --port 9101 --workers 1
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`EMBED_BENCH_MODEL` is provided via drop-in `/etc/systemd/system/embed-bench.service.d/model.conf` written by the orchestrator.
+
+- [ ] **Step 2: Create levara-bench systemd unit**
+
+Create `deploy/bench/levara-bench.service`:
+
+```ini
+[Unit]
+Description=Levara bench instance (model calibration)
+After=network-online.target embed-bench.service ollama.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=stek0v
+WorkingDirectory=/home/stek0v/levara-bench
+Environment=DB_PROVIDER=sqlite
+Environment=DB_PATH=/home/stek0v/levara-bench/data/levara.db
+Environment=EMBEDDING_ENDPOINT=http://127.0.0.1:9101/v1/embeddings
+Environment=LLM_PROVIDER=openai
+Environment=LLM_ENDPOINT=http://127.0.0.1:11434/v1
+Environment=LLM_MODEL=qwen3:0.6b
+Environment=RERANK_ENDPOINT=http://127.0.0.1:9100/rerank
+Environment=RERANK_MODEL=mmini-L12-int8
+Environment=RERANK_BUDGET_MS=5000
+Environment=LOG_LEVEL=INFO
+ExecStart=/home/stek0v/levara-bench/levara -standalone=true -port=8091 -grpc-port=0 \
+  -data-dir=/home/stek0v/levara-bench/data -node-id=pi-bench
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`JWT_SECRET`, `EMBEDDING_MODEL`, and `-dim` are provided via drop-ins.
+
+- [ ] **Step 3: Create setup script**
+
+Create `deploy/bench/setup_pi.sh`:
+
+```bash
+#!/usr/bin/env bash
+# One-time Pi setup. Idempotent.
+# Usage: ssh stek0v@10.23.0.53 bash -s < deploy/bench/setup_pi.sh
+set -euo pipefail
+
+EMBED_DIR=/home/stek0v/embed-bench
+BENCH_DIR=/home/stek0v/levara-bench
+REPO_DIR=/home/stek0v/levara-source
+
+mkdir -p "$EMBED_DIR/hf-cache" "$BENCH_DIR/data"
+
+if [ ! -d "$EMBED_DIR/venv" ]; then
+  python3 -m venv "$EMBED_DIR/venv"
+fi
+"$EMBED_DIR/venv/bin/pip" install --upgrade pip
+"$EMBED_DIR/venv/bin/pip" install -r "$REPO_DIR/scripts/load-profiles/embed_bench/requirements.txt"
+
+rsync -a --delete "$REPO_DIR/scripts/" "$EMBED_DIR/scripts/"
+
+JWT_FILE=/etc/systemd/system/levara-bench.service.d/jwt.conf
+if [ ! -f "$JWT_FILE" ]; then
+  SECRET=$(head -c 32 /dev/urandom | xxd -p -c 32)
+  sudo mkdir -p "$(dirname "$JWT_FILE")"
+  sudo tee "$JWT_FILE" >/dev/null <<EOF
+[Service]
+Environment=JWT_SECRET=$SECRET
+EOF
+fi
+
+sudo install -m 0644 "$REPO_DIR/deploy/bench/embed-bench.service"  /etc/systemd/system/
+sudo install -m 0644 "$REPO_DIR/deploy/bench/levara-bench.service" /etc/systemd/system/
+sudo systemctl daemon-reload
+
+echo "[setup_pi.sh] OK. embed-bench + levara-bench installed (not enabled)."
+```
+
+- [ ] **Step 4: Create README**
+
+Create `deploy/bench/README.md`:
+
+```markdown
+# Bench stack on Pi (10.23.0.53)
+
+Isolated from production levara.service:8090. Lifecycle controlled by
+scripts/load-profiles/run_all_models.sh.
+
+## One-time setup
+
+1. Sync repo to Pi at /home/stek0v/levara-source
+2. Place levara binary at /home/stek0v/levara-bench/levara (cross-compiled
+   from cmd/server, GOOS=linux GOARCH=arm64)
+3. Run setup: `ssh stek0v@10.23.0.53 'bash /home/stek0v/levara-source/deploy/bench/setup_pi.sh'`
+
+## Per-model run
+
+Drop-ins written by orchestrator:
+- /etc/systemd/system/embed-bench.service.d/model.conf
+    Environment=EMBED_BENCH_MODEL=<short>
+- /etc/systemd/system/levara-bench.service.d/embed.conf
+    Environment=EMBEDDING_MODEL=<openai-name>
+- /etc/systemd/system/levara-bench.service.d/dim.conf
+    ExecStart= override with -dim=<N>
+
+After writing drop-ins: `systemctl daemon-reload && systemctl restart`.
+
+## Cleanup
+
+`systemctl stop levara-bench embed-bench` frees memory. Data persists in
+/home/stek0v/levara-bench/data; remove manually for a fresh start.
+```
+
+- [ ] **Step 5: Mark executable, commit**
+
+```bash
+chmod +x deploy/bench/setup_pi.sh
+git add deploy/bench/
+git commit -m "feat(bench): systemd units + Pi setup script for bench stack"
+```
+
+---
+
+## Task 5: preflight_model.py (TDD)
+
+Gate before any seed or run. HTTP injected for tests.
+
+**Files:**
+- Create: `scripts/load-profiles/preflight_model.py`
+- Create: `scripts/load-profiles/tests/__init__.py`
+- Create: `scripts/load-profiles/tests/test_preflight.py`
+
+- [ ] **Step 1: Create package marker**
+
+```bash
+mkdir -p scripts/load-profiles/tests
+touch scripts/load-profiles/tests/__init__.py
+```
+
+- [ ] **Step 2: Write failing test**
+
+Create `scripts/load-profiles/tests/test_preflight.py`:
+
+```python
+from scripts.load_profiles.preflight_model import Checks, run_checks
+
+
+class FakeHTTP:
+    def __init__(self, routes):
+        self.routes = routes
+
+    def __call__(self, method, url, headers=None, body=None, timeout=10.0):
+        key = (method, url)
+        if key not in self.routes:
+            raise RuntimeError(f"unmocked HTTP {method} {url}")
+        return self.routes[key]
+
+
+GOOD = FakeHTTP({
+    ("GET",  "http://10.23.0.53:9101/health"):   {"model": "potion-code-16M", "dim": 256, "backend": "model2vec", "ram_mb": 120},
+    ("POST", "http://10.23.0.53:9101/v1/embeddings"): {"data": [{"embedding": [0.0] * 256, "index": 0}], "model": "potion-code-16M"},
+    ("GET",  "http://10.23.0.53:8091/health"):   {"status": "ok"},
+    ("GET",  "http://10.23.0.53:11434/api/tags"): {"models": [{"name": "qwen3:0.6b"}]},
+    ("GET",  "http://10.23.0.53:9100/health"):    {"status": "ok"},
+    ("POST", "http://10.23.0.53:8091/api/v1/auth/register"): {"access_token": "tok"},
+})
+
+
+def test_all_checks_pass_for_good_stack():
+    checks = Checks(model_short="potion", expected_dim=256, expected_openai_name="potion-code-16M")
+    result = run_checks(checks, http=GOOD)
+    assert result.ok is True
+    assert result.failed == []
+
+
+def test_fails_on_sidecar_dim_mismatch():
+    bad = FakeHTTP({
+        **GOOD.routes,
+        ("GET", "http://10.23.0.53:9101/health"): {"model": "potion-code-16M", "dim": 999, "backend": "model2vec", "ram_mb": 120},
+    })
+    checks = Checks(model_short="potion", expected_dim=256, expected_openai_name="potion-code-16M")
+    result = run_checks(checks, http=bad)
+    assert result.ok is False
+    assert any("sidecar_dim" in f for f in result.failed)
+
+
+def test_fails_on_missing_llm():
+    bad = FakeHTTP({
+        **GOOD.routes,
+        ("GET", "http://10.23.0.53:11434/api/tags"): {"models": [{"name": "other:1b"}]},
+    })
+    checks = Checks(model_short="potion", expected_dim=256, expected_openai_name="potion-code-16M")
+    result = run_checks(checks, http=bad)
+    assert result.ok is False
+    assert any("ollama_model" in f for f in result.failed)
+
+
+def test_fails_on_embed_vector_length_mismatch():
+    bad = FakeHTTP({
+        **GOOD.routes,
+        ("POST", "http://10.23.0.53:9101/v1/embeddings"): {"data": [{"embedding": [0.0] * 7, "index": 0}], "model": "potion-code-16M"},
+    })
+    checks = Checks(model_short="potion", expected_dim=256, expected_openai_name="potion-code-16M")
+    result = run_checks(checks, http=bad)
+    assert result.ok is False
+    assert any("embed_ping_dim" in f for f in result.failed)
+```
+
+- [ ] **Step 3: Run test, verify FAIL**
+
+Run: `python -m pytest scripts/load-profiles/tests/test_preflight.py -v`
+
+- [ ] **Step 4: Implement**
+
+Create `scripts/load-profiles/preflight_model.py`:
+
+```python
+#!/usr/bin/env python3
+"""Preflight gate for one model run on the Pi bench stack.
+
+Usage: python preflight_model.py --model <short> --host 10.23.0.53
+Exits 0 if every check passes, 1 otherwise. Prints structured JSON report.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Callable
+
+from scripts.load_profiles.embed_bench.recipes import get_recipe
+
+
+@dataclass
+class Checks:
+    model_short: str
+    expected_dim: int
+    expected_openai_name: str
+    host: str = "10.23.0.53"
+    sidecar_port: int = 9101
+    bench_port: int = 8091
+    rerank_port: int = 9100
+    ollama_port: int = 11434
+    ollama_model_required: str = "qwen3:0.6b"
+
+
+@dataclass
+class Result:
+    ok: bool
+    passed: list[str] = field(default_factory=list)
+    failed: list[str] = field(default_factory=list)
+
+
+def default_http(method: str, url: str, headers=None, body=None, timeout: float = 10.0) -> dict:
+    payload = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(url, data=payload, headers=headers or {}, method=method)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        data = resp.read()
+        if not data:
+            return {}
+        return json.loads(data)
+
+
+HttpFn = Callable[..., dict]
+
+
+def run_checks(c: Checks, *, http: HttpFn = default_http) -> Result:
+    passed: list[str] = []
+    failed: list[str] = []
+
+    def _try(label: str, fn):
+        try:
+            fn()
+            passed.append(label)
+        except Exception as e:
+            failed.append(f"{label}: {e}")
+
+    sidecar = f"http://{c.host}:{c.sidecar_port}"
+    bench = f"http://{c.host}:{c.bench_port}"
+    rerank = f"http://{c.host}:{c.rerank_port}"
+    ollama = f"http://{c.host}:{c.ollama_port}"
+
+    def check_sidecar_health():
+        body = http("GET", f"{sidecar}/health")
+        if body.get("model") != c.expected_openai_name:
+            raise RuntimeError(f"model name mismatch: {body.get('model')!r} != {c.expected_openai_name!r}")
+        if body.get("dim") != c.expected_dim:
+            raise RuntimeError(f"sidecar_dim mismatch: {body.get('dim')} != {c.expected_dim}")
+
+    def check_embed_ping():
+        body = http("POST", f"{sidecar}/v1/embeddings",
+                    headers={"Content-Type": "application/json"},
+                    body={"input": ["ping"], "model": c.expected_openai_name})
+        data = body.get("data", [])
+        if not data:
+            raise RuntimeError("empty data array")
+        v = data[0].get("embedding", [])
+        if len(v) != c.expected_dim:
+            raise RuntimeError(f"embed_ping_dim {len(v)} != {c.expected_dim}")
+
+    def check_bench_health():
+        http("GET", f"{bench}/health")
+
+    def check_ollama_model():
+        body = http("GET", f"{ollama}/api/tags")
+        names = {m.get("name") for m in body.get("models", [])}
+        if c.ollama_model_required not in names:
+            raise RuntimeError(f"ollama_model {c.ollama_model_required!r} not in {names}")
+
+    def check_rerank_health():
+        http("GET", f"{rerank}/health")
+
+    def check_auth():
+        import secrets
+        email = f"preflight_{secrets.token_hex(4)}@local"
+        passwd = secrets.token_hex(8)
+        body = http("POST", f"{bench}/api/v1/auth/register",
+                    headers={"Content-Type": "application/json"},
+                    body={"email": email, "password": passwd})
+        if not body.get("access_token"):
+            raise RuntimeError("no access_token returned")
+
+    _try("sidecar_health", check_sidecar_health)
+    _try("embed_ping",     check_embed_ping)
+    _try("bench_health",   check_bench_health)
+    _try("ollama_model",   check_ollama_model)
+    _try("rerank_health",  check_rerank_health)
+    _try("auth_register",  check_auth)
+
+    return Result(ok=not failed, passed=passed, failed=failed)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--model", required=True)
+    p.add_argument("--host", default="10.23.0.53")
+    args = p.parse_args()
+
+    recipe = get_recipe(args.model)
+    checks = Checks(
+        model_short=recipe.short,
+        expected_dim=recipe.dim,
+        expected_openai_name=recipe.openai_name,
+        host=args.host,
+    )
+    result = run_checks(checks)
+    print(json.dumps({"ok": result.ok, "passed": result.passed, "failed": result.failed}, indent=2))
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 5: Run test, verify PASS**
+
+Run: `python -m pytest scripts/load-profiles/tests/test_preflight.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/load-profiles/preflight_model.py \
+        scripts/load-profiles/tests/__init__.py \
+        scripts/load-profiles/tests/test_preflight.py
+git commit -m "feat(load-profiles): preflight gate for per-model bench runs"
+```
+
+---
+
+## Task 6: keyword_metrics helper in runner.py (TDD)
+
+Pure function over the no-rerank response + expected keywords.
+
+**Files:**
+- Modify: `scripts/load-profiles/runner.py`
+- Create: `scripts/load-profiles/tests/test_keyword_metrics.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `scripts/load-profiles/tests/test_keyword_metrics.py`:
+
+```python
+from scripts.load_profiles.runner import keyword_metrics
+
+
+def _resp(*texts):
+    return [{"id": str(i), "score": 1.0 - i*0.1, "metadata": {"text": t}}
+            for i, t in enumerate(texts)]
+
+
+def test_no_keywords_returns_zero():
+    metrics = keyword_metrics(_resp("foo bar"), expected_keywords=[])
+    assert metrics == {"keyword_hits_top5": 0, "top1_keyword_hit": False}
+
+
+def test_top1_match_case_insensitive():
+    metrics = keyword_metrics(_resp("Redis Cache invalidation logic"),
+                              expected_keywords=["redis", "cache"])
+    assert metrics["top1_keyword_hit"] is True
+    assert metrics["keyword_hits_top5"] == 2
+
+
+def test_only_top5_window_counted():
+    docs = _resp("a", "b", "c", "d", "e", "redis-server", "cache-key")
+    metrics = keyword_metrics(docs, expected_keywords=["redis", "cache"])
+    assert metrics["keyword_hits_top5"] == 0
+    assert metrics["top1_keyword_hit"] is False
+
+
+def test_each_keyword_counted_at_most_once_per_query():
+    docs = _resp("redis redis redis", "redis again", "x", "y", "z")
+    metrics = keyword_metrics(docs, expected_keywords=["redis"])
+    assert metrics["keyword_hits_top5"] == 1
+
+
+def test_empty_response_safe():
+    metrics = keyword_metrics(None, expected_keywords=["x"])
+    assert metrics == {"keyword_hits_top5": 0, "top1_keyword_hit": False}
+    metrics = keyword_metrics([], expected_keywords=["x"])
+    assert metrics == {"keyword_hits_top5": 0, "top1_keyword_hit": False}
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+Run: `python -m pytest scripts/load-profiles/tests/test_keyword_metrics.py -v`
+Expected: ImportError.
+
+- [ ] **Step 3: Add implementation**
+
+Open `scripts/load-profiles/runner.py`. Find the function `top_changed` (around line 546). Add this new function immediately after it (before `build_query_record`):
+
+```python
+def keyword_metrics(resp: Any, *, expected_keywords: list[str]) -> dict[str, Any]:
+    """Light-weight retrieval-quality metric.
+
+    keyword_hits_top5: distinct expected_keywords (case-insensitive substring)
+        appearing in any top-5 hit text. Each keyword counts at most once.
+
+    top1_keyword_hit: any expected_keyword in top-1 text.
+    """
+    hits = _hits_from(resp)[:5]
+    if not hits or not expected_keywords:
+        return {"keyword_hits_top5": 0, "top1_keyword_hit": False}
+    needles = [k.lower() for k in expected_keywords]
+
+    def _text_of(h):
+        m = h.get("metadata")
+        if isinstance(m, dict):
+            return str(m.get("text", "")).lower()
+        if isinstance(m, str):
+            try:
+                inner = json.loads(m)
+                if isinstance(inner, dict):
+                    return str(inner.get("text", "")).lower()
+            except Exception:
+                return ""
+        return ""
+
+    top1_text = _text_of(hits[0])
+    top1_hit = any(n in top1_text for n in needles)
+
+    found: set[str] = set()
+    for h in hits:
+        text = _text_of(h)
+        for n in needles:
+            if n in text:
+                found.add(n)
+
+    return {"keyword_hits_top5": len(found), "top1_keyword_hit": top1_hit}
+```
+
+- [ ] **Step 4: Run test, verify PASS**
+
+Run: `python -m pytest scripts/load-profiles/tests/test_keyword_metrics.py -v`
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/load-profiles/runner.py \
+        scripts/load-profiles/tests/test_keyword_metrics.py
+git commit -m "feat(load-profiles): keyword_metrics helper"
+```
+
+---
+
+## Task 7: Profile scripts — `--model`, `--embed-dim`, `--collection-override`
+
+p4 and p5 get three new CLI flags and pass keyword metrics into `build_query_record` via the `extra` dict.
+
+**Files:**
+- Modify: `scripts/load-profiles/p4_memory_palace.py`
+- Modify: `scripts/load-profiles/p5_filtered_search.py`
+
+- [ ] **Step 1: Inspect existing argparse blocks**
+
+Run: `grep -n "argparse\|add_argument\|build_query_record" scripts/load-profiles/p4_memory_palace.py scripts/load-profiles/p5_filtered_search.py`
+
+- [ ] **Step 2: Add CLI flags to p4_memory_palace.py**
+
+In the argparse block (around line 135), before `args = p.parse_args()`, add:
+
+```python
+    p.add_argument("--model", default="", help="embed model short (potion/granite/jina); used for JSONL fields")
+    p.add_argument("--embed-dim", type=int, default=0, help="expected embedding dim (JSONL only)")
+    p.add_argument("--collection-override", default="", help="if set, use this collection name instead of the default")
+```
+
+- [ ] **Step 3: Use the override and attach metrics in p4**
+
+Find `collection = runner.profile_collection(PROFILE_ID)` (around line 82) and replace with:
+
+```python
+    collection = args.collection_override or runner.profile_collection(PROFILE_ID)
+```
+
+Find the `runner.build_query_record(` call (around line 104) and replace it with:
+
+```python
+                rec = runner.build_query_record(
+                    profile_id=PROFILE_ID,
+                    target=target,
+                    query_id=q["id"],
+                    query_text=q["text"],
+                    collection=collection,
+                    query_type=q.get("query_type", "CHUNKS"),
+                    pair=pair,
+                    extra={
+                        "embed_model": args.model or target.embed_model,
+                        "embed_dim": args.embed_dim,
+                        "expected_keywords": q.get("expected_keywords", []),
+                        **runner.keyword_metrics(
+                            pair["no_rerank"]["response"],
+                            expected_keywords=q.get("expected_keywords", []),
+                        ),
+                    },
+                )
+```
+
+If `extra=` is already used, merge fields rather than replace.
+
+- [ ] **Step 4: Mirror in p5_filtered_search.py**
+
+Apply identical patches in `scripts/load-profiles/p5_filtered_search.py`: three new argparse calls, `collection` override line, `build_query_record(...)` with new `extra` dict.
+
+- [ ] **Step 5: Verify help output**
+
+```bash
+python scripts/load-profiles/p4_memory_palace.py --help 2>&1 | grep -E "model|embed-dim|collection-override"
+python scripts/load-profiles/p5_filtered_search.py --help 2>&1 | grep -E "model|embed-dim|collection-override"
+```
+
+Expected: each prints the three new flags.
+
+- [ ] **Step 6: Verify keyword_metrics test still green**
+
+Run: `python -m pytest scripts/load-profiles/tests/test_keyword_metrics.py -v`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/load-profiles/p4_memory_palace.py scripts/load-profiles/p5_filtered_search.py
+git commit -m "feat(load-profiles): per-model flags + keyword metrics in p4/p5"
+```
+
+---
+
+## Task 8: seed_via_cognify in seed/code_corpus.py
+
+Function that submits the corpus to `/api/v1/cognify` and polls for completion. Keeps existing direct-insert path for backward-compat.
+
+**Files:**
+- Modify: `scripts/load-profiles/seed/code_corpus.py`
+
+- [ ] **Step 1: Append seed_via_cognify**
+
+Open `scripts/load-profiles/seed/code_corpus.py`. At the bottom of the file, before any `if __name__ == "__main__":` block, add:
+
+```python
+def seed_via_cognify(
+    target,
+    collection: str,
+    *,
+    chunks: list[dict],
+    poll_seconds: float = 2.0,
+    timeout_seconds: float = 1800.0,
+) -> dict:
+    """Seed `collection` by submitting the joined corpus to /api/v1/cognify.
+
+    Runs the FULL Levara pipeline (chunk -> LLM entity extraction -> dedup
+    -> embed -> write HNSW+BM25+graph+WAL) so the bench is honest.
+    """
+    import time
+    import sys
+    from scripts.load_profiles import runner
+
+    text = "\n\n=====\n\n".join(c["text"] for c in chunks)
+
+    resp = runner.http_request(
+        "POST",
+        target.url("/api/v1/cognify"),
+        headers=target.headers(),
+        body={"dataset": collection, "dataset_name": collection, "text": text},
+        timeout=60.0,
+    )
+    run_id = resp.get("run_id") or resp.get("id")
+    if not run_id:
+        raise RuntimeError(f"cognify did not return run_id: {resp!r}")
+
+    print(f"[cognify] run_id={run_id} polling...", file=sys.stderr)
+    start = time.time()
+    while True:
+        if time.time() - start > timeout_seconds:
+            raise TimeoutError(f"cognify {run_id} did not terminate in {timeout_seconds}s")
+        status = runner.http_request(
+            "GET",
+            target.url(f"/api/v1/cognify/status/{run_id}"),
+            headers=target.headers(),
+        )
+        state = (status.get("status") or status.get("state") or "").lower()
+        if state in ("done", "completed", "success"):
+            print(f"[cognify] done in {time.time()-start:.1f}s", file=sys.stderr)
+            return status
+        if state in ("error", "failed"):
+            raise RuntimeError(f"cognify failed: {status!r}")
+        time.sleep(poll_seconds)
+```
+
+- [ ] **Step 2: Commit (smoke-tested in Task 11)**
+
+```bash
+git add scripts/load-profiles/seed/code_corpus.py
+git commit -m "feat(load-profiles): cognify-pathway seeding"
+```
+
+---
+
+## Task 9: seed_one.py orchestrator helper
+
+Bridges the shell orchestrator and the Python seeding code without inline `python3 -c`.
+
+**Files:**
+- Create: `scripts/load-profiles/seed_one.py`
+
+- [ ] **Step 1: Implement**
+
+Create `scripts/load-profiles/seed_one.py`:
+
+```python
+#!/usr/bin/env python3
+"""Seed ONE collection via the full cognify pipeline against bench Levara.
+
+Called by run_all_models.sh. Reads target URL + token from args/env,
+loads the code corpus, calls seed_via_cognify.
+
+Usage:
+    python seed_one.py --target-url http://10.23.0.53:8091 \
+        --collection loadprofile_p4_main_potion
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+from scripts.load_profiles import runner
+from scripts.load_profiles.seed import code_corpus
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--target-url", required=True)
+    p.add_argument("--target-name", default="bench")
+    p.add_argument("--collection", required=True)
+    p.add_argument("--token-env", default="LEVARA_BENCH_TOKEN")
+    args = p.parse_args()
+
+    token = runner.load_token(args.token_env, args.target_name)
+    target = runner.Target(
+        name=args.target_name,
+        base_url=args.target_url,
+        token=token,
+        embed_model="",
+        rerank_endpoint="",
+        rerank_enabled=None,
+    )
+
+    chunks = code_corpus.load_corpus()
+    print(f"[seed_one] loaded {len(chunks)} chunks", file=sys.stderr)
+    code_corpus.seed_via_cognify(target, args.collection, chunks=chunks)
+    print(f"[seed_one] seeded collection={args.collection}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+Note: `runner.load_token` and `runner.Target` and `code_corpus.load_corpus` exist in the codebase already. If `load_token` does not exist, replace with the existing equivalent (e.g. `runner.load_token_from_env_or_file`); same for `load_corpus` (it may be `iter_corpus` or `build_corpus`). Grep first:
+
+```bash
+grep -n "^def load_corpus\|^def iter_corpus\|^def build_corpus" scripts/load-profiles/seed/code_corpus.py
+grep -n "^def load_token\|^def load_token_from" scripts/load-profiles/runner.py
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/load-profiles/seed_one.py
+git commit -m "feat(load-profiles): seed_one.py helper for orchestrator"
+```
+
+---
+
+## Task 10: analyze.py — `--by-model` + cross-model table (TDD)
+
+**Files:**
+- Modify: `scripts/load-profiles/analyze.py`
+- Create: `scripts/load-profiles/tests/test_analyze_by_model.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `scripts/load-profiles/tests/test_analyze_by_model.py`:
+
+```python
+from scripts.load_profiles.analyze import (
+    group_by_model,
+    summarize_quality,
+    render_cross_model_markdown,
+)
+
+
+def _rec(model, gap, recall, top1):
+    return {
+        "embed_model": model,
+        "score_gap_top_bottom": gap,
+        "keyword_hits_top5": recall,
+        "top1_keyword_hit": top1,
+        "latency_no_rerank_ms": 10.0,
+        "latency_with_rerank_ms": 50.0,
+        "rerank_outcome": "reranked",
+    }
+
+
+def test_group_by_model_splits_correctly():
+    recs = [_rec("potion", 0.1, 2, True), _rec("granite", 0.2, 3, True), _rec("potion", 0.15, 1, False)]
+    g = group_by_model(recs)
+    assert set(g) == {"potion", "granite"}
+    assert len(g["potion"]) == 2
+    assert len(g["granite"]) == 1
+
+
+def test_summarize_quality_means():
+    recs = [_rec("p", 0.1, 2, True), _rec("p", 0.2, 4, False), _rec("p", 0.0, 0, False)]
+    s = summarize_quality(recs)
+    assert abs(s["mean_recall_top5"] - 2.0) < 1e-9
+    assert abs(s["top1_keyword_hit_rate"] - (1/3)) < 1e-9
+    assert s["n"] == 3
+
+
+def test_cross_model_markdown_has_all_models():
+    recs = [_rec("potion", 0.1, 2, True), _rec("granite", 0.2, 3, True), _rec("jina", 0.05, 1, False)]
+    md = render_cross_model_markdown(group_by_model(recs))
+    assert "potion" in md and "granite" in md and "jina" in md
+    assert "mean_recall_top5" in md
+    assert "top1_keyword_hit_rate" in md
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+Run: `python -m pytest scripts/load-profiles/tests/test_analyze_by_model.py -v`
+
+- [ ] **Step 3: Implement**
+
+Open `scripts/load-profiles/analyze.py`. After existing `pct` helper, before `load`, add:
+
+```python
+def group_by_model(recs: list[dict]) -> dict[str, list[dict]]:
+    out: dict[str, list[dict]] = {}
+    for r in recs:
+        m = r.get("embed_model") or "_unknown"
+        out.setdefault(m, []).append(r)
+    return out
+
+
+def summarize_quality(recs: list[dict]) -> dict:
+    if not recs:
+        return {"n": 0, "mean_recall_top5": 0.0, "top1_keyword_hit_rate": 0.0}
+    hits = [int(r.get("keyword_hits_top5", 0)) for r in recs]
+    top1 = [bool(r.get("top1_keyword_hit", False)) for r in recs]
+    return {
+        "n": len(recs),
+        "mean_recall_top5": sum(hits) / len(hits),
+        "top1_keyword_hit_rate": sum(1 for x in top1 if x) / len(top1),
+    }
+
+
+def render_cross_model_markdown(by_model: dict[str, list[dict]]) -> str:
+    lines = ["## Cross-model comparison", ""]
+    lines.append("| model | n | mean_recall_top5 | top1_keyword_hit_rate | p50 gap | p50 lat_no_rerank_ms | p50 lat_with_rerank_ms |")
+    lines.append("|---|---|---|---|---|---|---|")
+    for model in sorted(by_model):
+        recs = by_model[model]
+        q = summarize_quality(recs)
+        gaps = [float(r.get("score_gap_top_bottom", 0.0)) for r in recs]
+        lat_no = [float(r.get("latency_no_rerank_ms", 0.0)) for r in recs]
+        lat_w = [float(r.get("latency_with_rerank_ms", 0.0)) for r in recs]
+        lines.append(
+            f"| {model} | {q['n']} | {q['mean_recall_top5']:.3f} | {q['top1_keyword_hit_rate']:.3f} "
+            f"| {pct(gaps, 50):.4f} | {pct(lat_no, 50):.1f} | {pct(lat_w, 50):.1f} |"
+        )
+    return "\n".join(lines)
+```
+
+In the argparse block, add (before `parse_args()`):
+
+```python
+    p.add_argument("--by-model", action="store_true", help="group records by embed_model and emit per-model + cross-model report")
+```
+
+In `main()`, before final return, add:
+
+```python
+    if args.by_model:
+        all_recs: list[dict] = []
+        for path in args.files:
+            all_recs.extend(load(path))
+        by_model = group_by_model(all_recs)
+        for model, recs in sorted(by_model.items()):
+            print(f"\n=== model: {model} (n={len(recs)}) ===")
+            profiles = per_profile(recs)
+            for label, prof in profiles.items():
+                print_profile(f"{model}/{label}", prof)
+            threshold_sweep(profiles)
+        print()
+        print(render_cross_model_markdown(by_model))
+```
+
+- [ ] **Step 4: Run test, verify PASS**
+
+Run: `python -m pytest scripts/load-profiles/tests/test_analyze_by_model.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/load-profiles/analyze.py \
+        scripts/load-profiles/tests/test_analyze_by_model.py
+git commit -m "feat(load-profiles): --by-model grouping + cross-model table"
+```
+
+---
+
+## Task 11: run_all_models.sh — orchestrator
+
+Wraps the per-model sequence. Idempotent.
+
+**Files:**
+- Create: `scripts/load-profiles/run_all_models.sh`
+
+- [ ] **Step 1: Create**
+
+Create `scripts/load-profiles/run_all_models.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Sequentially run 3 embed models through the full Levara cognify
+# pipeline on Pi bench. Refuses to touch production levara.service.
+#
+# Usage:
+#   bash run_all_models.sh              # all 3 models
+#   bash run_all_models.sh potion       # just one
+set -euo pipefail
+
+PI_HOST="${PI_HOST:-10.23.0.53}"
+PI_USER="${PI_USER:-stek0v}"
+OUT_DIR="${OUT_DIR:-scripts/load-profiles/out}"
+DEFAULT_MODELS=(potion granite jina)
+MODELS_ARR=(${MODELS:-${DEFAULT_MODELS[@]}})
+if [ $# -gt 0 ]; then
+  MODELS_ARR=("$@")
+fi
+
+mkdir -p "$OUT_DIR"
+
+safe_unit() {
+  case "$1" in
+    levara.service) echo "REFUSING to touch prod unit $1" >&2; exit 2 ;;
+  esac
+}
+
+write_dropin() {
+  local unit="$1" name="$2" content="$3"
+  safe_unit "$unit"
+  ssh "$PI_USER@$PI_HOST" "sudo mkdir -p /etc/systemd/system/${unit}.d && \
+    printf '%s\n' '$content' | sudo tee /etc/systemd/system/${unit}.d/${name}.conf >/dev/null"
+}
+
+restart_bench() {
+  ssh "$PI_USER@$PI_HOST" "sudo systemctl daemon-reload && \
+    sudo systemctl restart embed-bench.service levara-bench.service"
+}
+
+stop_bench() {
+  ssh "$PI_USER@$PI_HOST" "sudo systemctl stop levara-bench.service embed-bench.service || true"
+}
+
+run_one_model() {
+  local short="$1"
+  echo "=== model: $short ==="
+
+  case "$short" in
+    potion)  OPENAI="potion-code-16M";              DIM=256 ;;
+    granite) OPENAI="granite-97m-multilingual-r2";  DIM=384 ;;
+    jina)    OPENAI="jina-omni-nano";               DIM=512 ;;
+    *) echo "unknown model: $short" >&2; exit 2 ;;
+  esac
+
+  stop_bench
+
+  write_dropin embed-bench.service model "[Service]
+Environment=EMBED_BENCH_MODEL=$short"
+  write_dropin levara-bench.service embed "[Service]
+Environment=EMBEDDING_MODEL=$OPENAI"
+  write_dropin levara-bench.service dim "[Service]
+ExecStart=
+ExecStart=/home/stek0v/levara-bench/levara -standalone=true -port=8091 -grpc-port=0 -dim=$DIM -data-dir=/home/stek0v/levara-bench/data -node-id=pi-bench"
+
+  restart_bench
+  sleep 10
+
+  python3 scripts/load-profiles/preflight_model.py --model "$short" --host "$PI_HOST" \
+    || { echo "preflight failed for $short, skipping" >&2; stop_bench; return 1; }
+
+  local TARGET_URL="http://$PI_HOST:8091"
+  local COLL_P4="loadprofile_p4_main_$short"
+  local COLL_P5="loadprofile_p5_main_$short"
+
+  echo "[seed] $COLL_P4 + $COLL_P5"
+  python3 scripts/load-profiles/seed_one.py --target-url "$TARGET_URL" --collection "$COLL_P4"
+  python3 scripts/load-profiles/seed_one.py --target-url "$TARGET_URL" --collection "$COLL_P5"
+
+  echo "[run] p4 / $short"
+  python3 scripts/load-profiles/p4_memory_palace.py \
+    --target-name bench --target-url "$TARGET_URL" \
+    --model "$short" --embed-dim "$DIM" \
+    --collection-override "$COLL_P4" \
+    --out "$OUT_DIR/p4_$short.jsonl"
+
+  echo "[run] p5 / $short"
+  python3 scripts/load-profiles/p5_filtered_search.py \
+    --target-name bench --target-url "$TARGET_URL" \
+    --model "$short" --embed-dim "$DIM" \
+    --collection-override "$COLL_P5" \
+    --out "$OUT_DIR/p5_$short.jsonl"
+
+  stop_bench
+}
+
+for m in "${MODELS_ARR[@]}"; do
+  run_one_model "$m" || echo "model $m skipped" >&2
+done
+
+echo "=== analyze ==="
+python3 scripts/load-profiles/analyze.py --by-model "$OUT_DIR"/p?_*.jsonl \
+  > docs/load-profile-analysis-pi-multimodel.md
+
+echo "OK. Output: docs/load-profile-analysis-pi-multimodel.md"
+```
+
+- [ ] **Step 2: Check syntax**
+
+```bash
+chmod +x scripts/load-profiles/run_all_models.sh
+bash -n scripts/load-profiles/run_all_models.sh && echo "syntax OK"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/load-profiles/run_all_models.sh
+git commit -m "feat(load-profiles): orchestrator for 3-model sequential bench"
+```
+
+---
+
+## Task 12: End-to-end smoke with potion (smallest model first)
+
+Manual validation. Prove the full chain works before the overnight run.
+
+- [ ] **Step 1: Cross-compile Levara binary**
+
+```bash
+cd Levara && GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o /tmp/levara-pi ./cmd/server
+file /tmp/levara-pi
+```
+
+Expected: ELF 64-bit LSB ARM aarch64.
+
+- [ ] **Step 2: Deploy binary + source + run setup**
+
+```bash
+ssh stek0v@10.23.0.53 'mkdir -p /home/stek0v/levara-bench/data /home/stek0v/levara-source'
+rsync -a --delete --exclude='.git' --exclude='Levara/data' --exclude='out' \
+  ./ stek0v@10.23.0.53:/home/stek0v/levara-source/
+scp /tmp/levara-pi stek0v@10.23.0.53:/home/stek0v/levara-bench/levara
+ssh stek0v@10.23.0.53 'chmod +x /home/stek0v/levara-bench/levara && \
+  bash /home/stek0v/levara-source/deploy/bench/setup_pi.sh'
+```
+
+Expected: `[setup_pi.sh] OK.`
+
+- [ ] **Step 3: Prefetch potion model**
+
+```bash
+ssh stek0v@10.23.0.53 '/home/stek0v/embed-bench/venv/bin/huggingface-cli download minishlab/potion-code-16M'
+```
+
+- [ ] **Step 4: Run orchestrator for ONLY potion**
+
+```bash
+bash scripts/load-profiles/run_all_models.sh potion
+```
+
+Expected: completes under 30 min; produces `scripts/load-profiles/out/p{4,5}_potion.jsonl` and `docs/load-profile-analysis-pi-multimodel.md` containing a `potion` row in the cross-model table.
+
+- [ ] **Step 5: Validate JSONL fields**
+
+```bash
+head -1 scripts/load-profiles/out/p4_potion.jsonl > /tmp/probe.json
+python3 -m json.tool < /tmp/probe.json | grep -E "embed_model|embed_dim|keyword_hits_top5|top1_keyword_hit"
+```
+
+Expected: all four fields present with sensible values.
+
+- [ ] **Step 6: Verify production untouched**
+
+```bash
+ssh stek0v@10.23.0.53 'systemctl is-active levara.service'
+ssh stek0v@10.23.0.53 'curl -s http://localhost:8090/health'
+```
+
+Expected: `active` and valid health response.
+
+- [ ] **Step 7: If dims/recipe were wrong, fix and re-run**
+
+If `make_backend` raised a `ValueError`, the true dim was logged. Update `scripts/load-profiles/embed_bench/recipes.py`, re-run Task 1 tests, redeploy source, re-run smoke. Commit fix as a separate commit.
+
+---
+
+## Task 13: Full overnight 3-model run + writeup
+
+- [ ] **Step 1: Prefetch remaining models**
+
+```bash
+ssh stek0v@10.23.0.53 '/home/stek0v/embed-bench/venv/bin/huggingface-cli download ibm-granite/granite-embedding-97m-multilingual-r2'
+ssh stek0v@10.23.0.53 '/home/stek0v/embed-bench/venv/bin/huggingface-cli download jinaai/jina-embeddings-v5-omni-nano'
+```
+
+- [ ] **Step 2: Kick off full sweep in tmux on Pi**
+
+```bash
+ssh stek0v@10.23.0.53 'cd /home/stek0v/levara-source && \
+  tmux new-session -d -s bench "bash scripts/load-profiles/run_all_models.sh 2>&1 | tee /tmp/bench.log"'
+```
+
+Check progress: `ssh stek0v@10.23.0.53 'tmux capture-pane -p -t bench | tail -30'`
+
+- [ ] **Step 3: Wait + pull results (~10-11h)**
+
+```bash
+scp -r stek0v@10.23.0.53:/home/stek0v/levara-source/scripts/load-profiles/out/ scripts/load-profiles/out/
+scp stek0v@10.23.0.53:/home/stek0v/levara-source/docs/load-profile-analysis-pi-multimodel.md docs/
+```
+
+- [ ] **Step 4: Hand-review the report**
+
+Open `docs/load-profile-analysis-pi-multimodel.md`. Confirm three model rows, sane recall@5 values, p50 latency within an order of magnitude of nomic baseline.
+
+- [ ] **Step 5: Commit results + open PR**
+
+```bash
+git add scripts/load-profiles/out/p?_potion.jsonl \
+        scripts/load-profiles/out/p?_granite.jsonl \
+        scripts/load-profiles/out/p?_jina.jsonl \
+        docs/load-profile-analysis-pi-multimodel.md
+git commit -m "data: 3-embed-model Pi calibration results"
+
+git push -u origin feat/load-profiles
+gh pr create --base main \
+  --title "feat(bench): 3-embed-model honest calibration on Pi" \
+  --body "Spec: docs/superpowers/specs/2026-05-26-pi-embed-model-calibration-design.md
+Plan: docs/superpowers/plans/2026-05-26-pi-embed-model-calibration-plan.md
+Report: docs/load-profile-analysis-pi-multimodel.md"
+```
+
+---
+
+## Notes for the executor
+
+- **Order matters for Tasks 1-3.** recipes drives backends drives server.
+- **Tasks 4 + 11 (infra) have no unit tests** — validated end-to-end by Task 12.
+- **Task 12 is a gate.** Do not start Task 13 until Task 12 produces a complete potion run.
+- **Production safety.** `safe_unit()` in `run_all_models.sh` refuses `levara.service`. Do NOT add unguarded `systemctl restart levara` anywhere.
+- **HF Hub access.** Granite/Jina may require accepting a license. Prefetch will fail visibly — accept license and retry.
+- **Model dims.** Hardcoded dims in `recipes.py` are best-effort. Dim probe in `backends.py` raises if reality disagrees.
+- **gitignore.** `scripts/load-profiles/out/` is already gitignored. The Task 13 `git add` deliberately overrides per-file.

--- a/docs/superpowers/specs/2026-05-26-pi-embed-model-calibration-design.md
+++ b/docs/superpowers/specs/2026-05-26-pi-embed-model-calibration-design.md
@@ -1,0 +1,287 @@
+# Pi 3-embed-model honest calibration — design
+
+**Date:** 2026-05-26
+**Author:** stek0v (with Claude Opus 4.7)
+**Status:** approved, ready for implementation plan
+
+## 1. Goal
+
+For each of three candidate embedding models, produce comparable
+calibration and quality data by running them through the **full
+cognify pipeline** (chunk → LLM entity extraction → dedup → embed →
+write HNSW+BM25+graph+WAL) on the Pi 5, then exercising P4/P5 load
+profiles via `/api/v1/search/text` (the canonical client path, post
+PR #85 fix).
+
+Candidates:
+
+| Model | HF repo | Stack |
+|---|---|---|
+| `granite-97m` | `ibm-granite/granite-embedding-97m-multilingual-r2` | HuggingFace transformers / ONNX |
+| `jina-omni-nano` | `jinaai/jina-embeddings-v5-omni-nano` | HuggingFace transformers (trust_remote_code) |
+| `potion-code-16M` | `minishlab/potion-code-16M` | model2vec (static embeddings) |
+
+## 2. Success criteria
+
+Single deliverable: `docs/load-profile-analysis-pi-multimodel.md`
+containing per-model and cross-model sections.
+
+Per model, the analyzer must report:
+
+- **Calibration:** score_gap_top_bottom percentiles (p25/p50/p75/p90),
+  threshold sweep `T ∈ [0.02..0.20]` with `skip%` and `gate-wrong%`,
+  and recommended `RERANK_SCORE_GAP_THRESHOLD`.
+- **Quality** (light ground truth from `QUERIES[].expected_keywords`):
+  mean recall@5, top1-keyword-hit-rate, mean rerank latency.
+
+Cross-model: side-by-side comparison table, plus identification of
+the model with the highest top1-keyword-hit-rate at lowest p50 latency.
+
+## 3. Non-goals
+
+- Not building a long-running benchmark service. Bench instance only
+  exists for the duration of the test sweep, then is stopped.
+- Not migrating production. The output is data and a recommendation;
+  any production model swap is a follow-up project.
+- Not constructing a rigorous IR ground-truth set. We use existing
+  `expected_keywords` from `QUERIES[]` as a light proxy.
+
+## 4. Architecture
+
+Production stack stays untouched. A second Levara instance runs in
+parallel for the duration of each model's sweep, with its own data
+directory, port, and JWT secret.
+
+```
+Pi 10.23.0.53
+┌───────────────────────────────────────────┐
+│ PRODUCTION (unchanged)                    │
+│  levara.service           :8090           │
+│    -dim=768, prod sqlite, prod 71 colls   │
+│  ollama.service           :11434          │
+│  rerank-sidecar.service   :9100           │
+├───────────────────────────────────────────┤
+│ BENCH (lifecycle controlled per model)    │
+│  embed-bench.service      :9101           │
+│    FastAPI, OpenAI /v1/embeddings         │
+│    loads ONE model from EMBED_BENCH_MODEL │
+│    GET /health → {model, dim, ram_mb}     │
+│  levara-bench.service     :8091           │
+│    same Levara binary, separate data-dir  │
+│    /home/stek0v/levara-bench/data         │
+│    JWT_SECRET pinned (constant string)    │
+│    EMBEDDING_ENDPOINT=http://127.0.0.1:9101│
+│    EMBEDDING_MODEL=<current>              │
+│    -dim=<current model dim>               │
+│    -port=8091 -grpc-port=0                │
+│    LLM_ENDPOINT=http://localhost:11434/v1 │
+│    LLM_MODEL=qwen3:0.6b (shared w/ prod)  │
+│    RERANK_ENDPOINT=http://127.0.0.1:9100  │
+└───────────────────────────────────────────┘
+```
+
+The bench instance is plain `systemd start/stop`; no docker. The
+embed-bench sidecar lives in `~/embed-bench/` on the Pi with its own
+Python venv, and is also a plain systemd unit.
+
+## 5. Components
+
+### 5.1 embed-bench sidecar
+
+- New directory `scripts/load-profiles/embed_bench/`
+- `server.py` — FastAPI app, OpenAI-compatible `POST /v1/embeddings`
+  + `GET /health` returning `{model, dim, ram_mb, backend}`
+- `backends/transformers.py` — for granite-97m, jina-omni-nano
+  - uses `transformers.AutoModel` with `trust_remote_code=True` for jina
+  - mean-pooling + L2-normalize, returns `list[list[float]]`
+- `backends/model2vec.py` — for potion-code-16M, uses `model2vec.StaticModel`
+- Backend selection: env `EMBED_BENCH_MODEL` matches one of three
+  hardcoded recipes; unknown name → exit 1.
+- Single model loaded at process start. No hot-swap (sequential
+  process restart instead — simpler, guaranteed RAM release).
+- Batch size: 32. Returns 422 on dim mismatch with expected.
+
+### 5.2 Bench Levara unit
+
+`deploy/bench/levara-bench.service` (new), installed alongside but
+**not** enabled at boot. Drop-in `EMBEDDING_MODEL` + `-dim` rewritten
+by harness before each model run.
+
+`JWT_SECRET` pinned via the unit file (constant per bench-stack
+lifetime) so the harness can reuse tokens across restarts without
+re-registering.
+
+### 5.3 Harness changes
+
+**`scripts/load-profiles/runner.py`**:
+- New `--target bench` aliasing to `http://10.23.0.53:8091`.
+- Removes `LEVARA_PRE_EMBED_URL` bypass code path entirely for bench
+  target (canonical `/api/v1/search/text` after PR #85 fix).
+- Adds JSONL fields: `embed_model`, `embed_dim`, `keyword_hits_top5`
+  (int, case-insensitive substring count of expected keywords across
+  the `metadata.text` field of top-5 hits), `top1_keyword_hit` (bool,
+  true if any expected keyword appears in top1 `metadata.text`).
+- `model_short` convention: `potion`, `granite`, `jina` — used as
+  collection-name suffix and JSONL filename component.
+
+**`scripts/load-profiles/seed/code_corpus.py`**:
+- Replaces direct insert with `POST /api/v1/cognify` call against
+  `loadprofile_<profile>_<model_short>`.
+- Polls `/cognify/status/{run_id}` until terminal.
+- Validates chunk count via `/api/v1/collections/<name>/info` post-run.
+
+**`scripts/load-profiles/preflight_model.py`** (new):
+- Single executable, exit code 0/1.
+- Checks (all must pass):
+  1. `GET 9101/health` 200, returns `{model, dim}` matching expected
+  2. `POST 9101/v1/embeddings {"input":["ping"]}` 200, vector length == dim
+  3. `GET 8091/health` 200
+  4. `GET 11434/api/tags` includes `qwen3:0.6b`
+  5. `GET 9100/health` 200
+  6. Bench Levara `-dim` matches sidecar dim (read from process args
+     via `ssh ps -ef`)
+  7. Auth: register a fresh bench-only user, login, token returned
+  8. Free disk on `/home/stek0v/levara-bench` ≥ 5GB
+- On failure: prints the failing check + diagnostic, returns 1.
+
+**`scripts/load-profiles/analyze.py`**:
+- `--by-model` flag groups JSONL records by `embed_model`.
+- Adds per-model recall@5 mean, top1-keyword-hit-rate.
+- Renders cross-model markdown table to stdout (the runner pipes this
+  into `docs/load-profile-analysis-pi-multimodel.md`).
+
+**`scripts/load-profiles/run_all_models.sh`** (new):
+- Orchestrates the per-model loop documented in §6.
+- Reads model list from env or `MODELS=(potion-code-16M granite-97m jina-omni-nano)`.
+- For each: writes drop-ins, restarts services, runs preflight, seeds,
+  runs P4+P5, stops services. Smallest-first ordering.
+
+## 6. Execution sequence (per model)
+
+```
+0. Prefetch HF cache (one-time, outside timed window)
+   ssh Pi: huggingface-cli download <repo>
+
+For each model in [potion-code-16M, granite-97m, jina-omni-nano]:
+
+1. Tear down previous model (idempotent)
+   ssh: sudo systemctl stop levara-bench embed-bench
+
+2. Rewrite drop-ins
+   ssh: write /etc/systemd/system/embed-bench.service.d/model.conf with
+        Environment=EMBED_BENCH_MODEL=<model_id>
+   ssh: write /etc/systemd/system/levara-bench.service.d/embed.conf with
+        Environment=EMBEDDING_MODEL=<openai-name-for-model>
+        ExecStart=... -dim=<model_dim> ...
+
+3. Start sidecar (loads model, may take 10-60s)
+   ssh: sudo systemctl start embed-bench
+   wait until GET 9101/health responds with model+dim
+
+4. Start bench Levara
+   ssh: sudo systemctl start levara-bench
+   wait until GET 8091/health 200
+
+5. Preflight gate
+   python3 preflight_model.py <model> || abort_with_logs
+
+6. Seed corpus
+   python3 seed/code_corpus.py --target bench --model <model>
+     --collections loadprofile_p4_main_<short>,loadprofile_p5_main_<short>
+   (uses /api/v1/cognify, blocks on terminal status, validates count)
+
+7. Load profile runs
+   python3 runner.py --target bench --profile p4 --model <model>
+     --collection loadprofile_p4_main_<short>
+     --out out/p4_<short>.jsonl
+   python3 runner.py --target bench --profile p5 --model <model>
+     --collection loadprofile_p5_main_<short>
+     --out out/p5_<short>.jsonl
+
+8. Tear down to free RAM
+   ssh: sudo systemctl stop levara-bench embed-bench
+
+End for.
+
+9. Analysis (once, after all models complete)
+   python3 analyze.py --by-model out/p[45]_*.jsonl
+     > docs/load-profile-analysis-pi-multimodel.md
+```
+
+## 7. Data flow
+
+For one query inside a profile run:
+
+```
+runner.py
+  └─ POST :8091/api/v1/search/text {collection, query_text, top_k=5}
+     └─ Levara-bench searchHandler → chunksSearch (post PR #85)
+        ├─ embed query: POST 127.0.0.1:9101/v1/embeddings
+        ├─ HNSW search in loadprofile_<profile>_<model>
+        ├─ overfetch ×3, optional rerank via :9100
+        └─ filter (RBAC, tags), return top_k
+  └─ pair query: same call WITHOUT rerank (rerank:false)
+  └─ compute: score_gap_top_bottom, top_changed, latencies
+  └─ compute: keyword_hits_top5 = count(kw in top5_text), top1_keyword_hit
+  └─ append JSONL with embed_model, embed_dim
+```
+
+For seeding one collection:
+
+```
+seed/code_corpus.py
+  └─ load 576 chunks from seed/data/
+  └─ POST :8091/api/v1/cognify {dataset, text, dataset_name, ...}
+     └─ Levara-bench orchestrator:
+        chunk → LLM extract (qwen3:0.6b @ 11434) → dedup
+        → embed via 9101 → write HNSW+BM25+graph+WAL
+  └─ poll :8091/api/v1/cognify/status/<run_id> until done|error
+  └─ GET :8091/api/v1/collections/<name>/info → assert count >= 576
+```
+
+## 8. Error handling
+
+| Failure | Behavior |
+|---|---|
+| Sidecar load fails (e.g. jina trust_remote_code blocked) | embed-bench exits non-zero; preflight detects, run skipped for that model, others continue |
+| Cognify run errors mid-corpus | seed script captures `run_status=error`, prints last 200 lines of bench Levara journalctl, exits 1; harness skips that model's runner step |
+| Dim mismatch between sidecar and bench Levara | preflight check 6 fails; both services stopped; harness aborts model |
+| `/api/v1/search/text` returns 502 (PR #85 path) | runner logs error to JSONL with `error="search_502"`, continues with next query; analyzer reports error rate per model |
+| OOM on Pi during model load | sidecar process killed; preflight check 1 times out → fail → skip model |
+| HF Hub network failure | prefetch step in §6 step 0 catches this; if cache missing, sidecar exits with clear error |
+
+## 9. Cost estimate
+
+- Per-model cognify seeding (576 chunks, LLM extraction via qwen3:0.6b on Pi 5): ~10 min for P4+P5 collections combined
+- Per-model load-profile run (720 queries P4 + P5): ~3-3.5 h (based on prior 6h12m observation, expected slightly faster post-fix)
+- Per-model overhead (service restarts, preflight, teardown): ~5 min
+- **3 models × ~3.5 h ≈ 10-11 h wall clock** — overnight prog run
+
+## 10. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Jina v5 omni nano needs special preprocessing or HF auth | Order ensures potion (model2vec, simplest) and granite (well-documented ONNX path) succeed first; jina failure does not invalidate other data |
+| Bench Levara `-dim` change requires restart between models | Already part of the sequence — sequential by design |
+| Cognify LLM extraction is slow on Pi 5 (qwen3:0.6b on CPU) | Cost accepted; user explicitly chose full pipeline ("honest test") |
+| Restarting bench Levara mid-run loses in-flight queries | Bench restarts happen only between models, not within a model's profile run |
+| Production Levara restart accidentally triggered | Harness ssh commands target `levara-bench.service` only; explicit grep in restart wrapper rejects unit name `levara.service` |
+| Collection namespace collision with prod 71 collections | Bench Levara has its own data-dir; physical isolation. Plus existing `loadprofile_` prefix assertion stays in place |
+| Drop-in files left behind after run | Harness teardown step removes drop-ins on completion or on Ctrl-C trap |
+
+## 11. Out of scope (deferred follow-ups)
+
+- Adding cross-encoder rerank models alongside (only embedding swap)
+- Migrating from sqlite to postgres for bench data
+- Running on .64 host as well (current target Pi only, per user)
+- Replacing `expected_keywords` proxy with curated IR ground truth
+- Automated CI re-run on Levara binary changes
+
+## 12. Open items (decided post-design)
+
+None at design freeze. Implementation plan will pick concrete:
+- Model dim values (read from HF config at prefetch time)
+- Pinned JWT_SECRET value (generated once during initial setup)
+- Per-model OpenAI-style "model name" strings (the values Levara
+  sends as `model` in its embed request — sidecar can ignore or
+  validate)

--- a/scripts/load-profiles/.gitignore
+++ b/scripts/load-profiles/.gitignore
@@ -1,0 +1,2 @@
+out/
+__pycache__/

--- a/scripts/load-profiles/analyze.py
+++ b/scripts/load-profiles/analyze.py
@@ -259,7 +259,13 @@ def main() -> int:
     if args.by_model:
         all_recs: list[dict] = []
         for path in args.paths:
-            all_recs.extend(load(path))
+            recs = load(path)
+            base = os.path.basename(path).split(".")[0]
+            inferred = base.split("_", 1)[1] if "_" in base else ""
+            for r in recs:
+                if not r.get("embed_model"):
+                    r["embed_model"] = r.get("embedding_model") or inferred or "_unknown"
+            all_recs.extend(recs)
         by_model = group_by_model(all_recs)
         for model, recs in sorted(by_model.items()):
             print(f"\n=== model: {model} (n={len(recs)}) ===")

--- a/scripts/load-profiles/analyze.py
+++ b/scripts/load-profiles/analyze.py
@@ -39,6 +39,43 @@ def pct(values: list[float], p: float) -> float:
     return arr[lo] + (arr[hi] - arr[lo]) * (i - lo)
 
 
+def group_by_model(recs: list[dict]) -> dict[str, list[dict]]:
+    out: dict[str, list[dict]] = {}
+    for r in recs:
+        m = r.get("embed_model") or "_unknown"
+        out.setdefault(m, []).append(r)
+    return out
+
+
+def summarize_quality(recs: list[dict]) -> dict:
+    if not recs:
+        return {"n": 0, "mean_recall_top5": 0.0, "top1_keyword_hit_rate": 0.0}
+    hits = [int(r.get("keyword_hits_top5", 0)) for r in recs]
+    top1 = [bool(r.get("top1_keyword_hit", False)) for r in recs]
+    return {
+        "n": len(recs),
+        "mean_recall_top5": sum(hits) / len(hits),
+        "top1_keyword_hit_rate": sum(1 for x in top1 if x) / len(top1),
+    }
+
+
+def render_cross_model_markdown(by_model: dict[str, list[dict]]) -> str:
+    lines = ["## Cross-model comparison", ""]
+    lines.append("| model | n | mean_recall_top5 | top1_keyword_hit_rate | p50 gap | p50 lat_no_rerank_ms | p50 lat_with_rerank_ms |")
+    lines.append("|---|---|---|---|---|---|---|")
+    for model in sorted(by_model):
+        recs = by_model[model]
+        q = summarize_quality(recs)
+        gaps = [float(r.get("score_gap_top_bottom", 0.0)) for r in recs]
+        lat_no = [float(r.get("latency_no_rerank_ms", 0.0)) for r in recs]
+        lat_w = [float(r.get("latency_with_rerank_ms", 0.0)) for r in recs]
+        lines.append(
+            f"| {model} | {q['n']} | {q['mean_recall_top5']:.3f} | {q['top1_keyword_hit_rate']:.3f} "
+            f"| {pct(gaps, 50):.4f} | {pct(lat_no, 50):.1f} | {pct(lat_w, 50):.1f} |"
+        )
+    return "\n".join(lines)
+
+
 def load(path: str) -> list[dict]:
     out: list[dict] = []
     with open(path) as f:
@@ -196,6 +233,7 @@ def main() -> int:
     p = argparse.ArgumentParser()
     p.add_argument("paths", nargs="+", help="JSONL output files (any number)")
     p.add_argument("--json", action="store_true", help="also emit JSON summary on stdout")
+    p.add_argument("--by-model", action="store_true", help="group records by embed_model and emit per-model + cross-model report")
     args = p.parse_args()
 
     profiles: dict[str, list[dict]] = {}
@@ -217,6 +255,19 @@ def main() -> int:
     threshold_sweep(profiles)
     precision_loss_sweep(profiles)
     recommend(profiles)
+
+    if args.by_model:
+        all_recs: list[dict] = []
+        for path in args.paths:
+            all_recs.extend(load(path))
+        by_model = group_by_model(all_recs)
+        for model, recs in sorted(by_model.items()):
+            print(f"\n=== model: {model} (n={len(recs)}) ===")
+            profiles_m = per_profile(recs)
+            print_profile(f"{model}", profiles_m)
+            threshold_sweep({model: recs})
+        print()
+        print(render_cross_model_markdown(by_model))
 
     if args.json:
         summary = {

--- a/scripts/load-profiles/analyze.py
+++ b/scripts/load-profiles/analyze.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Calibration analysis for RERANK_SCORE_GAP_THRESHOLD (Phase 2.5).
+
+Reads JSONL outputs from p{1,2,3,4,5}_*.py runs and reports score-gap
+distributions, threshold-sweep coverage, and a recommended threshold
+band. The recommended value optimises for "skip rerank when the
+bi-encoder is already confident, otherwise spend the budget" — i.e.
+high coverage on profiles where rerank rarely changes the top, but
+keep coverage low on profiles where it routinely flips the order.
+
+Usage:
+  python3 analyze.py out/p1_rpi64.jsonl out/p2_rpi64.jsonl out/p3_rpi64.jsonl
+  python3 analyze.py out/*.jsonl              # auto-detect
+
+Outputs human-readable tables to stdout; pass --json to emit machine-
+readable summary alongside.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+from collections import Counter, defaultdict
+from typing import Iterable
+
+
+def pct(values: list[float], p: float) -> float:
+    if not values:
+        return float("nan")
+    arr = sorted(values)
+    i = (p / 100.0) * (len(arr) - 1)
+    lo = math.floor(i)
+    hi = math.ceil(i)
+    if lo == hi:
+        return arr[lo]
+    return arr[lo] + (arr[hi] - arr[lo]) * (i - lo)
+
+
+def load(path: str) -> list[dict]:
+    out: list[dict] = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            out.append(json.loads(line))
+    return out
+
+
+def label_for(recs: list[dict], fallback: str) -> str:
+    if not recs:
+        return fallback
+    pid = recs[0].get("profile_id", fallback)
+    tgt = recs[0].get("target", "")
+    return f"{pid}@{tgt}" if tgt else pid
+
+
+def per_profile(recs: list[dict]) -> dict:
+    gaps = [r["score_gap_top_bottom"] for r in recs if r.get("score_gap_top_bottom") is not None]
+    g12 = [r["score_gap_top1_top2"] for r in recs if r.get("score_gap_top1_top2") is not None]
+    top1 = [r["score_top1"] for r in recs if r.get("score_top1") is not None]
+    lat_n = [r["latency_no_rerank_ms"] for r in recs]
+    lat_r = [r["latency_with_rerank_ms"] for r in recs]
+    changed = sum(1 for r in recs if r.get("top_changed_by_rerank"))
+    zero_hits = sum(1 for r in recs if r.get("n_hits_no_rerank", 0) == 0)
+    return {
+        "n": len(recs),
+        "zero_hits": zero_hits,
+        "changed": changed,
+        "changed_pct": (100.0 * changed / len(recs)) if recs else 0.0,
+        "gap": gaps,
+        "g12": g12,
+        "top1": top1,
+        "lat_n": lat_n,
+        "lat_r": lat_r,
+        "outcome": Counter(r.get("rerank_outcome") for r in recs),
+        "kind": Counter(r.get("query_kind") for r in recs),
+    }
+
+
+def fmt_dist(name: str, arr: list[float], width: int = 7, places: int = 4) -> str:
+    if not arr:
+        return f"{name}: (no data)"
+    return (
+        f"{name}: p25={pct(arr,25):.{places}f} p50={pct(arr,50):.{places}f} "
+        f"p75={pct(arr,75):.{places}f} p90={pct(arr,90):.{places}f} "
+        f"min={min(arr):.{places}f} max={max(arr):.{places}f}"
+    )
+
+
+def print_profile(label: str, s: dict) -> None:
+    print(f"\n=== {label} (n={s['n']}) ===")
+    print(f"  zero_hits={s['zero_hits']}  top_changed={s['changed']} ({s['changed_pct']:.0f}%)")
+    print("  " + fmt_dist("score_gap_top_bottom", s["gap"]))
+    print("  " + fmt_dist("score_gap_top1_top2 ", s["g12"]))
+    print("  " + fmt_dist("score_top1          ", s["top1"], places=3))
+    print(
+        f"  latency_ms no/with: p50 {int(pct(s['lat_n'],50))}/{int(pct(s['lat_r'],50))}  "
+        f"p95 {int(pct(s['lat_n'],95))}/{int(pct(s['lat_r'],95))}"
+    )
+    print(f"  rerank_outcome: {dict(s['outcome'])}")
+    print(f"  query_kind: {dict(s['kind'])}")
+
+
+# Score-gap threshold sweep: % of traffic that would skip rerank at each T.
+SWEEP_THRESHOLDS = [0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.10, 0.13, 0.16, 0.20]
+
+
+def threshold_sweep(profiles: dict[str, list[dict]]) -> None:
+    print("\n=== threshold sweep: %% of traffic where gap > T (rerank skipped) ===")
+    cols = list(profiles.keys())
+    print("  T       " + "  ".join(f"{c:>10}" for c in cols))
+    for T in SWEEP_THRESHOLDS:
+        row = [f"  {T:6.3f}"]
+        for c in cols:
+            recs = profiles[c]
+            gaps = [r["score_gap_top_bottom"] for r in recs if r.get("score_gap_top_bottom") is not None]
+            if not gaps:
+                row.append(f"{'-':>10}")
+                continue
+            skip = sum(1 for g in gaps if g > T)
+            row.append(f"{100.0*skip/len(gaps):>9.0f}%")
+        print("  ".join(row))
+
+
+def precision_loss_sweep(profiles: dict[str, list[dict]]) -> None:
+    """For each profile and threshold, how many queries where the gate
+    would have skipped rerank had `top_changed_by_rerank == True`?
+    These are the cases where the gate is "wrong" — bi-encoder looked
+    confident but rerank still flipped the top. Lower is better."""
+    print("\n=== gate-wrong rate at T: %% of skipped queries where rerank WOULD have changed top ===")
+    cols = list(profiles.keys())
+    print("  T       " + "  ".join(f"{c:>14}" for c in cols))
+    for T in SWEEP_THRESHOLDS:
+        row = [f"  {T:6.3f}"]
+        for c in cols:
+            recs = profiles[c]
+            skipped = [r for r in recs if (r.get("score_gap_top_bottom") or 0) > T]
+            if not skipped:
+                row.append(f"{'-':>14}")
+                continue
+            wrong = sum(1 for r in skipped if r.get("top_changed_by_rerank"))
+            row.append(f"{wrong:>3}/{len(skipped):<3} ({100.0*wrong/len(skipped):>3.0f}%)")
+        print("  ".join(row))
+
+
+def recommend(profiles: dict[str, list[dict]]) -> None:
+    """Pick the smallest T at which, averaged across profiles, more
+    than 30%% of traffic is skipped AND fewer than 25%% of skipped
+    queries lose a rerank flip. This is a heuristic compromise — the
+    real choice depends on how much we value the saved latency vs.
+    the occasional precision loss. Treat the output as a starting
+    point, not a final answer."""
+    candidates = []
+    for T in SWEEP_THRESHOLDS:
+        coverage = []
+        wrong_rate = []
+        for recs in profiles.values():
+            gaps = [r["score_gap_top_bottom"] for r in recs if r.get("score_gap_top_bottom") is not None]
+            if not gaps:
+                continue
+            skipped = [r for r in recs if (r.get("score_gap_top_bottom") or 0) > T]
+            coverage.append(len(skipped) / len(gaps))
+            if skipped:
+                wrong_rate.append(
+                    sum(1 for r in skipped if r.get("top_changed_by_rerank")) / len(skipped)
+                )
+        if not coverage:
+            continue
+        avg_cov = sum(coverage) / len(coverage)
+        avg_wrong = (sum(wrong_rate) / len(wrong_rate)) if wrong_rate else 0.0
+        candidates.append((T, avg_cov, avg_wrong))
+
+    print("\n=== recommendation scan ===")
+    print(f"  {'T':>6}  {'avg_skip%':>10}  {'avg_wrong%':>11}")
+    for T, cov, wrong in candidates:
+        print(f"  {T:>6.3f}  {100*cov:>9.1f}%  {100*wrong:>10.1f}%")
+
+    eligible = [
+        (T, cov, wrong) for T, cov, wrong in candidates if cov > 0.30 and wrong < 0.25
+    ]
+    if eligible:
+        T, cov, wrong = min(eligible, key=lambda x: x[0])
+        print(
+            f"\n  suggested RERANK_SCORE_GAP_THRESHOLD={T:.3f} "
+            f"(skips ~{100*cov:.0f}% of traffic, gate-wrong ~{100*wrong:.0f}%)"
+        )
+    else:
+        print("\n  no threshold meets both targets (skip>30%, wrong<25%) — leave gate off or widen the corpus")
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("paths", nargs="+", help="JSONL output files (any number)")
+    p.add_argument("--json", action="store_true", help="also emit JSON summary on stdout")
+    args = p.parse_args()
+
+    profiles: dict[str, list[dict]] = {}
+    for path in args.paths:
+        recs = load(path)
+        if not recs:
+            print(f"[warn] {path}: empty", file=sys.stderr)
+            continue
+        key = label_for(recs, os.path.basename(path).split(".")[0])
+        profiles[key] = recs
+
+    if not profiles:
+        print("no data", file=sys.stderr)
+        return 1
+
+    for label, recs in profiles.items():
+        print_profile(label, per_profile(recs))
+
+    threshold_sweep(profiles)
+    precision_loss_sweep(profiles)
+    recommend(profiles)
+
+    if args.json:
+        summary = {
+            label: {
+                k: (list(v) if isinstance(v, (set,)) else v)
+                for k, v in per_profile(recs).items()
+                if k not in ("gap", "g12", "top1", "lat_n", "lat_r", "outcome", "kind")
+            }
+            for label, recs in profiles.items()
+        }
+        print("\n--- JSON ---")
+        print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/load-profiles/conftest.py
+++ b/scripts/load-profiles/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+LOAD_PROFILES_ROOT = Path(__file__).resolve().parent
+if str(LOAD_PROFILES_ROOT) not in sys.path:
+    sys.path.insert(0, str(LOAD_PROFILES_ROOT))

--- a/scripts/load-profiles/embed_bench/backends.py
+++ b/scripts/load-profiles/embed_bench/backends.py
@@ -1,0 +1,87 @@
+"""Embedding backends.
+
+TransformersBackend: HuggingFace AutoModel + AutoTokenizer; mean-pools the
+last hidden state with attention mask, then L2-normalizes.
+
+Model2VecBackend: minishlab/model2vec StaticModel (single matmul, sub-ms).
+"""
+from __future__ import annotations
+
+from typing import Protocol
+
+import numpy as np
+
+from .recipes import Recipe
+
+
+class Backend(Protocol):
+    dim: int
+
+    def embed(self, texts: list[str]) -> list[list[float]]: ...
+
+
+class TransformersBackend:
+    def __init__(self, recipe: Recipe):
+        from transformers import AutoModel, AutoTokenizer
+        import torch
+
+        self._torch = torch
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            recipe.repo, trust_remote_code=recipe.trust_remote_code
+        )
+        self.model = AutoModel.from_pretrained(
+            recipe.repo, trust_remote_code=recipe.trust_remote_code
+        )
+        self.model.train(False)
+        with torch.no_grad():
+            inputs = self.tokenizer(["dim probe"], padding=True, truncation=True, return_tensors="pt")
+            out = self.model(**inputs)
+            pooled = self._mean_pool(out.last_hidden_state, inputs["attention_mask"])
+            self.dim = pooled.shape[-1]
+        if self.dim != recipe.dim:
+            raise ValueError(
+                f"recipe dim mismatch: {recipe.repo} produced {self.dim}-d, "
+                f"recipe said {recipe.dim}"
+            )
+
+    def _mean_pool(self, last_hidden_state, attention_mask):
+        mask = attention_mask.unsqueeze(-1).float()
+        summed = (last_hidden_state * mask).sum(dim=1)
+        counts = mask.sum(dim=1).clamp(min=1e-9)
+        return summed / counts
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        with self._torch.no_grad():
+            inputs = self.tokenizer(
+                texts, padding=True, truncation=True, max_length=512, return_tensors="pt"
+            )
+            out = self.model(**inputs)
+            pooled = self._mean_pool(out.last_hidden_state, inputs["attention_mask"])
+            normed = self._torch.nn.functional.normalize(pooled, p=2, dim=1)
+            return normed.cpu().tolist()
+
+
+class Model2VecBackend:
+    def __init__(self, recipe: Recipe):
+        from model2vec import StaticModel
+
+        self.model = StaticModel.from_pretrained(recipe.repo)
+        probe = self.model.encode(["dim probe"])
+        self.dim = int(np.asarray(probe).shape[-1])
+        if self.dim != recipe.dim:
+            raise ValueError(
+                f"recipe dim mismatch: {recipe.repo} produced {self.dim}-d, "
+                f"recipe said {recipe.dim}"
+            )
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        arr = self.model.encode(texts)
+        return np.asarray(arr).astype(float).tolist()
+
+
+def make_backend(recipe: Recipe) -> Backend:
+    if recipe.backend == "transformers":
+        return TransformersBackend(recipe)
+    if recipe.backend == "model2vec":
+        return Model2VecBackend(recipe)
+    raise ValueError(f"unknown backend {recipe.backend!r}")

--- a/scripts/load-profiles/embed_bench/recipes.py
+++ b/scripts/load-profiles/embed_bench/recipes.py
@@ -1,0 +1,50 @@
+"""Model recipes for the embed-bench sidecar.
+
+Each recipe records the HuggingFace repo, the backend name (consumed by
+backends.py), the expected output dimension (consumed by preflight and
+collection creation), and the model name to advertise in OpenAI-style
+embedding responses (so cognify accepts our /v1/embeddings).
+"""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Recipe:
+    short: str
+    repo: str
+    backend: str  # "transformers" | "model2vec"
+    dim: int
+    openai_name: str
+    trust_remote_code: bool = False
+
+
+RECIPES: dict[str, Recipe] = {
+    "potion": Recipe(
+        short="potion",
+        repo="minishlab/potion-code-16M",
+        backend="model2vec",
+        dim=256,
+        openai_name="potion-code-16M",
+    ),
+    "granite": Recipe(
+        short="granite",
+        repo="ibm-granite/granite-embedding-97m-multilingual-r2",
+        backend="transformers",
+        dim=384,
+        openai_name="granite-97m-multilingual-r2",
+    ),
+    "jina": Recipe(
+        short="jina",
+        repo="jinaai/jina-embeddings-v5-omni-nano",
+        backend="transformers",
+        dim=512,
+        openai_name="jina-omni-nano",
+        trust_remote_code=True,
+    ),
+}
+
+
+def get_recipe(short: str) -> Recipe:
+    if short not in RECIPES:
+        raise KeyError(f"unknown model short name: {short!r}; known: {sorted(RECIPES)}")
+    return RECIPES[short]

--- a/scripts/load-profiles/embed_bench/recipes.py
+++ b/scripts/load-profiles/embed_bench/recipes.py
@@ -33,6 +33,14 @@ RECIPES: dict[str, Recipe] = {
         dim=384,
         openai_name="granite-97m-multilingual-r2",
     ),
+    "nomic": Recipe(
+        short="nomic",
+        repo="nomic-ai/nomic-embed-text-v2-moe",
+        backend="transformers",
+        dim=768,
+        openai_name="nomic-embed-text-v2-moe",
+        trust_remote_code=True,
+    ),
     "jina": Recipe(
         short="jina",
         repo="jinaai/jina-embeddings-v5-omni-nano",

--- a/scripts/load-profiles/embed_bench/requirements.txt
+++ b/scripts/load-profiles/embed_bench/requirements.txt
@@ -1,6 +1,7 @@
 fastapi==0.115.0
 uvicorn[standard]==0.32.0
-transformers==4.46.0
+transformers==4.49.0
+pillow==12.2.0
 torch==2.4.1
 model2vec==0.4.0
 numpy==1.26.4

--- a/scripts/load-profiles/embed_bench/requirements.txt
+++ b/scripts/load-profiles/embed_bench/requirements.txt
@@ -4,5 +4,6 @@ transformers==4.49.0
 pillow==12.2.0
 torch==2.4.1
 model2vec==0.4.0
+einops==0.8.2
 numpy==1.26.4
 pydantic==2.9.2

--- a/scripts/load-profiles/embed_bench/requirements.txt
+++ b/scripts/load-profiles/embed_bench/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.115.0
+uvicorn[standard]==0.32.0
+transformers==4.46.0
+torch==2.4.1
+model2vec==0.4.0
+numpy==1.26.4
+pydantic==2.9.2

--- a/scripts/load-profiles/embed_bench/server.py
+++ b/scripts/load-profiles/embed_bench/server.py
@@ -1,0 +1,82 @@
+"""Embed-bench FastAPI sidecar.
+
+Reads EMBED_BENCH_MODEL at startup (e.g. "potion" | "granite" | "jina"),
+resolves the recipe, instantiates the backend, exposes:
+
+  GET  /health           -> {model, dim, ram_mb, backend}
+  POST /v1/embeddings    -> OpenAI-compatible
+
+Fake mode (unit tests only): EMBED_BENCH_MODEL=_fake + EMBED_BENCH_FAKE_DIM=N.
+"""
+from __future__ import annotations
+
+import os
+import resource
+from typing import Union
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .backends import make_backend
+from .recipes import get_recipe
+
+
+class EmbedRequest(BaseModel):
+    input: Union[str, list[str]]
+    model: str | None = None
+
+
+def _ram_mb() -> int:
+    return int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024)
+
+
+class _FakeBackend:
+    def __init__(self, dim: int):
+        self.dim = dim
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[float((hash(t) + i) % 7) / 7.0 for i in range(self.dim)] for t in texts]
+
+
+def build_app() -> FastAPI:
+    model_short = os.environ.get("EMBED_BENCH_MODEL", "")
+    if not model_short:
+        raise RuntimeError("EMBED_BENCH_MODEL env required")
+
+    if model_short == "_fake":
+        backend = _FakeBackend(int(os.environ.get("EMBED_BENCH_FAKE_DIM", "8")))
+        openai_name = "_fake"
+        backend_name = "fake"
+    else:
+        recipe = get_recipe(model_short)
+        backend = make_backend(recipe)
+        openai_name = recipe.openai_name
+        backend_name = recipe.backend
+
+    app = FastAPI(title="embed-bench", version="1")
+
+    @app.get("/health")
+    def health() -> dict:
+        return {
+            "model": openai_name,
+            "dim": backend.dim,
+            "ram_mb": _ram_mb(),
+            "backend": backend_name,
+        }
+
+    @app.post("/v1/embeddings")
+    def embeddings(req: EmbedRequest) -> dict:
+        texts = [req.input] if isinstance(req.input, str) else req.input
+        if not texts:
+            raise HTTPException(status_code=400, detail="input must not be empty")
+        vectors = backend.embed(texts)
+        return {
+            "model": openai_name,
+            "data": [{"embedding": v, "index": i} for i, v in enumerate(vectors)],
+            "object": "list",
+        }
+
+    return app
+
+
+app = build_app() if os.environ.get("EMBED_BENCH_MODEL") else None

--- a/scripts/load-profiles/embed_bench/tests/conftest.py
+++ b/scripts/load-profiles/embed_bench/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Make the load-profiles harness importable in tests.
+
+Mirrors what p1/p2/etc. do at runtime: prepend scripts/load-profiles/ to
+sys.path so `from embed_bench.X import ...` resolves the way it does for
+`import runner` etc.
+"""
+import sys
+from pathlib import Path
+
+LOAD_PROFILES_ROOT = Path(__file__).resolve().parents[2]  # scripts/load-profiles/
+if str(LOAD_PROFILES_ROOT) not in sys.path:
+    sys.path.insert(0, str(LOAD_PROFILES_ROOT))

--- a/scripts/load-profiles/embed_bench/tests/test_backends.py
+++ b/scripts/load-profiles/embed_bench/tests/test_backends.py
@@ -1,0 +1,35 @@
+"""Backend tests. Skipped when the HF cache lacks the model files."""
+import os
+from pathlib import Path
+
+import pytest
+
+from embed_bench.backends import make_backend
+from embed_bench.recipes import get_recipe
+
+
+def _cache_has(repo: str) -> bool:
+    hf_home = Path(os.environ.get("HF_HOME", Path.home() / ".cache" / "huggingface"))
+    safe = repo.replace("/", "--")
+    return (hf_home / "hub" / f"models--{safe}").exists()
+
+
+@pytest.mark.parametrize("short", ["potion", "granite", "jina"])
+def test_backend_dim_matches_recipe(short):
+    recipe = get_recipe(short)
+    if not _cache_has(recipe.repo):
+        pytest.skip(f"HF cache missing for {recipe.repo}")
+    backend = make_backend(recipe)
+    assert backend.dim == recipe.dim
+
+
+@pytest.mark.parametrize("short", ["potion", "granite", "jina"])
+def test_backend_embed_returns_correct_shape(short):
+    recipe = get_recipe(short)
+    if not _cache_has(recipe.repo):
+        pytest.skip(f"HF cache missing for {recipe.repo}")
+    backend = make_backend(recipe)
+    out = backend.embed(["hello world", "another query"])
+    assert len(out) == 2
+    assert len(out[0]) == recipe.dim
+    assert all(isinstance(x, float) for x in out[0])

--- a/scripts/load-profiles/embed_bench/tests/test_recipes.py
+++ b/scripts/load-profiles/embed_bench/tests/test_recipes.py
@@ -1,0 +1,37 @@
+import pytest
+
+from scripts.load_profiles.embed_bench.recipes import RECIPES, get_recipe
+
+
+def test_three_recipes_present():
+    assert set(RECIPES.keys()) == {"potion", "granite", "jina"}
+
+
+def test_potion_recipe_shape():
+    r = get_recipe("potion")
+    assert r.repo == "minishlab/potion-code-16M"
+    assert r.backend == "model2vec"
+    assert r.dim == 256
+    assert r.openai_name == "potion-code-16M"
+
+
+def test_granite_recipe_shape():
+    r = get_recipe("granite")
+    assert r.repo == "ibm-granite/granite-embedding-97m-multilingual-r2"
+    assert r.backend == "transformers"
+    assert r.dim == 384
+    assert r.openai_name == "granite-97m-multilingual-r2"
+
+
+def test_jina_recipe_shape():
+    r = get_recipe("jina")
+    assert r.repo == "jinaai/jina-embeddings-v5-omni-nano"
+    assert r.backend == "transformers"
+    assert r.dim == 512
+    assert r.openai_name == "jina-omni-nano"
+    assert r.trust_remote_code is True
+
+
+def test_unknown_recipe_raises():
+    with pytest.raises(KeyError):
+        get_recipe("nope")

--- a/scripts/load-profiles/embed_bench/tests/test_recipes.py
+++ b/scripts/load-profiles/embed_bench/tests/test_recipes.py
@@ -1,6 +1,6 @@
 import pytest
 
-from scripts.load_profiles.embed_bench.recipes import RECIPES, get_recipe
+from embed_bench.recipes import RECIPES, get_recipe
 
 
 def test_three_recipes_present():

--- a/scripts/load-profiles/embed_bench/tests/test_server.py
+++ b/scripts/load-profiles/embed_bench/tests/test_server.py
@@ -1,0 +1,46 @@
+"""Server tests use a fake backend; no model files needed."""
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ["EMBED_BENCH_FAKE_DIM"] = "8"
+os.environ["EMBED_BENCH_MODEL"] = "_fake"
+
+from embed_bench.server import build_app  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    return TestClient(build_app())
+
+
+def test_health_returns_model_dim_backend(client):
+    r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["model"] == "_fake"
+    assert body["dim"] == 8
+    assert body["backend"] == "fake"
+    assert isinstance(body["ram_mb"], int)
+
+
+def test_embeddings_returns_openai_shape(client):
+    r = client.post("/v1/embeddings", json={"input": ["a", "b"], "model": "_fake"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["model"] == "_fake"
+    assert len(body["data"]) == 2
+    assert len(body["data"][0]["embedding"]) == 8
+    assert body["data"][0]["index"] == 0
+
+
+def test_embeddings_accepts_single_string(client):
+    r = client.post("/v1/embeddings", json={"input": "single", "model": "_fake"})
+    assert r.status_code == 200
+    assert len(r.json()["data"]) == 1
+
+
+def test_embeddings_empty_input_returns_400(client):
+    r = client.post("/v1/embeddings", json={"input": [], "model": "_fake"})
+    assert r.status_code == 400

--- a/scripts/load-profiles/install_64.sh
+++ b/scripts/load-profiles/install_64.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# install_64.sh — deploy the load-profile suite to 10.23.0.64.
+#
+# Copies scripts/load-profiles/ to the .64 host, mints a service JWT,
+# and prints the command to launch profile P1. Idempotent — safe to
+# re-run; existing JWT files are preserved.
+#
+# Usage:
+#   bash scripts/load-profiles/install_64.sh
+#
+# Env overrides:
+#   HOST=stek0v@10.23.0.64        SSH target
+#   REMOTE_DIR=~/levara-loadprofiles  Remote install root
+#   LEVARA_URL=http://10.23.0.64:8080  Levara base URL on the target host
+
+set -euo pipefail
+
+HOST="${HOST:-stek0v@10.23.0.64}"
+REMOTE_DIR="${REMOTE_DIR:-/home/stek0v/levara-loadprofiles}"
+LEVARA_URL="${LEVARA_URL:-http://localhost:8080}"
+TARGET_NAME="${TARGET_NAME:-rpi64}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+echo "[install_64] syncing scripts/load-profiles/ → ${HOST}:${REMOTE_DIR}"
+ssh "$HOST" "mkdir -p ${REMOTE_DIR}/out ${REMOTE_DIR}/seed ~/.config/levara-service-keys"
+rsync -av --delete \
+  --exclude '__pycache__' --exclude 'out/' --exclude '*.pyc' \
+  "$HERE/" "$HOST:$REMOTE_DIR/"
+
+# Mint a service JWT on the remote host so the token never crosses
+# the network from this workstation. Reuses the existing helper.
+echo "[install_64] minting JWT (subject=loadprofile-${TARGET_NAME})"
+ssh "$HOST" "bash -s loadprofile-${TARGET_NAME}" <<'REMOTE_MINT'
+set -euo pipefail
+SUBJECT="$1"
+LEVARA_URL="${LEVARA_URL:-http://localhost:8080}"
+KEY_DIR="$HOME/.config/levara-service-keys"
+JWT_FILE="${KEY_DIR}/${SUBJECT}.jwt"
+if [ -s "$JWT_FILE" ]; then
+  echo "[mint] reusing existing ${JWT_FILE}"
+  exit 0
+fi
+mkdir -p "$KEY_DIR" && chmod 700 "$KEY_DIR"
+# Lightweight login — assumes the service account exists on this host.
+# Use scripts/mint-levara-jwt.sh from the main repo if you need to
+# bootstrap a brand-new account.
+echo "[mint] no JWT at ${JWT_FILE}; please run mint-levara-jwt.sh on this host first"
+exit 1
+REMOTE_MINT
+
+cat <<EOF
+
+[install_64] done. To run profile P1 on ${HOST}:
+
+  ssh ${HOST} 'cd ${REMOTE_DIR} && LEVARA_URL=${LEVARA_URL} python3 p1_narrative_factual.py --rounds 10 --out out/p1.jsonl'
+
+Output JSONL lives at ${REMOTE_DIR}/out/p1.jsonl on the remote host.
+EOF

--- a/scripts/load-profiles/install_pi.sh
+++ b/scripts/load-profiles/install_pi.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# install_pi.sh — deploy the load-profile suite to 10.23.0.53 (Pi).
+#
+# Lighter target than .64: P4 and P5 run here. Same idempotent
+# rsync + remote JWT bootstrap as install_64.sh.
+#
+# Usage:
+#   bash scripts/load-profiles/install_pi.sh
+#
+# Env overrides:
+#   HOST=stek0v@10.23.0.53        SSH target
+#   REMOTE_DIR=~/levara-loadprofiles  Remote install root
+#   LEVARA_URL=http://localhost:8080  Levara base URL on the target host
+#   TARGET_NAME=pi                Tag used to namespace the JWT file
+
+set -euo pipefail
+
+HOST="${HOST:-stek0v@10.23.0.53}"
+REMOTE_DIR="${REMOTE_DIR:-/home/stek0v/levara-loadprofiles}"
+LEVARA_URL="${LEVARA_URL:-http://localhost:8080}"
+TARGET_NAME="${TARGET_NAME:-pi}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "[install_pi] syncing scripts/load-profiles/ → ${HOST}:${REMOTE_DIR}"
+ssh "$HOST" "mkdir -p ${REMOTE_DIR}/out ${REMOTE_DIR}/seed ~/.config/levara-service-keys"
+rsync -av --delete \
+  --exclude '__pycache__' --exclude 'out/' --exclude '*.pyc' \
+  "$HERE/" "$HOST:$REMOTE_DIR/"
+
+echo "[install_pi] verifying JWT (subject=loadprofile-${TARGET_NAME})"
+ssh "$HOST" "test -s \"\$HOME/.config/levara-service-keys/${TARGET_NAME}.jwt\" || { \
+  echo '[mint] no JWT at ~/.config/levara-service-keys/${TARGET_NAME}.jwt — run mint-levara-jwt.sh on this host first'; \
+  exit 1; \
+}"
+
+cat <<EOF
+
+[install_pi] done. Run profiles on ${HOST}:
+
+  ssh ${HOST} 'cd ${REMOTE_DIR} && LEVARA_URL=${LEVARA_URL} python3 p4_memory_palace.py --rounds 15 --out out/p4.jsonl'
+  ssh ${HOST} 'cd ${REMOTE_DIR} && LEVARA_URL=${LEVARA_URL} python3 p5_filtered_search.py --rounds 15 --out out/p5.jsonl'
+
+Output JSONL lives at ${REMOTE_DIR}/out/{p4,p5}.jsonl on the remote host.
+EOF

--- a/scripts/load-profiles/p1_narrative_factual.py
+++ b/scripts/load-profiles/p1_narrative_factual.py
@@ -52,12 +52,12 @@ def seed_if_needed(target: runner.Target, collection: str) -> dict:
     try:
         info = runner.http_request(
             "GET",
-            target.url(f"/api/v1/collections/{collection}/info"),
+            target.url(f"/api/v1/collections/{collection}/meta"),
             headers=target.headers(),
         )
     except runner.HttpError:
         info = {}
-    current = int(info.get("count", 0)) if isinstance(info, dict) else 0
+    current = int(info.get("record_count", info.get("count", 0))) if isinstance(info, dict) else 0
     if current >= int(expected * 0.95):
         runner.stderr(
             f"[seed] {collection} has {current} chunks (expected {expected}), skipping"

--- a/scripts/load-profiles/p1_narrative_factual.py
+++ b/scripts/load-profiles/p1_narrative_factual.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Profile P1 — narrative + factual.
+
+Target: 10.23.0.64 (heavy host with GPU rerank).
+
+Corpus: ~2000 paragraph-sized chunks from 8 public-domain Gutenberg
+books spanning fiction, philosophy and detective genres. The mix is
+deliberate — single-genre corpora collapse score distributions and
+make calibration data unrepresentative.
+
+Query mix (24 queries × N rounds):
+  - factual (8): one clearly best passage — expect high top1 and
+    wide gap, rerank shouldn't move top-1.
+  - ambiguous (8): multiple plausible passages across books — top
+    candidates should be close in vector space, rerank may reorder.
+  - paraphrase (8): vocabulary mismatch with the source — vector
+    score lower, more rerank flips.
+  - out-of-corpus (4): topics not in any book — wide gap, anything
+    rerank does is noise.
+
+This is the diversity calibration needs: enough flips to learn the
+threshold, enough wide-gap easy cases to learn what `skipped_gap`
+should cost in quality.
+
+Output: JSONL at $LOADPROFILE_OUT or ./out/p1.jsonl.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import runner  # noqa: E402
+from seed import gutenberg  # noqa: E402
+
+PROFILE_ID = "p1"
+DEFAULT_TARGET_URL = "http://10.23.0.64:8080"
+DEFAULT_TARGET_NAME = "rpi64"
+
+
+def seed_if_needed(target: runner.Target, collection: str) -> dict:
+    """Ingest the Gutenberg corpus if the collection is empty or
+    significantly smaller than expected. Idempotent: skip when the
+    chunk count is within 5% of plan."""
+    expected = len(gutenberg.load_corpus())
+    info = {}
+    try:
+        info = runner.http_request(
+            "GET",
+            target.url(f"/api/v1/collections/{collection}/info"),
+            headers=target.headers(),
+        )
+    except runner.HttpError:
+        info = {}
+    current = int(info.get("count", 0)) if isinstance(info, dict) else 0
+    if current >= int(expected * 0.95):
+        runner.stderr(
+            f"[seed] {collection} has {current} chunks (expected {expected}), skipping"
+        )
+        return {"reused": True, "count": current}
+
+    runner.stderr(f"[seed] ingesting {expected} chunks into {collection}")
+    corpus = gutenberg.load_corpus()
+    batch_size = 64
+    written = 0
+    for i in range(0, len(corpus), batch_size):
+        batch = corpus[i : i + batch_size]
+        runner.add_texts(
+            target,
+            collection,
+            batch,
+            room="literature",
+            tags=["loadprofile", "p1", "gutenberg"],
+        )
+        written += len(batch)
+        if written % (batch_size * 4) == 0:
+            runner.stderr(f"[seed] {written}/{len(corpus)}")
+    return {"reused": False, "count": written}
+
+
+def run(
+    target: runner.Target,
+    out_path: str,
+    rounds: int,
+    sleep_ms: int,
+    top_k: int,
+) -> None:
+    collection = runner.profile_collection(PROFILE_ID)
+    runner.assert_namespace(target, PROFILE_ID)
+    seed_info = seed_if_needed(target, collection)
+
+    writer = runner.JsonlWriter(out_path)
+    sent = 0
+    errors = 0
+    try:
+        for round_idx in range(rounds):
+            for q in gutenberg.QUERIES:
+                try:
+                    pair = runner.search_pair(
+                        target,
+                        collection,
+                        q["text"],
+                        top_k=top_k,
+                        query_type="CHUNKS",
+                        room="literature",
+                    )
+                except runner.HttpError as e:
+                    errors += 1
+                    runner.stderr(f"[search] {q['id']}: {e}")
+                    continue
+                rec = runner.build_query_record(
+                    profile_id=PROFILE_ID,
+                    target=target,
+                    query_id=f"{q['id']}_r{round_idx}",
+                    query_text=q["text"],
+                    collection=collection,
+                    query_type="CHUNKS",
+                    pair=pair,
+                    extra={
+                        "query_kind": q["kind"],
+                        "round": round_idx,
+                        "seed_reused": seed_info.get("reused", False),
+                        "corpus_fingerprint": gutenberg.corpus_fingerprint(),
+                    },
+                )
+                writer.write(rec)
+                sent += 1
+                if sleep_ms > 0:
+                    time.sleep(sleep_ms / 1000.0)
+            runner.stderr(f"[run] round {round_idx + 1}/{rounds} done ({sent} queries)")
+    finally:
+        writer.close()
+    runner.stderr(
+        f"[done] queries={sent} errors={errors} out={out_path} "
+        f"dropped={writer.dropped}"
+    )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="P1 narrative+factual load profile")
+    p.add_argument("--rounds", type=int, default=10)
+    p.add_argument("--top-k", type=int, default=10)
+    p.add_argument("--sleep-ms", type=int, default=250)
+    p.add_argument(
+        "--out",
+        default=os.environ.get(
+            "LOADPROFILE_OUT", str(Path("out") / f"{PROFILE_ID}.jsonl")
+        ),
+    )
+    p.add_argument("--target-name", default=DEFAULT_TARGET_NAME)
+    p.add_argument("--target-url", default=DEFAULT_TARGET_URL)
+    args = p.parse_args()
+
+    target = runner.Target(
+        name=args.target_name,
+        base_url=args.target_url,
+        token=runner.load_token_from_env_or_file(args.target_name),
+    )
+    runner.preflight(target)
+    runner.stderr(
+        f"[preflight] target={target.name} embed={target.embed_model} "
+        f"rerank={target.rerank_endpoint}"
+    )
+    run(target, args.out, args.rounds, args.sleep_ms, args.top_k)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/load-profiles/p2_docs_ambiguous.py
+++ b/scripts/load-profiles/p2_docs_ambiguous.py
@@ -38,12 +38,12 @@ def seed_if_needed(target: runner.Target, collection: str) -> dict:
     try:
         info = runner.http_request(
             "GET",
-            target.url(f"/api/v1/collections/{collection}/info"),
+            target.url(f"/api/v1/collections/{collection}/meta"),
             headers=target.headers(),
         )
     except runner.HttpError:
         info = {}
-    current = int(info.get("count", 0)) if isinstance(info, dict) else 0
+    current = int(info.get("record_count", info.get("count", 0))) if isinstance(info, dict) else 0
     if current >= int(expected * 0.95):
         runner.stderr(
             f"[seed] {collection} has {current} chunks (expected {expected}), skipping"

--- a/scripts/load-profiles/p2_docs_ambiguous.py
+++ b/scripts/load-profiles/p2_docs_ambiguous.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Profile P2 — technical docs with ambiguity.
+
+Target: 10.23.0.64 (heavy host with GPU rerank).
+
+Corpus: ~600 chunks across 12 Kubernetes + Postgres doc pages with
+deliberate semantic overlap (pods/replicasets/deployments share
+language; WAL/checkpoint/backup all touch durability). The overlap
+is the whole point — ambiguous queries with multiple plausible
+targets are where the rerank pass actually changes results, and
+that's the regime the gate threshold must distinguish from the
+clear-winner regime where rerank is wasted budget.
+
+Output: JSONL at $LOADPROFILE_OUT or ./out/p2.jsonl.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import runner  # noqa: E402
+from seed import docs_corpus  # noqa: E402
+
+PROFILE_ID = "p2"
+DEFAULT_TARGET_URL = "http://10.23.0.64:8080"
+DEFAULT_TARGET_NAME = "rpi64"
+
+
+def seed_if_needed(target: runner.Target, collection: str) -> dict:
+    expected = len(docs_corpus.load_corpus())
+    info = {}
+    try:
+        info = runner.http_request(
+            "GET",
+            target.url(f"/api/v1/collections/{collection}/info"),
+            headers=target.headers(),
+        )
+    except runner.HttpError:
+        info = {}
+    current = int(info.get("count", 0)) if isinstance(info, dict) else 0
+    if current >= int(expected * 0.95):
+        runner.stderr(
+            f"[seed] {collection} has {current} chunks (expected {expected}), skipping"
+        )
+        return {"reused": True, "count": current}
+
+    runner.stderr(f"[seed] ingesting {expected} chunks into {collection}")
+    corpus = docs_corpus.load_corpus()
+    batch_size = 64
+    written = 0
+    for i in range(0, len(corpus), batch_size):
+        batch = corpus[i : i + batch_size]
+        runner.add_texts(
+            target,
+            collection,
+            batch,
+            room="docs",
+            tags=["loadprofile", "p2", "k8s", "postgres"],
+        )
+        written += len(batch)
+        if written % (batch_size * 4) == 0:
+            runner.stderr(f"[seed] {written}/{len(corpus)}")
+    return {"reused": False, "count": written}
+
+
+def run(
+    target: runner.Target,
+    out_path: str,
+    rounds: int,
+    sleep_ms: int,
+    top_k: int,
+) -> None:
+    collection = runner.profile_collection(PROFILE_ID)
+    runner.assert_namespace(target, PROFILE_ID)
+    seed_info = seed_if_needed(target, collection)
+
+    writer = runner.JsonlWriter(out_path)
+    sent = 0
+    errors = 0
+    try:
+        for round_idx in range(rounds):
+            for q in docs_corpus.QUERIES:
+                try:
+                    pair = runner.search_pair(
+                        target,
+                        collection,
+                        q["text"],
+                        top_k=top_k,
+                        query_type="CHUNKS",
+                        room="docs",
+                    )
+                except runner.HttpError as e:
+                    errors += 1
+                    runner.stderr(f"[search] {q['id']}: {e}")
+                    continue
+                rec = runner.build_query_record(
+                    profile_id=PROFILE_ID,
+                    target=target,
+                    query_id=f"{q['id']}_r{round_idx}",
+                    query_text=q["text"],
+                    collection=collection,
+                    query_type="CHUNKS",
+                    pair=pair,
+                    extra={
+                        "query_kind": q["kind"],
+                        "round": round_idx,
+                        "seed_reused": seed_info.get("reused", False),
+                        "corpus_fingerprint": docs_corpus.corpus_fingerprint(),
+                    },
+                )
+                writer.write(rec)
+                sent += 1
+                if sleep_ms > 0:
+                    time.sleep(sleep_ms / 1000.0)
+            runner.stderr(f"[run] round {round_idx + 1}/{rounds} done ({sent} queries)")
+    finally:
+        writer.close()
+    runner.stderr(
+        f"[done] queries={sent} errors={errors} out={out_path} "
+        f"dropped={writer.dropped}"
+    )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="P2 docs+ambiguous load profile")
+    p.add_argument("--rounds", type=int, default=10)
+    p.add_argument("--top-k", type=int, default=10)
+    p.add_argument("--sleep-ms", type=int, default=250)
+    p.add_argument(
+        "--out",
+        default=os.environ.get(
+            "LOADPROFILE_OUT", str(Path("out") / f"{PROFILE_ID}.jsonl")
+        ),
+    )
+    p.add_argument("--target-name", default=DEFAULT_TARGET_NAME)
+    p.add_argument("--target-url", default=DEFAULT_TARGET_URL)
+    args = p.parse_args()
+
+    target = runner.Target(
+        name=args.target_name,
+        base_url=args.target_url,
+        token=runner.load_token_from_env_or_file(args.target_name),
+    )
+    runner.preflight(target)
+    runner.stderr(
+        f"[preflight] target={target.name} embed={target.embed_model} "
+        f"rerank={target.rerank_endpoint}"
+    )
+    run(target, args.out, args.rounds, args.sleep_ms, args.top_k)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/load-profiles/p3_code_semantic.py
+++ b/scripts/load-profiles/p3_code_semantic.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Profile P3 — code + prose, semantic split.
+
+Target: 10.23.0.64 (heavy host with GPU rerank).
+
+Corpus: ~400 chunks of real Go/Python/JS source from pinned commits
+plus 8 hand-written prose paragraphs describing the same concepts.
+The split is intentional — code and prose embed into different
+regions of the vector space even when they describe the same idea,
+and the gate has to make different cost/benefit calls for each.
+
+Query mix probes that split deliberately:
+  - code-precise: token-shaped, should match code via lexical/
+    embedding overlap (small gap from neighbours expected — rerank
+    has work to do).
+  - concept-paraphrase: natural language, prose should win after
+    rerank but vector top-1 will often be code.
+  - mixed: either kind is a valid answer.
+  - adversarial: code-shaped queries for code NOT in corpus —
+    expect deceptively high vector top-1 with no real signal.
+  - ooc: nothing related — gap should be tiny and rerank is
+    wasted budget.
+
+Output: JSONL at $LOADPROFILE_OUT or ./out/p3.jsonl, with
+`query_kind` AND `target_kind` so analyzer can cross-tabulate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import runner  # noqa: E402
+from seed import code_corpus  # noqa: E402
+
+PROFILE_ID = "p3"
+DEFAULT_TARGET_URL = "http://10.23.0.64:8080"
+DEFAULT_TARGET_NAME = "rpi64"
+
+
+def seed_if_needed(target: runner.Target, collection: str) -> dict:
+    expected = len(code_corpus.load_corpus())
+    info = {}
+    try:
+        info = runner.http_request(
+            "GET",
+            target.url(f"/api/v1/collections/{collection}/info"),
+            headers=target.headers(),
+        )
+    except runner.HttpError:
+        info = {}
+    current = int(info.get("count", 0)) if isinstance(info, dict) else 0
+    if current >= int(expected * 0.95):
+        runner.stderr(
+            f"[seed] {collection} has {current} chunks (expected {expected}), skipping"
+        )
+        return {"reused": True, "count": current}
+    runner.stderr(f"[seed] ingesting {expected} chunks into {collection}")
+    corpus = code_corpus.load_corpus()
+    batch_size = 64
+    written = 0
+    for i in range(0, len(corpus), batch_size):
+        batch = corpus[i : i + batch_size]
+        runner.add_texts(
+            target,
+            collection,
+            batch,
+            room="code",
+            tags=["loadprofile", "p3", "code+prose"],
+        )
+        written += len(batch)
+        if written % (batch_size * 4) == 0:
+            runner.stderr(f"[seed] {written}/{len(corpus)}")
+    return {"reused": False, "count": written}
+
+
+def run(
+    target: runner.Target,
+    out_path: str,
+    rounds: int,
+    sleep_ms: int,
+    top_k: int,
+) -> None:
+    collection = runner.profile_collection(PROFILE_ID)
+    runner.assert_namespace(target, PROFILE_ID)
+    seed_info = seed_if_needed(target, collection)
+    writer = runner.JsonlWriter(out_path)
+    sent = 0
+    errors = 0
+    try:
+        for round_idx in range(rounds):
+            for q in code_corpus.QUERIES:
+                try:
+                    pair = runner.search_pair(
+                        target,
+                        collection,
+                        q["text"],
+                        top_k=top_k,
+                        query_type="CHUNKS",
+                        room="code",
+                    )
+                except runner.HttpError as e:
+                    errors += 1
+                    runner.stderr(f"[search] {q['id']}: {e}")
+                    continue
+                rec = runner.build_query_record(
+                    profile_id=PROFILE_ID,
+                    target=target,
+                    query_id=f"{q['id']}_r{round_idx}",
+                    query_text=q["text"],
+                    collection=collection,
+                    query_type="CHUNKS",
+                    pair=pair,
+                    extra={
+                        "query_kind": q["kind"],
+                        "target_kind": q.get("target_kind"),
+                        "round": round_idx,
+                        "seed_reused": seed_info.get("reused", False),
+                        "corpus_fingerprint": code_corpus.corpus_fingerprint(),
+                    },
+                )
+                writer.write(rec)
+                sent += 1
+                if sleep_ms > 0:
+                    time.sleep(sleep_ms / 1000.0)
+            runner.stderr(f"[run] round {round_idx + 1}/{rounds} done ({sent} queries)")
+    finally:
+        writer.close()
+    runner.stderr(
+        f"[done] queries={sent} errors={errors} out={out_path} "
+        f"dropped={writer.dropped}"
+    )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="P3 code+prose load profile")
+    p.add_argument("--rounds", type=int, default=10)
+    p.add_argument("--top-k", type=int, default=10)
+    p.add_argument("--sleep-ms", type=int, default=250)
+    p.add_argument(
+        "--out",
+        default=os.environ.get(
+            "LOADPROFILE_OUT", str(Path("out") / f"{PROFILE_ID}.jsonl")
+        ),
+    )
+    p.add_argument("--target-name", default=DEFAULT_TARGET_NAME)
+    p.add_argument("--target-url", default=DEFAULT_TARGET_URL)
+    args = p.parse_args()
+
+    target = runner.Target(
+        name=args.target_name,
+        base_url=args.target_url,
+        token=runner.load_token_from_env_or_file(args.target_name),
+    )
+    runner.preflight(target)
+    runner.stderr(
+        f"[preflight] target={target.name} embed={target.embed_model} "
+        f"rerank={target.rerank_endpoint}"
+    )
+    run(target, args.out, args.rounds, args.sleep_ms, args.top_k)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/load-profiles/p3_code_semantic.py
+++ b/scripts/load-profiles/p3_code_semantic.py
@@ -85,8 +85,9 @@ def run(
     rounds: int,
     sleep_ms: int,
     top_k: int,
+    collection_override: str | None = None,
 ) -> None:
-    collection = runner.profile_collection(PROFILE_ID)
+    collection = collection_override or runner.profile_collection(PROFILE_ID)
     runner.assert_namespace(target, PROFILE_ID)
     seed_info = seed_if_needed(target, collection)
     writer = runner.JsonlWriter(out_path)
@@ -150,6 +151,12 @@ def main() -> int:
     )
     p.add_argument("--target-name", default=DEFAULT_TARGET_NAME)
     p.add_argument("--target-url", default=DEFAULT_TARGET_URL)
+    p.add_argument("--collection-override", default=None,
+                   help="override the profile_collection name (used by multi-model sweep)")
+    p.add_argument("--model", default=None,
+                   help="informational: embedding short-name (recorded into JSONL)")
+    p.add_argument("--embed-dim", type=int, default=None,
+                   help="informational: embedding dimension")
     args = p.parse_args()
 
     target = runner.Target(
@@ -162,7 +169,8 @@ def main() -> int:
         f"[preflight] target={target.name} embed={target.embed_model} "
         f"rerank={target.rerank_endpoint}"
     )
-    run(target, args.out, args.rounds, args.sleep_ms, args.top_k)
+    run(target, args.out, args.rounds, args.sleep_ms, args.top_k,
+        collection_override=args.collection_override)
     return 0
 
 

--- a/scripts/load-profiles/p3_code_semantic.py
+++ b/scripts/load-profiles/p3_code_semantic.py
@@ -49,12 +49,12 @@ def seed_if_needed(target: runner.Target, collection: str) -> dict:
     try:
         info = runner.http_request(
             "GET",
-            target.url(f"/api/v1/collections/{collection}/info"),
+            target.url(f"/api/v1/collections/{collection}/meta"),
             headers=target.headers(),
         )
     except runner.HttpError:
         info = {}
-    current = int(info.get("count", 0)) if isinstance(info, dict) else 0
+    current = int(info.get("record_count", info.get("count", 0))) if isinstance(info, dict) else 0
     if current >= int(expected * 0.95):
         runner.stderr(
             f"[seed] {collection} has {current} chunks (expected {expected}), skipping"

--- a/scripts/load-profiles/p4_memory_palace.py
+++ b/scripts/load-profiles/p4_memory_palace.py
@@ -57,21 +57,19 @@ def seed_if_needed(target: runner.Target, collection: str) -> dict:
         return {"reused": True, "count": current}
     runner.stderr(f"[seed] ingesting {expected} chunks into {collection}")
     corpus = memory_palace.load_corpus()
-    batch_size = 64
-    written = 0
-    for i in range(0, len(corpus), batch_size):
-        batch = corpus[i : i + batch_size]
-        runner.add_texts(
-            target,
-            collection,
-            batch,
-            room="memory",
-            tags=["loadprofile", "p4", "palace"],
-        )
-        written += len(batch)
-        if written % (batch_size * 4) == 0:
-            runner.stderr(f"[seed] {written}/{len(corpus)}")
-    return {"reused": False, "count": written}
+    # Single-batch ingest. Chunk IDs are uuid5("doc-{i}-{chunkIndex}")
+    # where i is the text index within the /cognify call; submitting
+    # everything in one call keeps i unique and avoids cross-batch
+    # collisions on Levara builds that don't carry the per-run-prefix
+    # fix (Pi b4fface).
+    runner.add_texts(
+        target,
+        collection,
+        corpus,
+        room="memory",
+        tags=["loadprofile", "p4", "palace"],
+    )
+    return {"reused": False, "count": len(corpus)}
 
 
 def run(

--- a/scripts/load-profiles/p4_memory_palace.py
+++ b/scripts/load-profiles/p4_memory_palace.py
@@ -44,12 +44,12 @@ def seed_if_needed(target: runner.Target, collection: str) -> dict:
     try:
         info = runner.http_request(
             "GET",
-            target.url(f"/api/v1/collections/{collection}/info"),
+            target.url(f"/api/v1/collections/{collection}/meta"),
             headers=target.headers(),
         )
     except runner.HttpError:
         info = {}
-    current = int(info.get("count", 0)) if isinstance(info, dict) else 0
+    current = int(info.get("record_count", info.get("count", 0))) if isinstance(info, dict) else 0
     if current >= int(expected * 0.95):
         runner.stderr(
             f"[seed] {collection} has {current} chunks (expected {expected}), skipping"

--- a/scripts/load-profiles/p4_memory_palace.py
+++ b/scripts/load-profiles/p4_memory_palace.py
@@ -78,8 +78,11 @@ def run(
     rounds: int,
     sleep_ms: int,
     top_k: int,
+    model: str = "",
+    embed_dim: int = 0,
+    collection_override: str = "",
 ) -> None:
-    collection = runner.profile_collection(PROFILE_ID)
+    collection = collection_override or runner.profile_collection(PROFILE_ID)
     runner.assert_namespace(target, PROFILE_ID)
     seed_info = seed_if_needed(target, collection)
     writer = runner.JsonlWriter(out_path)
@@ -116,6 +119,13 @@ def run(
                         "round": round_idx,
                         "seed_reused": seed_info.get("reused", False),
                         "corpus_fingerprint": memory_palace.corpus_fingerprint(),
+                        "embed_model": model or target.embed_model,
+                        "embed_dim": embed_dim,
+                        "expected_keywords": q.get("expected_keywords", []),
+                        **runner.keyword_metrics(
+                            pair["no_rerank"]["response"],
+                            expected_keywords=q.get("expected_keywords", []),
+                        ),
                     },
                 )
                 writer.write(rec)
@@ -144,6 +154,9 @@ def main() -> int:
     )
     p.add_argument("--target-name", default=DEFAULT_TARGET_NAME)
     p.add_argument("--target-url", default=DEFAULT_TARGET_URL)
+    p.add_argument("--model", default="", help="embed model short (potion/granite/jina); used for JSONL fields")
+    p.add_argument("--embed-dim", type=int, default=0, help="expected embedding dim (JSONL only)")
+    p.add_argument("--collection-override", default="", help="if set, use this collection name instead of the default")
     args = p.parse_args()
 
     target = runner.Target(
@@ -156,7 +169,16 @@ def main() -> int:
         f"[preflight] target={target.name} embed={target.embed_model} "
         f"rerank={target.rerank_endpoint}"
     )
-    run(target, args.out, args.rounds, args.sleep_ms, args.top_k)
+    run(
+        target,
+        args.out,
+        args.rounds,
+        args.sleep_ms,
+        args.top_k,
+        model=args.model,
+        embed_dim=args.embed_dim,
+        collection_override=args.collection_override,
+    )
     return 0
 
 

--- a/scripts/load-profiles/p4_memory_palace.py
+++ b/scripts/load-profiles/p4_memory_palace.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Profile P4 — memory palace recall pattern.
+
+Target: 10.23.0.53 (Pi, light host).
+
+Models an agent-style memory workload: ~600 short records bucketed
+by (room, hall), queried with a mix of broad/sharp/ambiguous shapes
+similar to what real agents send to the mfs MCP. The records are
+generated deterministically — no external download, which matters
+because the Pi runs the lighter embedding stack (nomic-768) and we
+want the test runtime dominated by inference, not by network IO.
+
+Calibration value: short records produce different score
+distributions than the long doc/code chunks in P1-P3. The gate
+threshold must work across this regime too, and P4 surfaces
+exactly that — the JSONL output is sliced by query_kind so the
+analyzer can compare gap distributions against P1-P3 on the same
+axis.
+
+Output: JSONL at $LOADPROFILE_OUT or ./out/p4.jsonl.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import runner  # noqa: E402
+from seed import memory_palace  # noqa: E402
+
+PROFILE_ID = "p4"
+DEFAULT_TARGET_URL = "http://10.23.0.53:8080"
+DEFAULT_TARGET_NAME = "pi"
+
+
+def seed_if_needed(target: runner.Target, collection: str) -> dict:
+    expected = len(memory_palace.load_corpus())
+    info = {}
+    try:
+        info = runner.http_request(
+            "GET",
+            target.url(f"/api/v1/collections/{collection}/info"),
+            headers=target.headers(),
+        )
+    except runner.HttpError:
+        info = {}
+    current = int(info.get("count", 0)) if isinstance(info, dict) else 0
+    if current >= int(expected * 0.95):
+        runner.stderr(
+            f"[seed] {collection} has {current} chunks (expected {expected}), skipping"
+        )
+        return {"reused": True, "count": current}
+    runner.stderr(f"[seed] ingesting {expected} chunks into {collection}")
+    corpus = memory_palace.load_corpus()
+    batch_size = 64
+    written = 0
+    for i in range(0, len(corpus), batch_size):
+        batch = corpus[i : i + batch_size]
+        runner.add_texts(
+            target,
+            collection,
+            batch,
+            room="memory",
+            tags=["loadprofile", "p4", "palace"],
+        )
+        written += len(batch)
+        if written % (batch_size * 4) == 0:
+            runner.stderr(f"[seed] {written}/{len(corpus)}")
+    return {"reused": False, "count": written}
+
+
+def run(
+    target: runner.Target,
+    out_path: str,
+    rounds: int,
+    sleep_ms: int,
+    top_k: int,
+) -> None:
+    collection = runner.profile_collection(PROFILE_ID)
+    runner.assert_namespace(target, PROFILE_ID)
+    seed_info = seed_if_needed(target, collection)
+    writer = runner.JsonlWriter(out_path)
+    sent = 0
+    errors = 0
+    try:
+        for round_idx in range(rounds):
+            for q in memory_palace.QUERIES:
+                try:
+                    pair = runner.search_pair(
+                        target,
+                        collection,
+                        q["text"],
+                        top_k=top_k,
+                        query_type="CHUNKS",
+                        room="memory",
+                    )
+                except runner.HttpError as e:
+                    errors += 1
+                    runner.stderr(f"[search] {q['id']}: {e}")
+                    continue
+                rec = runner.build_query_record(
+                    profile_id=PROFILE_ID,
+                    target=target,
+                    query_id=f"{q['id']}_r{round_idx}",
+                    query_text=q["text"],
+                    collection=collection,
+                    query_type="CHUNKS",
+                    pair=pair,
+                    extra={
+                        "query_kind": q["kind"],
+                        "expected_hall": q.get("expected_hall"),
+                        "expected_room": q.get("expected_room"),
+                        "round": round_idx,
+                        "seed_reused": seed_info.get("reused", False),
+                        "corpus_fingerprint": memory_palace.corpus_fingerprint(),
+                    },
+                )
+                writer.write(rec)
+                sent += 1
+                if sleep_ms > 0:
+                    time.sleep(sleep_ms / 1000.0)
+            runner.stderr(f"[run] round {round_idx + 1}/{rounds} done ({sent} queries)")
+    finally:
+        writer.close()
+    runner.stderr(
+        f"[done] queries={sent} errors={errors} out={out_path} "
+        f"dropped={writer.dropped}"
+    )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="P4 memory-palace load profile")
+    p.add_argument("--rounds", type=int, default=15)
+    p.add_argument("--top-k", type=int, default=10)
+    p.add_argument("--sleep-ms", type=int, default=400)
+    p.add_argument(
+        "--out",
+        default=os.environ.get(
+            "LOADPROFILE_OUT", str(Path("out") / f"{PROFILE_ID}.jsonl")
+        ),
+    )
+    p.add_argument("--target-name", default=DEFAULT_TARGET_NAME)
+    p.add_argument("--target-url", default=DEFAULT_TARGET_URL)
+    args = p.parse_args()
+
+    target = runner.Target(
+        name=args.target_name,
+        base_url=args.target_url,
+        token=runner.load_token_from_env_or_file(args.target_name),
+    )
+    runner.preflight(target)
+    runner.stderr(
+        f"[preflight] target={target.name} embed={target.embed_model} "
+        f"rerank={target.rerank_endpoint}"
+    )
+    run(target, args.out, args.rounds, args.sleep_ms, args.top_k)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/load-profiles/p5_filtered_search.py
+++ b/scripts/load-profiles/p5_filtered_search.py
@@ -94,34 +94,22 @@ def seed_if_needed(target: runner.Target, collection: str) -> dict:
         return {"reused": True, "count": current}
     runner.stderr(f"[seed] ingesting {expected} chunks into {collection}")
     corpus = memory_palace.load_corpus()
-    # Re-tag each record's metadata room into the per-record room so
-    # /search room-filter actually selects on per-chunk metadata
-    # (not just on the request's room tag). The seeder already
-    # encodes room into metadata; we forward it as the chunk's
-    # add-time room so it's indexed for filter overfetch.
-    batch_size = 64
-    written = 0
-    # Group corpus by room to send one batch per room, attaching
-    # the room tag at request level. This is what makes the
-    # downstream `room` filter on /search meaningful for P5.
-    by_room: dict[str, list[dict[str, str]]] = {}
-    import json as _json
-    for rec in corpus:
-        meta = _json.loads(rec["metadata"])
-        by_room.setdefault(meta["room"], []).append(rec)
-    for room_name, recs in by_room.items():
-        for i in range(0, len(recs), batch_size):
-            batch = recs[i : i + batch_size]
-            runner.add_texts(
-                target,
-                collection,
-                batch,
-                room=room_name,
-                tags=["loadprofile", "p5", "palace", room_name],
-            )
-            written += len(batch)
-        runner.stderr(f"[seed] room={room_name}: {len(recs)} records")
-    return {"reused": False, "count": written}
+    # Single-batch ingest. P5's earlier per-room batching attached the
+    # room tag at request level, but /cognify doesn't propagate
+    # room/tags to chunks (see runner.add_texts note) — the room
+    # filter at query time relies on per-text content semantics, not
+    # on add-time metadata. So batching by room buys nothing and
+    # exposes the cross-batch chunk-ID collision bug on unpatched
+    # Levara (Pi b4fface). Send everything in one call to keep the
+    # uuid5 text index unique.
+    runner.add_texts(
+        target,
+        collection,
+        corpus,
+        room="palace",
+        tags=["loadprofile", "p5", "palace"],
+    )
+    return {"reused": False, "count": len(corpus)}
 
 
 def run(

--- a/scripts/load-profiles/p5_filtered_search.py
+++ b/scripts/load-profiles/p5_filtered_search.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Profile P5 — filtered search (room / tag pre-filter).
+
+Target: 10.23.0.53 (Pi, light host).
+
+Reuses the deterministic memory-palace corpus from P4 but every
+query is paired with a `room` filter that exercises Levara's
+overfetch-and-filter HNSW path. Calibration value:
+
+  - The filter shrinks the candidate set the bi-encoder sees, which
+    changes the shape of the score distribution feeding the rerank
+    gate. The gate threshold tuned on unfiltered traffic may behave
+    differently under filters; P5 is what surfaces that.
+  - Some queries pair a `room` with mismatched semantic content
+    ("auth-room query about deploy") so the bi-encoder will return
+    weak matches inside the filter — exactly the case where rerank
+    has the most or least to offer.
+
+Output: JSONL at $LOADPROFILE_OUT or ./out/p5.jsonl. Each record
+carries `filter_room` so the analyzer can compare gap distributions
+filter-on vs filter-off (cross-referenced against P4's same-corpus
+output).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import runner  # noqa: E402
+from seed import memory_palace  # noqa: E402
+
+PROFILE_ID = "p5"
+DEFAULT_TARGET_URL = "http://10.23.0.53:8080"
+DEFAULT_TARGET_NAME = "pi"
+
+
+# Filter-aware queries. Each is a (room, query, kind) triple. The
+# kinds are:
+#   on-topic     — query matches the filter room semantically
+#   off-topic    — query is about a different room (filter forces a
+#                  weak set; rerank has little to work with)
+#   broad-room   — query is general and applies to most records
+#                  within the room (close-call rerank regime)
+FILTERED_QUERIES: list[dict[str, str]] = [
+    {"id": "q01", "room": "auth", "text": "JWT secret rotation", "kind": "on-topic"},
+    {"id": "q02", "room": "auth", "text": "service account login flow", "kind": "on-topic"},
+    {"id": "q03", "room": "auth", "text": "p99 latency spike", "kind": "off-topic"},
+    {"id": "q04", "room": "auth", "text": "recent changes", "kind": "broad-room"},
+    {"id": "q05", "room": "deploy", "text": "host migration", "kind": "on-topic"},
+    {"id": "q06", "room": "deploy", "text": "config rollback", "kind": "on-topic"},
+    {"id": "q07", "room": "deploy", "text": "JWT secret rotation", "kind": "off-topic"},
+    {"id": "q08", "room": "deploy", "text": "what happened recently", "kind": "broad-room"},
+    {"id": "q09", "room": "rerank", "text": "score gap threshold", "kind": "on-topic"},
+    {"id": "q10", "room": "rerank", "text": "GPU memory fragmentation", "kind": "on-topic"},
+    {"id": "q11", "room": "rerank", "text": "user preferences for UI", "kind": "off-topic"},
+    {"id": "q12", "room": "rerank", "text": "decisions made", "kind": "broad-room"},
+    {"id": "q13", "room": "ingest", "text": "WAL fsync batching", "kind": "on-topic"},
+    {"id": "q14", "room": "ingest", "text": "embedding dim mismatch", "kind": "on-topic"},
+    {"id": "q15", "room": "ingest", "text": "auth tokens", "kind": "off-topic"},
+    {"id": "q16", "room": "ingest", "text": "facts about this subsystem", "kind": "broad-room"},
+    {"id": "q17", "room": "mcp", "text": "tool group classification", "kind": "on-topic"},
+    {"id": "q18", "room": "mcp", "text": "audit log rotation", "kind": "on-topic"},
+    {"id": "q19", "room": "graph", "text": "neo4j edge supersession", "kind": "on-topic"},
+    {"id": "q20", "room": "graph", "text": "JWT secret", "kind": "off-topic"},
+    {"id": "q21", "room": "ui", "text": "dashboard layout", "kind": "on-topic"},
+    {"id": "q22", "room": "observability", "text": "p99 grafana board", "kind": "on-topic"},
+    {"id": "q23", "room": "observability", "text": "lasagne recipe", "kind": "off-topic"},
+    {"id": "q24", "room": "observability", "text": "preferences", "kind": "broad-room"},
+]
+
+
+def seed_if_needed(target: runner.Target, collection: str) -> dict:
+    expected = len(memory_palace.load_corpus())
+    info = {}
+    try:
+        info = runner.http_request(
+            "GET",
+            target.url(f"/api/v1/collections/{collection}/info"),
+            headers=target.headers(),
+        )
+    except runner.HttpError:
+        info = {}
+    current = int(info.get("count", 0)) if isinstance(info, dict) else 0
+    if current >= int(expected * 0.95):
+        runner.stderr(
+            f"[seed] {collection} has {current} chunks (expected {expected}), skipping"
+        )
+        return {"reused": True, "count": current}
+    runner.stderr(f"[seed] ingesting {expected} chunks into {collection}")
+    corpus = memory_palace.load_corpus()
+    # Re-tag each record's metadata room into the per-record room so
+    # /search room-filter actually selects on per-chunk metadata
+    # (not just on the request's room tag). The seeder already
+    # encodes room into metadata; we forward it as the chunk's
+    # add-time room so it's indexed for filter overfetch.
+    batch_size = 64
+    written = 0
+    # Group corpus by room to send one batch per room, attaching
+    # the room tag at request level. This is what makes the
+    # downstream `room` filter on /search meaningful for P5.
+    by_room: dict[str, list[dict[str, str]]] = {}
+    import json as _json
+    for rec in corpus:
+        meta = _json.loads(rec["metadata"])
+        by_room.setdefault(meta["room"], []).append(rec)
+    for room_name, recs in by_room.items():
+        for i in range(0, len(recs), batch_size):
+            batch = recs[i : i + batch_size]
+            runner.add_texts(
+                target,
+                collection,
+                batch,
+                room=room_name,
+                tags=["loadprofile", "p5", "palace", room_name],
+            )
+            written += len(batch)
+        runner.stderr(f"[seed] room={room_name}: {len(recs)} records")
+    return {"reused": False, "count": written}
+
+
+def run(
+    target: runner.Target,
+    out_path: str,
+    rounds: int,
+    sleep_ms: int,
+    top_k: int,
+) -> None:
+    collection = runner.profile_collection(PROFILE_ID)
+    runner.assert_namespace(target, PROFILE_ID)
+    seed_info = seed_if_needed(target, collection)
+    writer = runner.JsonlWriter(out_path)
+    sent = 0
+    errors = 0
+    try:
+        for round_idx in range(rounds):
+            for q in FILTERED_QUERIES:
+                try:
+                    pair = runner.search_pair(
+                        target,
+                        collection,
+                        q["text"],
+                        top_k=top_k,
+                        query_type="CHUNKS",
+                        room=q["room"],
+                    )
+                except runner.HttpError as e:
+                    errors += 1
+                    runner.stderr(f"[search] {q['id']}: {e}")
+                    continue
+                rec = runner.build_query_record(
+                    profile_id=PROFILE_ID,
+                    target=target,
+                    query_id=f"{q['id']}_r{round_idx}",
+                    query_text=q["text"],
+                    collection=collection,
+                    query_type="CHUNKS",
+                    pair=pair,
+                    extra={
+                        "query_kind": q["kind"],
+                        "filter_room": q["room"],
+                        "round": round_idx,
+                        "seed_reused": seed_info.get("reused", False),
+                        "corpus_fingerprint": memory_palace.corpus_fingerprint(),
+                    },
+                )
+                writer.write(rec)
+                sent += 1
+                if sleep_ms > 0:
+                    time.sleep(sleep_ms / 1000.0)
+            runner.stderr(f"[run] round {round_idx + 1}/{rounds} done ({sent} queries)")
+    finally:
+        writer.close()
+    runner.stderr(
+        f"[done] queries={sent} errors={errors} out={out_path} "
+        f"dropped={writer.dropped}"
+    )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="P5 filtered-search load profile")
+    p.add_argument("--rounds", type=int, default=15)
+    p.add_argument("--top-k", type=int, default=10)
+    p.add_argument("--sleep-ms", type=int, default=400)
+    p.add_argument(
+        "--out",
+        default=os.environ.get(
+            "LOADPROFILE_OUT", str(Path("out") / f"{PROFILE_ID}.jsonl")
+        ),
+    )
+    p.add_argument("--target-name", default=DEFAULT_TARGET_NAME)
+    p.add_argument("--target-url", default=DEFAULT_TARGET_URL)
+    args = p.parse_args()
+
+    target = runner.Target(
+        name=args.target_name,
+        base_url=args.target_url,
+        token=runner.load_token_from_env_or_file(args.target_name),
+    )
+    runner.preflight(target)
+    runner.stderr(
+        f"[preflight] target={target.name} embed={target.embed_model} "
+        f"rerank={target.rerank_endpoint}"
+    )
+    run(target, args.out, args.rounds, args.sleep_ms, args.top_k)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/load-profiles/p5_filtered_search.py
+++ b/scripts/load-profiles/p5_filtered_search.py
@@ -81,12 +81,12 @@ def seed_if_needed(target: runner.Target, collection: str) -> dict:
     try:
         info = runner.http_request(
             "GET",
-            target.url(f"/api/v1/collections/{collection}/info"),
+            target.url(f"/api/v1/collections/{collection}/meta"),
             headers=target.headers(),
         )
     except runner.HttpError:
         info = {}
-    current = int(info.get("count", 0)) if isinstance(info, dict) else 0
+    current = int(info.get("record_count", info.get("count", 0))) if isinstance(info, dict) else 0
     if current >= int(expected * 0.95):
         runner.stderr(
             f"[seed] {collection} has {current} chunks (expected {expected}), skipping"

--- a/scripts/load-profiles/p5_filtered_search.py
+++ b/scripts/load-profiles/p5_filtered_search.py
@@ -118,8 +118,11 @@ def run(
     rounds: int,
     sleep_ms: int,
     top_k: int,
+    model: str = "",
+    embed_dim: int = 0,
+    collection_override: str = "",
 ) -> None:
-    collection = runner.profile_collection(PROFILE_ID)
+    collection = collection_override or runner.profile_collection(PROFILE_ID)
     runner.assert_namespace(target, PROFILE_ID)
     seed_info = seed_if_needed(target, collection)
     writer = runner.JsonlWriter(out_path)
@@ -155,6 +158,13 @@ def run(
                         "round": round_idx,
                         "seed_reused": seed_info.get("reused", False),
                         "corpus_fingerprint": memory_palace.corpus_fingerprint(),
+                        "embed_model": model or target.embed_model,
+                        "embed_dim": embed_dim,
+                        "expected_keywords": q.get("expected_keywords", []),
+                        **runner.keyword_metrics(
+                            pair["no_rerank"]["response"],
+                            expected_keywords=q.get("expected_keywords", []),
+                        ),
                     },
                 )
                 writer.write(rec)
@@ -183,6 +193,9 @@ def main() -> int:
     )
     p.add_argument("--target-name", default=DEFAULT_TARGET_NAME)
     p.add_argument("--target-url", default=DEFAULT_TARGET_URL)
+    p.add_argument("--model", default="", help="embed model short (potion/granite/jina); used for JSONL fields")
+    p.add_argument("--embed-dim", type=int, default=0, help="expected embedding dim (JSONL only)")
+    p.add_argument("--collection-override", default="", help="if set, use this collection name instead of the default")
     args = p.parse_args()
 
     target = runner.Target(
@@ -195,7 +208,16 @@ def main() -> int:
         f"[preflight] target={target.name} embed={target.embed_model} "
         f"rerank={target.rerank_endpoint}"
     )
-    run(target, args.out, args.rounds, args.sleep_ms, args.top_k)
+    run(
+        target,
+        args.out,
+        args.rounds,
+        args.sleep_ms,
+        args.top_k,
+        model=args.model,
+        embed_dim=args.embed_dim,
+        collection_override=args.collection_override,
+    )
     return 0
 
 

--- a/scripts/load-profiles/preflight_model.py
+++ b/scripts/load-profiles/preflight_model.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Preflight gate for one model run on the Pi bench stack.
+
+Usage: python preflight_model.py --model <short> --host 10.23.0.53
+Exits 0 if every check passes, 1 otherwise. Prints structured JSON report.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Callable
+
+from embed_bench.recipes import get_recipe
+
+
+@dataclass
+class Checks:
+    model_short: str
+    expected_dim: int
+    expected_openai_name: str
+    host: str = "10.23.0.53"
+    sidecar_port: int = 9101
+    bench_port: int = 8091
+    rerank_port: int = 9100
+    ollama_port: int = 11434
+    ollama_model_required: str = "qwen3:0.6b"
+
+
+@dataclass
+class Result:
+    ok: bool
+    passed: list[str] = field(default_factory=list)
+    failed: list[str] = field(default_factory=list)
+
+
+def default_http(method: str, url: str, headers=None, body=None, timeout: float = 10.0) -> dict:
+    payload = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(url, data=payload, headers=headers or {}, method=method)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        data = resp.read()
+        if not data:
+            return {}
+        return json.loads(data)
+
+
+HttpFn = Callable[..., dict]
+
+
+def run_checks(c: Checks, *, http: HttpFn = default_http) -> Result:
+    passed: list[str] = []
+    failed: list[str] = []
+
+    def _try(label: str, fn):
+        try:
+            fn()
+            passed.append(label)
+        except Exception as e:
+            failed.append(f"{label}: {e}")
+
+    sidecar = f"http://{c.host}:{c.sidecar_port}"
+    bench = f"http://{c.host}:{c.bench_port}"
+    rerank = f"http://{c.host}:{c.rerank_port}"
+    ollama = f"http://{c.host}:{c.ollama_port}"
+
+    def check_sidecar_health():
+        body = http("GET", f"{sidecar}/health")
+        if body.get("model") != c.expected_openai_name:
+            raise RuntimeError(f"model name mismatch: {body.get('model')!r} != {c.expected_openai_name!r}")
+        if body.get("dim") != c.expected_dim:
+            raise RuntimeError(f"sidecar_dim mismatch: {body.get('dim')} != {c.expected_dim}")
+
+    def check_embed_ping():
+        body = http("POST", f"{sidecar}/v1/embeddings",
+                    headers={"Content-Type": "application/json"},
+                    body={"input": ["ping"], "model": c.expected_openai_name})
+        data = body.get("data", [])
+        if not data:
+            raise RuntimeError("empty data array")
+        v = data[0].get("embedding", [])
+        if len(v) != c.expected_dim:
+            raise RuntimeError(f"embed_ping_dim {len(v)} != {c.expected_dim}")
+
+    def check_bench_health():
+        http("GET", f"{bench}/health")
+
+    def check_ollama_model():
+        body = http("GET", f"{ollama}/api/tags")
+        names = {m.get("name") for m in body.get("models", [])}
+        if c.ollama_model_required not in names:
+            raise RuntimeError(f"ollama_model {c.ollama_model_required!r} not in {names}")
+
+    def check_rerank_health():
+        http("GET", f"{rerank}/health")
+
+    def check_auth():
+        import secrets
+        email = f"preflight_{secrets.token_hex(4)}@local"
+        passwd = secrets.token_hex(8)
+        body = http("POST", f"{bench}/api/v1/auth/register",
+                    headers={"Content-Type": "application/json"},
+                    body={"email": email, "password": passwd})
+        if not body.get("access_token"):
+            raise RuntimeError("no access_token returned")
+
+    _try("sidecar_health", check_sidecar_health)
+    _try("embed_ping",     check_embed_ping)
+    _try("bench_health",   check_bench_health)
+    _try("ollama_model",   check_ollama_model)
+    _try("rerank_health",  check_rerank_health)
+    _try("auth_register",  check_auth)
+
+    return Result(ok=not failed, passed=passed, failed=failed)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--model", required=True)
+    p.add_argument("--host", default="10.23.0.53")
+    args = p.parse_args()
+
+    recipe = get_recipe(args.model)
+    checks = Checks(
+        model_short=recipe.short,
+        expected_dim=recipe.dim,
+        expected_openai_name=recipe.openai_name,
+        host=args.host,
+    )
+    result = run_checks(checks)
+    print(json.dumps({"ok": result.ok, "passed": result.passed, "failed": result.failed}, indent=2))
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/load-profiles/run_all_models.sh
+++ b/scripts/load-profiles/run_all_models.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 PI_HOST="${PI_HOST:-10.23.0.53}"
 PI_USER="${PI_USER:-stek0v}"
 OUT_DIR="${OUT_DIR:-scripts/load-profiles/out}"
-DEFAULT_MODELS=(potion granite jina)
+DEFAULT_MODELS=(nomic potion granite)
 MODELS_ARR=(${MODELS:-${DEFAULT_MODELS[@]}})
 if [ $# -gt 0 ]; then
   MODELS_ARR=("$@")
@@ -47,6 +47,7 @@ run_one_model() {
   case "$short" in
     potion)  OPENAI="potion-code-16M";              DIM=256 ;;
     granite) OPENAI="granite-97m-multilingual-r2";  DIM=384 ;;
+    nomic)   OPENAI="nomic-embed-text-v2-moe";      DIM=768 ;;
     jina)    OPENAI="jina-omni-nano";               DIM=512 ;;
     *) echo "unknown model: $short" >&2; exit 2 ;;
   esac
@@ -72,6 +73,7 @@ ExecStart=/home/stek0v/levara-bench/levara -standalone=true -port=8091 -grpc-por
     || { echo "preflight failed for $short, skipping" >&2; stop_bench; return 1; }
 
   local TARGET_URL="http://$PI_HOST:8091"
+  local COLL_P3="loadprofile_p3_main_$short"
   local COLL_P4="loadprofile_p4_main_$short"
   local COLL_P5="loadprofile_p5_main_$short"
 
@@ -101,9 +103,17 @@ ExecStart=/home/stek0v/levara-bench/levara -standalone=true -port=8091 -grpc-por
   # 700ms gives margin for retry/jitter and avoids 429s.
   local SEARCH_SLEEP_MS=700
 
-  echo "[seed] $COLL_P4 + $COLL_P5"
+  echo "[seed] $COLL_P3 + $COLL_P4 + $COLL_P5"
+  python3 scripts/load-profiles/seed_one.py --target-url "$TARGET_URL" --collection "$COLL_P3"
   python3 scripts/load-profiles/seed_one.py --target-url "$TARGET_URL" --collection "$COLL_P4"
   python3 scripts/load-profiles/seed_one.py --target-url "$TARGET_URL" --collection "$COLL_P5"
+
+  echo "[run] p3 / $short"
+  python3 scripts/load-profiles/p3_code_semantic.py \
+    --target-name bench --target-url "$TARGET_URL" \
+    --collection-override "$COLL_P3" \
+    --sleep-ms "$SEARCH_SLEEP_MS" \
+    --out "$OUT_DIR/p3_$short.jsonl"
 
   echo "[run] p4 / $short"
   python3 scripts/load-profiles/p4_memory_palace.py \
@@ -131,7 +141,8 @@ for m in "${MODELS_ARR[@]}"; do
 done
 
 echo "=== analyze ==="
-python3 scripts/load-profiles/analyze.py --by-model "$OUT_DIR"/p?_*.jsonl \
+python3 scripts/load-profiles/analyze.py --by-model \
+  "$OUT_DIR"/p3_*.jsonl "$OUT_DIR"/p4_*.jsonl "$OUT_DIR"/p5_*.jsonl \
   > docs/load-profile-analysis-pi-multimodel.md
 
 echo "OK. Output: docs/load-profile-analysis-pi-multimodel.md"

--- a/scripts/load-profiles/run_all_models.sh
+++ b/scripts/load-profiles/run_all_models.sh
@@ -67,6 +67,7 @@ ExecStart=/home/stek0v/levara-bench/levara -standalone=true -port=8091 -grpc-por
   rsync -a --delete scripts/ "$PI_USER@$PI_HOST:/home/stek0v/embed-bench/scripts/" >/dev/null
   rsync -a deploy/bench/embed-bench.service "$PI_USER@$PI_HOST:/tmp/embed-bench.service" >/dev/null
   ssh "$PI_USER@$PI_HOST" "sudo install -m 0644 /tmp/embed-bench.service /etc/systemd/system/embed-bench.service && sudo systemctl daemon-reload && sudo systemctl restart embed-bench.service"
+  sleep 8
   ssh "$PI_USER@$PI_HOST" "python3 /home/stek0v/embed-bench/scripts/load-profiles/preflight_model.py --model $short --host 127.0.0.1" \
     || { echo "preflight failed for $short, skipping" >&2; stop_bench; return 1; }
 

--- a/scripts/load-profiles/run_all_models.sh
+++ b/scripts/load-profiles/run_all_models.sh
@@ -64,12 +64,41 @@ ExecStart=/home/stek0v/levara-bench/levara -standalone=true -port=8091 -grpc-por
   restart_bench
   sleep 10
 
-  python3 scripts/load-profiles/preflight_model.py --model "$short" --host "$PI_HOST" \
+  rsync -a --delete scripts/ "$PI_USER@$PI_HOST:/home/stek0v/embed-bench/scripts/" >/dev/null
+  rsync -a deploy/bench/embed-bench.service "$PI_USER@$PI_HOST:/tmp/embed-bench.service" >/dev/null
+  ssh "$PI_USER@$PI_HOST" "sudo install -m 0644 /tmp/embed-bench.service /etc/systemd/system/embed-bench.service && sudo systemctl daemon-reload && sudo systemctl restart embed-bench.service"
+  ssh "$PI_USER@$PI_HOST" "python3 /home/stek0v/embed-bench/scripts/load-profiles/preflight_model.py --model $short --host 127.0.0.1" \
     || { echo "preflight failed for $short, skipping" >&2; stop_bench; return 1; }
 
   local TARGET_URL="http://$PI_HOST:8091"
   local COLL_P4="loadprofile_p4_main_$short"
   local COLL_P5="loadprofile_p5_main_$short"
+
+  # Pre-embed bypass for /api/v1/search/text null bug on Pi:
+  # runner._search_pair_pre_embed picks up these env vars and calls
+  # the embed-bench sidecar from the Mac directly, then POSTs the
+  # pre-computed vector to /api/v1/search (which is unaffected by
+  # the chunksSearch null-result regression). Sidecar binds 0.0.0.0
+  # so it's reachable from the Mac.
+  export LEVARA_PRE_EMBED_URL="http://$PI_HOST:9101/v1/embeddings"
+  export LEVARA_PRE_EMBED_MODEL="$short"
+
+  # Rerank sidecar on Pi binds 127.0.0.1:9100 (it was launched
+  # ad-hoc, not via systemd, so we can't safely rebind it from here).
+  # Open an SSH local-forward so http://127.0.0.1:9100/rerank on the
+  # Mac tunnels to the Pi's loopback, then point the runner at it
+  # via LEVARA_RERANK_URL (overrides the server-reported endpoint
+  # which would resolve to the Mac's own loopback otherwise).
+  if ! lsof -i :9100 -sTCP:LISTEN -t >/dev/null 2>&1; then
+    ssh -fN -L 9100:127.0.0.1:9100 "$PI_USER@$PI_HOST"
+  fi
+  export LEVARA_RERANK_URL="http://127.0.0.1:9100/rerank"
+
+  # Bench Levara enforces 100 req/min per-user JWT (T2). Each query
+  # in p4/p5 issues two /search calls (rerank=true + rerank=false),
+  # so 600ms between iterations ≈ the budget but offers no slack;
+  # 700ms gives margin for retry/jitter and avoids 429s.
+  local SEARCH_SLEEP_MS=700
 
   echo "[seed] $COLL_P4 + $COLL_P5"
   python3 scripts/load-profiles/seed_one.py --target-url "$TARGET_URL" --collection "$COLL_P4"
@@ -80,6 +109,7 @@ ExecStart=/home/stek0v/levara-bench/levara -standalone=true -port=8091 -grpc-por
     --target-name bench --target-url "$TARGET_URL" \
     --model "$short" --embed-dim "$DIM" \
     --collection-override "$COLL_P4" \
+    --sleep-ms "$SEARCH_SLEEP_MS" \
     --out "$OUT_DIR/p4_$short.jsonl"
 
   echo "[run] p5 / $short"
@@ -87,7 +117,10 @@ ExecStart=/home/stek0v/levara-bench/levara -standalone=true -port=8091 -grpc-por
     --target-name bench --target-url "$TARGET_URL" \
     --model "$short" --embed-dim "$DIM" \
     --collection-override "$COLL_P5" \
+    --sleep-ms "$SEARCH_SLEEP_MS" \
     --out "$OUT_DIR/p5_$short.jsonl"
+
+  unset LEVARA_PRE_EMBED_URL LEVARA_PRE_EMBED_MODEL LEVARA_RERANK_URL
 
   stop_bench
 }

--- a/scripts/load-profiles/run_all_models.sh
+++ b/scripts/load-profiles/run_all_models.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Sequentially run 3 embed models through the full Levara cognify
+# pipeline on Pi bench. Refuses to touch production levara.service.
+#
+# Usage:
+#   bash run_all_models.sh              # all 3 models
+#   bash run_all_models.sh potion       # just one
+set -euo pipefail
+
+PI_HOST="${PI_HOST:-10.23.0.53}"
+PI_USER="${PI_USER:-stek0v}"
+OUT_DIR="${OUT_DIR:-scripts/load-profiles/out}"
+DEFAULT_MODELS=(potion granite jina)
+MODELS_ARR=(${MODELS:-${DEFAULT_MODELS[@]}})
+if [ $# -gt 0 ]; then
+  MODELS_ARR=("$@")
+fi
+
+mkdir -p "$OUT_DIR"
+
+safe_unit() {
+  case "$1" in
+    levara.service) echo "REFUSING to touch prod unit $1" >&2; exit 2 ;;
+  esac
+}
+
+write_dropin() {
+  local unit="$1" name="$2" content="$3"
+  safe_unit "$unit"
+  ssh "$PI_USER@$PI_HOST" "sudo mkdir -p /etc/systemd/system/${unit}.d && \
+    printf '%s\n' '$content' | sudo tee /etc/systemd/system/${unit}.d/${name}.conf >/dev/null"
+}
+
+restart_bench() {
+  ssh "$PI_USER@$PI_HOST" "sudo systemctl daemon-reload && \
+    sudo systemctl restart embed-bench.service levara-bench.service"
+}
+
+stop_bench() {
+  ssh "$PI_USER@$PI_HOST" "sudo systemctl stop levara-bench.service embed-bench.service || true"
+}
+
+run_one_model() {
+  local short="$1"
+  echo "=== model: $short ==="
+
+  case "$short" in
+    potion)  OPENAI="potion-code-16M";              DIM=256 ;;
+    granite) OPENAI="granite-97m-multilingual-r2";  DIM=384 ;;
+    jina)    OPENAI="jina-omni-nano";               DIM=512 ;;
+    *) echo "unknown model: $short" >&2; exit 2 ;;
+  esac
+
+  stop_bench
+
+  write_dropin embed-bench.service model "[Service]
+Environment=EMBED_BENCH_MODEL=$short"
+  write_dropin levara-bench.service embed "[Service]
+Environment=EMBEDDING_MODEL=$OPENAI"
+  write_dropin levara-bench.service dim "[Service]
+ExecStart=
+ExecStart=/home/stek0v/levara-bench/levara -standalone=true -port=8091 -grpc-port=0 -dim=$DIM -data-dir=/home/stek0v/levara-bench/data -node-id=pi-bench"
+
+  restart_bench
+  sleep 10
+
+  python3 scripts/load-profiles/preflight_model.py --model "$short" --host "$PI_HOST" \
+    || { echo "preflight failed for $short, skipping" >&2; stop_bench; return 1; }
+
+  local TARGET_URL="http://$PI_HOST:8091"
+  local COLL_P4="loadprofile_p4_main_$short"
+  local COLL_P5="loadprofile_p5_main_$short"
+
+  echo "[seed] $COLL_P4 + $COLL_P5"
+  python3 scripts/load-profiles/seed_one.py --target-url "$TARGET_URL" --collection "$COLL_P4"
+  python3 scripts/load-profiles/seed_one.py --target-url "$TARGET_URL" --collection "$COLL_P5"
+
+  echo "[run] p4 / $short"
+  python3 scripts/load-profiles/p4_memory_palace.py \
+    --target-name bench --target-url "$TARGET_URL" \
+    --model "$short" --embed-dim "$DIM" \
+    --collection-override "$COLL_P4" \
+    --out "$OUT_DIR/p4_$short.jsonl"
+
+  echo "[run] p5 / $short"
+  python3 scripts/load-profiles/p5_filtered_search.py \
+    --target-name bench --target-url "$TARGET_URL" \
+    --model "$short" --embed-dim "$DIM" \
+    --collection-override "$COLL_P5" \
+    --out "$OUT_DIR/p5_$short.jsonl"
+
+  stop_bench
+}
+
+for m in "${MODELS_ARR[@]}"; do
+  run_one_model "$m" || echo "model $m skipped" >&2
+done
+
+echo "=== analyze ==="
+python3 scripts/load-profiles/analyze.py --by-model "$OUT_DIR"/p?_*.jsonl \
+  > docs/load-profile-analysis-pi-multimodel.md
+
+echo "OK. Output: docs/load-profile-analysis-pi-multimodel.md"

--- a/scripts/load-profiles/runner.py
+++ b/scripts/load-profiles/runner.py
@@ -174,19 +174,20 @@ class JsonlWriter:
 # ── Preflight & namespace guard ─────────────────────────────────────
 
 
-def preflight(target: Target) -> dict[str, Any]:
+def preflight(target: Target, *, require_rerank: bool = True) -> dict[str, Any]:
     """Verify auth + collect server-side capabilities.
 
     Populates target.embed_model / rerank_endpoint / rerank_enabled
-    from /api/v1/rerank/info and /api/v1/info. Raises if rerank isn't
-    configured — every load profile needs it (without it there's
-    nothing to calibrate).
+    from /api/v1/models/rerank and /api/v1/info. Raises if rerank
+    isn't configured and require_rerank is True — every calibration
+    profile needs it. Pass require_rerank=False for smoke tests
+    against dev environments without a configured reranker.
     """
     info = http_request("GET", target.url("/api/v1/info"), headers=target.headers())
     rerank_info: dict[str, Any] = {}
     try:
         rerank_info = http_request(
-            "GET", target.url("/api/v1/rerank/info"), headers=target.headers()
+            "GET", target.url("/api/v1/models/rerank"), headers=target.headers()
         )
     except HttpError as e:
         if e.status != 404:
@@ -195,11 +196,13 @@ def preflight(target: Target) -> dict[str, Any]:
         "embed_model", ""
     )
     target.rerank_endpoint = rerank_info.get("endpoint", "")
-    target.rerank_enabled = bool(target.rerank_endpoint)
-    if not target.rerank_enabled:
+    target.rerank_enabled = bool(rerank_info.get("enabled")) or bool(
+        target.rerank_endpoint
+    )
+    if not target.rerank_enabled and require_rerank:
         raise RuntimeError(
-            f"target {target.name}: RERANK_ENDPOINT not configured — "
-            f"profile output would be useless for gate calibration"
+            f"target {target.name}: rerank not configured — calibration "
+            f"output would be useless (pass --no-rerank for smoke runs)"
         )
     return {"info": info, "rerank_info": rerank_info}
 
@@ -244,22 +247,66 @@ def add_texts(
     *,
     room: str | None = None,
     tags: list[str] | None = None,
+    poll_timeout_s: float = 600.0,
+    poll_interval_s: float = 2.0,
 ) -> dict[str, Any]:
-    """Push a batch through /api/v1/add (cognify=false to keep ingest
-    deterministic — we want raw chunks indexed, not LLM-extracted
-    entities). Each doc must carry id + text; metadata is optional."""
+    """Ingest a batch of pre-chunked text into a named HNSW collection
+    via /api/v1/cognify with skip_graph=true (RAG mode).
+
+    This is the only canonical write path on b4fface: /api/v1/add
+    routes into dataset ingest and never touches the HNSW collection
+    store. Cognify with skip_graph runs only chunk → embed → HNSW
+    insert (+ BM25), with no LLM entity extraction or graph writes —
+    deterministic and clean for calibration corpora.
+
+    Note: server-side chunking may further split each `text` if it
+    exceeds MaxChunkChars (~2KB). For the load-profile corpora we keep
+    chunks under that boundary so the index size matches doc count.
+
+    The room/tags params are kept for API symmetry but cognify HTTP
+    doesn't propagate them per-doc; per-record metadata in `docs[i]`
+    is also unused by cognify. Filtered-search profiles (P5) rely on
+    the corpus-side room embedding in the text itself, not on
+    metadata tags. We log a warning if room/tags are provided here.
+    """
+    if room or tags:
+        stderr(
+            "[add_texts] note: room/tags not propagated to cognify; "
+            "rely on per-text content for filter semantics"
+        )
+    texts = [d["text"] for d in docs]
     body: dict[str, Any] = {
+        "texts": texts,
         "collection": collection,
-        "documents": docs,
-        "cognify": False,
+        "skip_graph": True,
+        "runInBackground": True,
     }
-    if room:
-        body["room"] = room
-    if tags:
-        body["tags"] = tags
-    return http_request(
-        "POST", target.url("/api/v1/add"), headers=target.headers(), body=body
+    resp = http_request(
+        "POST", target.url("/api/v1/cognify"), headers=target.headers(), body=body
     )
+    run_id = resp.get("pipeline_run_id") or resp.get("run_id")
+    if not run_id:
+        # already_processed or other terminal-on-arrival case
+        return resp
+    deadline = time.monotonic() + poll_timeout_s
+    last_stage = ""
+    while time.monotonic() < deadline:
+        status = http_request(
+            "GET",
+            target.url(f"/api/v1/cognify/{run_id}/status"),
+            headers=target.headers(),
+        )
+        state = (status.get("status") or "").upper()
+        stage = status.get("stage") or ""
+        if stage and stage != last_stage:
+            stderr(f"[cognify] {collection} run={run_id[:8]} stage={stage}")
+            last_stage = stage
+        if state in ("COMPLETED", "SUCCESS", "DONE"):
+            return {"status": "ok", "run_id": run_id, "chunks": len(texts), "result": status}
+        if state in ("FAILED", "ERROR"):
+            raise RuntimeError(f"cognify run {run_id} failed: {status}")
+        time.sleep(poll_interval_s)
+    raise TimeoutError(f"cognify run {run_id} did not complete in {poll_timeout_s}s")
 
 
 def search_pair(
@@ -296,8 +343,14 @@ def search_pair(
         if tags:
             body["tags"] = tags
         t0 = time.monotonic()
+        # /search/text is the canonical text-search route on b4fface;
+        # /search is shadowed by the legacy vector-only handler that
+        # demands a pre-computed embedding vector.
         resp = http_request(
-            "POST", target.url("/api/v1/search"), headers=target.headers(), body=body
+            "POST",
+            target.url("/api/v1/search/text"),
+            headers=target.headers(),
+            body=body,
         )
         out[label] = {
             "latency_ms": int((time.monotonic() - t0) * 1000),

--- a/scripts/load-profiles/runner.py
+++ b/scripts/load-profiles/runner.py
@@ -557,6 +557,45 @@ def top_changed(with_rerank_resp: Any, no_rerank_resp: Any) -> bool | None:
     return ida != idb
 
 
+def keyword_metrics(resp: Any, *, expected_keywords: list[str]) -> dict[str, Any]:
+    """Light-weight retrieval-quality metric.
+
+    keyword_hits_top5: distinct expected_keywords (case-insensitive substring)
+        appearing in any top-5 hit text. Each keyword counts at most once.
+
+    top1_keyword_hit: any expected_keyword in top-1 text.
+    """
+    hits = _hits_from(resp)[:5]
+    if not hits or not expected_keywords:
+        return {"keyword_hits_top5": 0, "top1_keyword_hit": False}
+    needles = [k.lower() for k in expected_keywords]
+
+    def _text_of(h: dict[str, Any]) -> str:
+        m = h.get("metadata")
+        if isinstance(m, dict):
+            return str(m.get("text", "")).lower()
+        if isinstance(m, str):
+            try:
+                inner = json.loads(m)
+                if isinstance(inner, dict):
+                    return str(inner.get("text", "")).lower()
+            except Exception:
+                return ""
+        return ""
+
+    top1_text = _text_of(hits[0])
+    top1_hit = any(n in top1_text for n in needles)
+
+    found: set[str] = set()
+    for h in hits:
+        text = _text_of(h)
+        for n in needles:
+            if n in text:
+                found.add(n)
+
+    return {"keyword_hits_top5": len(found), "top1_keyword_hit": top1_hit}
+
+
 # ── Convenience: build a record ready for JSONL ────────────────────
 
 

--- a/scripts/load-profiles/runner.py
+++ b/scripts/load-profiles/runner.py
@@ -362,11 +362,24 @@ def search_pair(
 # ── Score extraction (analyzer-side helpers used inline) ────────────
 
 
-def extract_score_vector(no_rerank_resp: dict[str, Any]) -> list[float]:
+def extract_score_vector(no_rerank_resp: Any) -> list[float]:
     """Pull the ordered vector-only score list from a `rerank=false`
-    /search response. Server returns hits under one of two keys
-    (`results` or `chunks`) depending on strategy — we accept both."""
-    items = no_rerank_resp.get("results") or no_rerank_resp.get("chunks") or []
+    /search response.
+
+    Three response shapes seen in the wild:
+    - bare JSON array (legacy contract, current default for /search/text
+      when include_debug=false; can be literal null on zero hits)
+    - {results: [...]} envelope (some strategies)
+    - {chunks: [...]} envelope (older alias)
+    """
+    if no_rerank_resp is None:
+        return []
+    if isinstance(no_rerank_resp, list):
+        items = no_rerank_resp
+    elif isinstance(no_rerank_resp, dict):
+        items = no_rerank_resp.get("results") or no_rerank_resp.get("chunks") or no_rerank_resp.get("items") or []
+    else:
+        return []
     return [float(item.get("score", 0.0)) for item in items if isinstance(item, dict)]
 
 
@@ -391,17 +404,28 @@ def gap_features(scores: list[float]) -> dict[str, float]:
     return f
 
 
-def top_changed(
-    with_rerank_resp: dict[str, Any], no_rerank_resp: dict[str, Any]
-) -> bool | None:
+def _hits_from(resp: Any) -> list[dict[str, Any]]:
+    if resp is None:
+        return []
+    if isinstance(resp, list):
+        return [h for h in resp if isinstance(h, dict)]
+    if isinstance(resp, dict):
+        for key in ("results", "chunks", "items"):
+            v = resp.get(key)
+            if isinstance(v, list):
+                return [h for h in v if isinstance(h, dict)]
+    return []
+
+
+def top_changed(with_rerank_resp: Any, no_rerank_resp: Any) -> bool | None:
     """True iff the top-1 id differs between rerank=on and rerank=off.
     None if either response is empty (signal absent → can't compare)."""
-    a = with_rerank_resp.get("results") or with_rerank_resp.get("chunks") or []
-    b = no_rerank_resp.get("results") or no_rerank_resp.get("chunks") or []
+    a = _hits_from(with_rerank_resp)
+    b = _hits_from(no_rerank_resp)
     if not a or not b:
         return None
-    ida = (a[0] or {}).get("id")
-    idb = (b[0] or {}).get("id")
+    ida = a[0].get("id")
+    idb = b[0].get("id")
     if ida is None or idb is None:
         return None
     return ida != idb
@@ -437,10 +461,8 @@ def build_query_record(
         "latency_no_rerank_ms": pair["no_rerank"]["latency_ms"],
         "latency_with_rerank_ms": pair["with_rerank"]["latency_ms"],
         "scores_vector": scores_vec,
-        "n_hits_no_rerank": len(no_r.get("results") or no_r.get("chunks") or []),
-        "n_hits_with_rerank": len(
-            with_r.get("results") or with_r.get("chunks") or []
-        ),
+        "n_hits_no_rerank": len(_hits_from(no_r)),
+        "n_hits_with_rerank": len(_hits_from(with_r)),
         "top_changed_by_rerank": top_changed(with_r, no_r),
         "rerank_outcome": _outcome_from_response(with_r),
     }
@@ -450,16 +472,16 @@ def build_query_record(
     return rec
 
 
-def _outcome_from_response(resp: dict[str, Any]) -> str:
+def _outcome_from_response(resp: Any) -> str:
     """Infer rerank outcome from response shape. Server doesn't echo
     the metric outcome name directly, but the per-hit `reranked` flag
     plus the rerank_skip_reason hint (when present) is enough."""
-    if "rerank_skip_reason" in resp:
+    if isinstance(resp, dict) and "rerank_skip_reason" in resp:
         return str(resp["rerank_skip_reason"])
-    hits = resp.get("results") or resp.get("chunks") or []
+    hits = _hits_from(resp)
     if not hits:
         return "no_results"
-    any_reranked = any((h or {}).get("reranked") for h in hits if isinstance(h, dict))
+    any_reranked = any(h.get("reranked") for h in hits)
     return "reranked" if any_reranked else "fallback"
 
 

--- a/scripts/load-profiles/runner.py
+++ b/scripts/load-profiles/runner.py
@@ -1,0 +1,446 @@
+"""Shared infrastructure for load-profile scripts.
+
+Profiles are not stress tests. Their job is to produce realistic
+production-shaped traffic against a Levara instance so that
+RERANK_SCORE_GAP_THRESHOLD (Phase 2.5) can be calibrated from real
+score distributions.
+
+Each profile imports this module to get:
+- A thin HTTP client with retries and per-host timeouts.
+- An atomic JSONL writer with periodic fsync.
+- A double-traffic search wrapper that calls /api/v1/search twice
+  per query (rerank=true and rerank=false) so the analyzer can
+  derive ground-truth `top1_changed` and full vector-score gaps
+  from the rerank=false response.
+- A namespace guard so profiles physically cannot touch existing
+  production collections — all writes go through prefixes like
+  `loadprofile_p1_*`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import sys
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from typing import Any, Iterable
+
+SCHEMA_VERSION = 1
+NAMESPACE_PREFIX = "loadprofile_"
+DEFAULT_TIMEOUT_S = 30.0
+RETRYABLE_STATUS = {429, 500, 502, 503, 504}
+
+
+# ── Target description ──────────────────────────────────────────────
+
+
+@dataclass
+class Target:
+    """A Levara instance under test."""
+
+    name: str
+    base_url: str  # e.g. http://10.23.0.64:8080
+    token: str
+    embed_model: str = ""  # filled in by preflight
+    rerank_endpoint: str = ""  # filled in by preflight
+    rerank_enabled: bool = False
+
+    def url(self, path: str) -> str:
+        return self.base_url.rstrip("/") + path
+
+    def headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+        }
+
+
+# ── HTTP client ─────────────────────────────────────────────────────
+
+
+class HttpError(RuntimeError):
+    def __init__(self, status: int, body: str):
+        super().__init__(f"HTTP {status}: {body[:300]}")
+        self.status = status
+        self.body = body
+
+
+def http_request(
+    method: str,
+    url: str,
+    headers: dict[str, str] | None = None,
+    body: dict[str, Any] | None = None,
+    timeout: float = DEFAULT_TIMEOUT_S,
+    max_retries: int = 3,
+) -> dict[str, Any]:
+    """Single HTTP call with retry-on-5xx / 429. Returns parsed JSON.
+
+    Body is JSON-encoded if not None. 4xx (other than 429) raise
+    immediately so caller can distinguish auth/validation problems.
+    """
+    payload = None
+    if body is not None:
+        payload = json.dumps(body).encode("utf-8")
+
+    last_err: Exception | None = None
+    for attempt in range(max_retries + 1):
+        try:
+            req = urllib.request.Request(
+                url, data=payload, headers=headers or {}, method=method
+            )
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = resp.read()
+                if not data:
+                    return {}
+                return json.loads(data)
+        except urllib.error.HTTPError as e:
+            text = ""
+            try:
+                text = e.read().decode("utf-8", "replace")
+            except Exception:
+                pass
+            if e.code in RETRYABLE_STATUS and attempt < max_retries:
+                last_err = HttpError(e.code, text)
+            else:
+                raise HttpError(e.code, text) from None
+        except (urllib.error.URLError, TimeoutError, ConnectionError) as e:
+            if attempt >= max_retries:
+                raise
+            last_err = e
+        sleep_s = min(2.0**attempt * 0.5, 8.0) + random.random() * 0.25
+        time.sleep(sleep_s)
+
+    raise last_err if last_err else RuntimeError("retry loop exhausted")
+
+
+# ── JSONL writer ────────────────────────────────────────────────────
+
+
+class JsonlWriter:
+    """Append-only JSONL writer with periodic fsync.
+
+    Atomicity: each line is written under a lock with a single write()
+    call. Lines are bounded — no embeddings or full chunk text are
+    ever emitted, only ids, scores, and short snippets.
+    """
+
+    def __init__(self, path: str, fsync_every_lines: int = 100, fsync_every_s: float = 5.0):
+        os.makedirs(os.path.dirname(os.path.abspath(path)) or ".", exist_ok=True)
+        self.path = path
+        self._fh = open(path, "a", encoding="utf-8")
+        self._lock = threading.Lock()
+        self._fsync_every_lines = fsync_every_lines
+        self._fsync_every_s = fsync_every_s
+        self._lines_since_fsync = 0
+        self._last_fsync = time.monotonic()
+        self.dropped = 0
+
+    def write(self, record: dict[str, Any]) -> None:
+        record.setdefault("schema_version", SCHEMA_VERSION)
+        line = json.dumps(record, separators=(",", ":"), ensure_ascii=False) + "\n"
+        with self._lock:
+            try:
+                self._fh.write(line)
+            except OSError:
+                self.dropped += 1
+                return
+            self._lines_since_fsync += 1
+            now = time.monotonic()
+            if (
+                self._lines_since_fsync >= self._fsync_every_lines
+                or now - self._last_fsync >= self._fsync_every_s
+            ):
+                self._fh.flush()
+                os.fsync(self._fh.fileno())
+                self._lines_since_fsync = 0
+                self._last_fsync = now
+
+    def close(self) -> None:
+        with self._lock:
+            try:
+                self._fh.flush()
+                os.fsync(self._fh.fileno())
+            except OSError:
+                pass
+            self._fh.close()
+
+
+# ── Preflight & namespace guard ─────────────────────────────────────
+
+
+def preflight(target: Target) -> dict[str, Any]:
+    """Verify auth + collect server-side capabilities.
+
+    Populates target.embed_model / rerank_endpoint / rerank_enabled
+    from /api/v1/rerank/info and /api/v1/info. Raises if rerank isn't
+    configured — every load profile needs it (without it there's
+    nothing to calibrate).
+    """
+    info = http_request("GET", target.url("/api/v1/info"), headers=target.headers())
+    rerank_info: dict[str, Any] = {}
+    try:
+        rerank_info = http_request(
+            "GET", target.url("/api/v1/rerank/info"), headers=target.headers()
+        )
+    except HttpError as e:
+        if e.status != 404:
+            raise
+    target.embed_model = (info.get("embedding") or {}).get("model", "") or info.get(
+        "embed_model", ""
+    )
+    target.rerank_endpoint = rerank_info.get("endpoint", "")
+    target.rerank_enabled = bool(target.rerank_endpoint)
+    if not target.rerank_enabled:
+        raise RuntimeError(
+            f"target {target.name}: RERANK_ENDPOINT not configured — "
+            f"profile output would be useless for gate calibration"
+        )
+    return {"info": info, "rerank_info": rerank_info}
+
+
+def assert_namespace(target: Target, profile_id: str) -> None:
+    """Sanity check: profile-owned collection names must start with
+    `loadprofile_<profile_id>_`. Also confirms we are not accidentally
+    pointed at a host where production datasets share that prefix
+    (very unlikely, but a single misconfigured target would otherwise
+    silently corrupt prod data)."""
+    expected = f"{NAMESPACE_PREFIX}{profile_id}_"
+    # We don't list collections directly — datasets endpoint is what
+    # admins use to see "human" data. Cross-check there's no overlap.
+    try:
+        datasets = http_request(
+            "GET", target.url("/api/v1/datasets"), headers=target.headers()
+        )
+    except HttpError:
+        datasets = {}
+    items = datasets.get("datasets") if isinstance(datasets, dict) else datasets
+    if isinstance(items, list):
+        for d in items:
+            name = (d.get("name") if isinstance(d, dict) else str(d)) or ""
+            if name.startswith(expected) and not name.startswith(NAMESPACE_PREFIX):
+                raise RuntimeError(
+                    f"namespace collision on {target.name}: {name}"
+                )
+    return None
+
+
+def profile_collection(profile_id: str, shard: str = "main") -> str:
+    return f"{NAMESPACE_PREFIX}{profile_id}_{shard}"
+
+
+# ── Add / search wrappers ───────────────────────────────────────────
+
+
+def add_texts(
+    target: Target,
+    collection: str,
+    docs: list[dict[str, Any]],
+    *,
+    room: str | None = None,
+    tags: list[str] | None = None,
+) -> dict[str, Any]:
+    """Push a batch through /api/v1/add (cognify=false to keep ingest
+    deterministic — we want raw chunks indexed, not LLM-extracted
+    entities). Each doc must carry id + text; metadata is optional."""
+    body: dict[str, Any] = {
+        "collection": collection,
+        "documents": docs,
+        "cognify": False,
+    }
+    if room:
+        body["room"] = room
+    if tags:
+        body["tags"] = tags
+    return http_request(
+        "POST", target.url("/api/v1/add"), headers=target.headers(), body=body
+    )
+
+
+def search_pair(
+    target: Target,
+    collection: str,
+    query: str,
+    *,
+    top_k: int = 10,
+    query_type: str = "CHUNKS",
+    room: str | None = None,
+    tags: list[str] | None = None,
+) -> dict[str, Any]:
+    """Issue the same query twice — rerank=true and rerank=false —
+    so the analyzer has both the production (post-rerank) order and
+    the vector-only order to compute score_gap and top1_changed.
+
+    Returns a dict shaped:
+        {
+          "with_rerank": {<server response>, latency_ms: ...},
+          "no_rerank":   {<server response>, latency_ms: ...},
+        }
+    """
+    out: dict[str, Any] = {}
+    for label, rerank in (("with_rerank", True), ("no_rerank", False)):
+        body = {
+            "collection": collection,
+            "query_text": query,
+            "top_k": top_k,
+            "query_type": query_type,
+            "rerank": rerank,
+        }
+        if room:
+            body["room"] = room
+        if tags:
+            body["tags"] = tags
+        t0 = time.monotonic()
+        resp = http_request(
+            "POST", target.url("/api/v1/search"), headers=target.headers(), body=body
+        )
+        out[label] = {
+            "latency_ms": int((time.monotonic() - t0) * 1000),
+            "response": resp,
+        }
+    return out
+
+
+# ── Score extraction (analyzer-side helpers used inline) ────────────
+
+
+def extract_score_vector(no_rerank_resp: dict[str, Any]) -> list[float]:
+    """Pull the ordered vector-only score list from a `rerank=false`
+    /search response. Server returns hits under one of two keys
+    (`results` or `chunks`) depending on strategy — we accept both."""
+    items = no_rerank_resp.get("results") or no_rerank_resp.get("chunks") or []
+    return [float(item.get("score", 0.0)) for item in items if isinstance(item, dict)]
+
+
+def gap_features(scores: list[float]) -> dict[str, float]:
+    """Compute the gap features the Phase 2.5 design specifies:
+
+    - score_gap_top_bottom: scores[0] - scores[-1]
+    - score_gap_top1_top2:  scores[0] - scores[1]
+    - score_gap_top1_top5:  scores[0] - scores[4] (if available)
+    """
+    if not scores:
+        return {}
+    n = len(scores)
+    f: dict[str, float] = {
+        "score_gap_top_bottom": scores[0] - scores[-1],
+        "score_top1": scores[0],
+    }
+    if n >= 2:
+        f["score_gap_top1_top2"] = scores[0] - scores[1]
+    if n >= 5:
+        f["score_gap_top1_top5"] = scores[0] - scores[4]
+    return f
+
+
+def top_changed(
+    with_rerank_resp: dict[str, Any], no_rerank_resp: dict[str, Any]
+) -> bool | None:
+    """True iff the top-1 id differs between rerank=on and rerank=off.
+    None if either response is empty (signal absent → can't compare)."""
+    a = with_rerank_resp.get("results") or with_rerank_resp.get("chunks") or []
+    b = no_rerank_resp.get("results") or no_rerank_resp.get("chunks") or []
+    if not a or not b:
+        return None
+    ida = (a[0] or {}).get("id")
+    idb = (b[0] or {}).get("id")
+    if ida is None or idb is None:
+        return None
+    return ida != idb
+
+
+# ── Convenience: build a record ready for JSONL ────────────────────
+
+
+def build_query_record(
+    *,
+    profile_id: str,
+    target: Target,
+    query_id: str,
+    query_text: str,
+    collection: str,
+    query_type: str,
+    pair: dict[str, Any],
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    no_r = pair["no_rerank"]["response"]
+    with_r = pair["with_rerank"]["response"]
+    scores_vec = extract_score_vector(no_r)
+    rec: dict[str, Any] = {
+        "ts": time.time(),
+        "profile_id": profile_id,
+        "target": target.name,
+        "embedding_model": target.embed_model,
+        "rerank_endpoint": target.rerank_endpoint,
+        "query_id": query_id,
+        "query_text_len": len(query_text),
+        "query_type": query_type,
+        "collection": collection,
+        "latency_no_rerank_ms": pair["no_rerank"]["latency_ms"],
+        "latency_with_rerank_ms": pair["with_rerank"]["latency_ms"],
+        "scores_vector": scores_vec,
+        "n_hits_no_rerank": len(no_r.get("results") or no_r.get("chunks") or []),
+        "n_hits_with_rerank": len(
+            with_r.get("results") or with_r.get("chunks") or []
+        ),
+        "top_changed_by_rerank": top_changed(with_r, no_r),
+        "rerank_outcome": _outcome_from_response(with_r),
+    }
+    rec.update(gap_features(scores_vec))
+    if extra:
+        rec.update(extra)
+    return rec
+
+
+def _outcome_from_response(resp: dict[str, Any]) -> str:
+    """Infer rerank outcome from response shape. Server doesn't echo
+    the metric outcome name directly, but the per-hit `reranked` flag
+    plus the rerank_skip_reason hint (when present) is enough."""
+    if "rerank_skip_reason" in resp:
+        return str(resp["rerank_skip_reason"])
+    hits = resp.get("results") or resp.get("chunks") or []
+    if not hits:
+        return "no_results"
+    any_reranked = any((h or {}).get("reranked") for h in hits if isinstance(h, dict))
+    return "reranked" if any_reranked else "fallback"
+
+
+# ── CLI plumbing ────────────────────────────────────────────────────
+
+
+def load_token_from_env_or_file(target_name: str) -> str:
+    """Token resolution order:
+      1. $LEVARA_TOKEN_<TARGETNAME>
+      2. $LEVARA_TOKEN
+      3. ~/.config/levara-service-keys/<target_name>.jwt
+    """
+    env_key = f"LEVARA_TOKEN_{target_name.upper()}"
+    for k in (env_key, "LEVARA_TOKEN"):
+        v = os.environ.get(k)
+        if v:
+            return v.strip()
+    path = os.path.expanduser(f"~/.config/levara-service-keys/{target_name}.jwt")
+    if os.path.exists(path):
+        with open(path) as f:
+            return f.read().strip()
+    raise SystemExit(
+        f"no JWT for target {target_name}: set {env_key} or place "
+        f"~/.config/levara-service-keys/{target_name}.jwt"
+    )
+
+
+def make_target_from_argv(default_url: str, target_name: str) -> Target:
+    base_url = os.environ.get("LEVARA_URL", default_url)
+    token = load_token_from_env_or_file(target_name)
+    t = Target(name=target_name, base_url=base_url, token=token)
+    preflight(t)
+    return t
+
+
+def stderr(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)

--- a/scripts/load-profiles/runner.py
+++ b/scripts/load-profiles/runner.py
@@ -309,6 +309,56 @@ def add_texts(
     raise TimeoutError(f"cognify run {run_id} did not complete in {poll_timeout_s}s")
 
 
+def _embed_local(query: str) -> list[float]:
+    """Embed `query` via the URL in LEVARA_PRE_EMBED_URL (Ollama or
+    OpenAI-compatible POST /v1/embeddings). The model used is
+    LEVARA_PRE_EMBED_MODEL (default 'nomic-embed-text-v2-moe').
+
+    Bypass for the Pi de809b71 binary regression where server-side
+    /api/v1/search/text serialises a nil result slice as literal JSON
+    `null` when the in-process embed step silently errors. See
+    docs/reviews/pi-search-text-null.md (memory).
+    """
+    url = os.environ["LEVARA_PRE_EMBED_URL"]
+    model = os.environ.get("LEVARA_PRE_EMBED_MODEL", "nomic-embed-text-v2-moe")
+    resp = http_request(
+        "POST",
+        url,
+        headers={"Content-Type": "application/json"},
+        body={"input": [query], "model": model},
+    )
+    data = resp.get("data")
+    if isinstance(data, list) and data and isinstance(data[0], dict):
+        return [float(x) for x in data[0]["embedding"]]
+    embs = resp.get("embeddings")
+    if isinstance(embs, list) and embs:
+        return [float(x) for x in embs[0]]
+    raise RuntimeError(f"embed response shape unrecognised: {list(resp.keys())[:5]}")
+
+
+def _rerank_local(query: str, documents: list[str], target: Target) -> list[dict[str, Any]]:
+    """Score (query, document) pairs against the rerank sidecar.
+    Returns the sidecar response shape: [{index, relevance_score}, ...]
+    sorted by score descending."""
+    resp = http_request(
+        "POST",
+        target.rerank_endpoint,
+        headers={"Content-Type": "application/json"},
+        body={"query": query, "documents": documents},
+    )
+    results = resp.get("results") or []
+    return sorted(results, key=lambda r: r.get("relevance_score", 0.0), reverse=True)
+
+
+def _result_text(hit: dict[str, Any]) -> str:
+    meta = hit.get("metadata")
+    if isinstance(meta, dict):
+        t = meta.get("text")
+        if isinstance(t, str):
+            return t
+    return ""
+
+
 def search_pair(
     target: Target,
     collection: str,
@@ -323,12 +373,26 @@ def search_pair(
     so the analyzer has both the production (post-rerank) order and
     the vector-only order to compute score_gap and top1_changed.
 
+    Two transport modes:
+    - Default: server-side /api/v1/search/text with rerank flag. Works
+      on .64 (main branch binary) — Levara embeds query, runs vector
+      search, optionally calls rerank sidecar, returns sorted hits.
+    - LEVARA_PRE_EMBED_URL set: client-side. Embed locally via Ollama,
+      POST /api/v1/search with the vector (legacy handler, never
+      reranks), then call the rerank sidecar from this process for
+      the with_rerank pair. Needed on Pi (de809b71) where server-side
+      /search/text returns literal JSON `null`.
+
     Returns a dict shaped:
         {
           "with_rerank": {<server response>, latency_ms: ...},
           "no_rerank":   {<server response>, latency_ms: ...},
         }
     """
+    if os.environ.get("LEVARA_PRE_EMBED_URL"):
+        return _search_pair_pre_embed(
+            target, collection, query, top_k=top_k, room=room, tags=tags
+        )
     out: dict[str, Any] = {}
     for label, rerank in (("with_rerank", True), ("no_rerank", False)):
         body = {
@@ -357,6 +421,68 @@ def search_pair(
             "response": resp,
         }
     return out
+
+
+def _search_pair_pre_embed(
+    target: Target,
+    collection: str,
+    query: str,
+    *,
+    top_k: int,
+    room: str | None,
+    tags: list[str] | None,
+) -> dict[str, Any]:
+    """Client-side equivalent of search_pair for the Pi /search/text
+    bypass. Overfetches 3× top_k for vector candidates, reranks
+    locally via the sidecar, then projects both views back into the
+    {results: [...]} envelope the analyzer expects."""
+    overfetch = max(top_k * 3, 30)
+    t_no_r0 = time.monotonic()
+    vector = _embed_local(query)
+    body = {"collection": collection, "vector": vector, "top_k": overfetch}
+    raw = http_request(
+        "POST", target.url("/api/v1/search"), headers=target.headers(), body=body
+    )
+    no_r_hits = raw.get("results") if isinstance(raw, dict) else None
+    if not isinstance(no_r_hits, list):
+        no_r_hits = []
+    no_r_top = no_r_hits[:top_k]
+    no_r_latency = int((time.monotonic() - t_no_r0) * 1000)
+
+    t_r0 = time.monotonic()
+    with_r_hits: list[dict[str, Any]] = no_r_top
+    if no_r_hits and target.rerank_endpoint:
+        docs = [_result_text(h) for h in no_r_hits]
+        # Drop empty-text candidates — rerank sidecar would score them
+        # against the query meaninglessly. The original chunksSearch
+        # path passes the text from metadata.text, and skips silently
+        # when extractText returns "" (see ExtractText in pipeline).
+        idx_keep = [i for i, t in enumerate(docs) if t]
+        if idx_keep:
+            kept_docs = [docs[i] for i in idx_keep]
+            scored = _rerank_local(query, kept_docs, target)
+            ordered: list[dict[str, Any]] = []
+            for s in scored:
+                local_idx = s.get("index")
+                if not isinstance(local_idx, int) or local_idx >= len(idx_keep):
+                    continue
+                hit = dict(no_r_hits[idx_keep[local_idx]])
+                hit["score"] = float(s.get("relevance_score", 0.0))
+                hit["reranked"] = True
+                ordered.append(hit)
+            with_r_hits = ordered[:top_k]
+    with_r_latency = int((time.monotonic() - t_r0) * 1000)
+
+    return {
+        "no_rerank": {
+            "latency_ms": no_r_latency,
+            "response": {"results": no_r_top},
+        },
+        "with_rerank": {
+            "latency_ms": no_r_latency + with_r_latency,
+            "response": {"results": with_r_hits},
+        },
+    }
 
 
 # ── Score extraction (analyzer-side helpers used inline) ────────────

--- a/scripts/load-profiles/runner.py
+++ b/scripts/load-profiles/runner.py
@@ -196,6 +196,13 @@ def preflight(target: Target, *, require_rerank: bool = True) -> dict[str, Any]:
         "embed_model", ""
     )
     target.rerank_endpoint = rerank_info.get("endpoint", "")
+    # Allow the orchestrator to override the rerank URL — needed when
+    # the server reports a loopback address (e.g. http://127.0.0.1:9100
+    # on Pi bench) but the caller is off-box. Cf. LEVARA_PRE_EMBED_URL,
+    # which exists for the same reason on the embed sidecar.
+    override = os.environ.get("LEVARA_RERANK_URL", "").strip()
+    if override:
+        target.rerank_endpoint = override
     target.rerank_enabled = bool(rerank_info.get("enabled")) or bool(
         target.rerank_endpoint
     )

--- a/scripts/load-profiles/seed/code_corpus.py
+++ b/scripts/load-profiles/seed/code_corpus.py
@@ -67,13 +67,13 @@ SOURCES: list[tuple[str, str, str, int]] = [
     (
         "js_lodash_debounce",
         "js",
-        "https://raw.githubusercontent.com/lodash/lodash/4.17.21/debounce.js",
+        "https://raw.githubusercontent.com/lodash/lodash/4.17.21-npm/debounce.js",
         2_000,
     ),
     (
         "js_lodash_throttle",
         "js",
-        "https://raw.githubusercontent.com/lodash/lodash/4.17.21/throttle.js",
+        "https://raw.githubusercontent.com/lodash/lodash/4.17.21-npm/throttle.js",
         1_500,
     ),
 ]

--- a/scripts/load-profiles/seed/code_corpus.py
+++ b/scripts/load-profiles/seed/code_corpus.py
@@ -258,6 +258,60 @@ def corpus_fingerprint() -> str:
     return h.hexdigest()[:12]
 
 
+def seed_via_cognify(
+    target,
+    collection: str,
+    *,
+    chunks: list[dict],
+    poll_seconds: float = 2.0,
+    timeout_seconds: float = 1800.0,
+) -> dict:
+    """Seed `collection` by submitting the joined corpus to /api/v1/cognify.
+
+    Runs the FULL Levara pipeline (chunk -> LLM entity extraction -> dedup
+    -> embed -> write HNSW+BM25+graph+WAL) so the bench is honest.
+    """
+    import sys
+    import time
+    from pathlib import Path
+
+    load_profiles_root = Path(__file__).resolve().parents[1]
+    if str(load_profiles_root) not in sys.path:
+        sys.path.insert(0, str(load_profiles_root))
+    import runner
+
+    text = "\n\n=====\n\n".join(c["text"] for c in chunks)
+
+    resp = runner.http_request(
+        "POST",
+        target.url("/api/v1/cognify"),
+        headers=target.headers(),
+        body={"dataset": collection, "dataset_name": collection, "text": text},
+        timeout=60.0,
+    )
+    run_id = resp.get("run_id") or resp.get("id")
+    if not run_id:
+        raise RuntimeError(f"cognify did not return run_id: {resp!r}")
+
+    print(f"[cognify] run_id={run_id} polling...", file=sys.stderr)
+    start = time.time()
+    while True:
+        if time.time() - start > timeout_seconds:
+            raise TimeoutError(f"cognify {run_id} did not terminate in {timeout_seconds}s")
+        status = runner.http_request(
+            "GET",
+            target.url(f"/api/v1/cognify/status/{run_id}"),
+            headers=target.headers(),
+        )
+        state = (status.get("status") or status.get("state") or "").lower()
+        if state in ("done", "completed", "success"):
+            print(f"[cognify] done in {time.time()-start:.1f}s", file=sys.stderr)
+            return status
+        if state in ("error", "failed"):
+            raise RuntimeError(f"cognify failed: {status!r}")
+        time.sleep(poll_seconds)
+
+
 # Mixed query set with explicit `target_kind` tag so the analyzer
 # can slice gap distributions by whether the right answer is code
 # or prose. The same conceptual query is duplicated in two shapes

--- a/scripts/load-profiles/seed/code_corpus.py
+++ b/scripts/load-profiles/seed/code_corpus.py
@@ -266,13 +266,17 @@ def seed_via_cognify(
     poll_seconds: float = 2.0,
     timeout_seconds: float = 1800.0,
 ) -> dict:
-    """Seed `collection` by submitting the joined corpus to /api/v1/cognify.
+    """Seed `collection` by submitting the chunk corpus to /api/v1/cognify
+    with skip_graph=true (RAG mode — chunk → embed → HNSW+BM25 insert,
+    no LLM entity extraction).
 
-    Runs the FULL Levara pipeline (chunk -> LLM entity extraction -> dedup
-    -> embed -> write HNSW+BM25+graph+WAL) so the bench is honest.
+    Delegates to runner.add_texts which is the canonical, known-good
+    cognify payload shape used by p4/p5 (texts:[...], collection,
+    skip_graph=true, runInBackground=true) and polls the run via
+    /api/v1/cognify/{run_id}/status. The original implementation sent
+    {dataset, text} which the server rejects with `no texts to cognify`.
     """
     import sys
-    import time
     from pathlib import Path
 
     load_profiles_root = Path(__file__).resolve().parents[1]
@@ -280,36 +284,13 @@ def seed_via_cognify(
         sys.path.insert(0, str(load_profiles_root))
     import runner
 
-    text = "\n\n=====\n\n".join(c["text"] for c in chunks)
-
-    resp = runner.http_request(
-        "POST",
-        target.url("/api/v1/cognify"),
-        headers=target.headers(),
-        body={"dataset": collection, "dataset_name": collection, "text": text},
-        timeout=60.0,
+    return runner.add_texts(
+        target,
+        collection,
+        chunks,
+        poll_timeout_s=timeout_seconds,
+        poll_interval_s=poll_seconds,
     )
-    run_id = resp.get("run_id") or resp.get("id")
-    if not run_id:
-        raise RuntimeError(f"cognify did not return run_id: {resp!r}")
-
-    print(f"[cognify] run_id={run_id} polling...", file=sys.stderr)
-    start = time.time()
-    while True:
-        if time.time() - start > timeout_seconds:
-            raise TimeoutError(f"cognify {run_id} did not terminate in {timeout_seconds}s")
-        status = runner.http_request(
-            "GET",
-            target.url(f"/api/v1/cognify/status/{run_id}"),
-            headers=target.headers(),
-        )
-        state = (status.get("status") or status.get("state") or "").lower()
-        if state in ("done", "completed", "success"):
-            print(f"[cognify] done in {time.time()-start:.1f}s", file=sys.stderr)
-            return status
-        if state in ("error", "failed"):
-            raise RuntimeError(f"cognify failed: {status!r}")
-        time.sleep(poll_seconds)
 
 
 # Mixed query set with explicit `target_kind` tag so the analyzer

--- a/scripts/load-profiles/seed/code_corpus.py
+++ b/scripts/load-profiles/seed/code_corpus.py
@@ -1,0 +1,296 @@
+"""Mixed code+prose corpus for P3.
+
+Half of the chunks are real source code (Go, Python, JS) and half
+are prose describing what that code does. The two halves share
+vocabulary but in very different syntactic shapes — that's the
+calibration signal we're after: vector embeddings collapse a lot of
+code into similar regions, while lexical/cross-encoder rerank can
+exploit token-level cues that the bi-encoder misses. The split
+also lets the calibration analyzer slice score-gap distributions
+by content kind (code vs prose) and see whether the same gate
+threshold works for both.
+
+Source: a small set of permissively-licensed open repos pinned to
+specific commits. We pull whole files rather than diffs so the
+content is stable across runs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import urllib.request
+
+# (slug, language, url, expected_min_chars).
+SOURCES: list[tuple[str, str, str, int]] = [
+    # Go — small handler files, easy to chunk.
+    (
+        "go_net_http_server",
+        "go",
+        "https://raw.githubusercontent.com/golang/go/release-branch.go1.22/src/net/http/server.go",
+        100_000,
+    ),
+    (
+        "go_sync_mutex",
+        "go",
+        "https://raw.githubusercontent.com/golang/go/release-branch.go1.22/src/sync/mutex.go",
+        5_000,
+    ),
+    (
+        "go_sync_waitgroup",
+        "go",
+        "https://raw.githubusercontent.com/golang/go/release-branch.go1.22/src/sync/waitgroup.go",
+        3_000,
+    ),
+    # Python stdlib
+    (
+        "py_asyncio_locks",
+        "py",
+        "https://raw.githubusercontent.com/python/cpython/v3.12.0/Lib/asyncio/locks.py",
+        10_000,
+    ),
+    (
+        "py_threading",
+        "py",
+        "https://raw.githubusercontent.com/python/cpython/v3.12.0/Lib/threading.py",
+        40_000,
+    ),
+    (
+        "py_queue",
+        "py",
+        "https://raw.githubusercontent.com/python/cpython/v3.12.0/Lib/queue.py",
+        8_000,
+    ),
+    # JS — a real-world utility lib
+    (
+        "js_lodash_debounce",
+        "js",
+        "https://raw.githubusercontent.com/lodash/lodash/4.17.21/debounce.js",
+        2_000,
+    ),
+    (
+        "js_lodash_throttle",
+        "js",
+        "https://raw.githubusercontent.com/lodash/lodash/4.17.21/throttle.js",
+        1_500,
+    ),
+]
+
+# Companion prose: short descriptions of each concept. Hand-written
+# so vocabulary overlap with the code is partial (function names
+# appear, but most of the prose is in natural-language paraphrase).
+# This is what makes P3 useful — bi-encoder will match the code
+# strongly when query is concept-shaped, and rerank should rescue
+# prose targets only when concept actually matches.
+PROSE: list[dict[str, str]] = [
+    {
+        "slug": "prose_http_handler",
+        "text": (
+            "An HTTP server in Go is built around the ServeMux router and the "
+            "Handler interface. A handler implements ServeHTTP, which receives "
+            "the response writer and the parsed request. The server reads the "
+            "request line, headers, and body off the connection, dispatches to "
+            "the registered handler, and writes the response back. Connection "
+            "lifecycle, keep-alive, and TLS termination are managed by the "
+            "Server struct."
+        ),
+    },
+    {
+        "slug": "prose_mutex",
+        "text": (
+            "A mutex is the simplest synchronization primitive: at most one "
+            "goroutine can hold it at a time. Lock blocks until the mutex is "
+            "free; Unlock releases it. Used to protect access to a shared "
+            "variable from concurrent reads and writes. Incorrect use — "
+            "double-unlock, lock-without-unlock — is a runtime error."
+        ),
+    },
+    {
+        "slug": "prose_waitgroup",
+        "text": (
+            "A WaitGroup lets a goroutine wait for a collection of other "
+            "goroutines to finish. Add increments the counter before "
+            "launching workers; each worker calls Done when it finishes; the "
+            "coordinator calls Wait, which blocks until the counter hits "
+            "zero."
+        ),
+    },
+    {
+        "slug": "prose_asyncio_lock",
+        "text": (
+            "An asyncio Lock is the asynchronous analogue of threading.Lock. "
+            "Acquire is a coroutine that suspends until the lock is free; "
+            "release wakes the next waiter. Locks are typically used as "
+            "async context managers via async with."
+        ),
+    },
+    {
+        "slug": "prose_threading_module",
+        "text": (
+            "The threading module exposes Thread, Lock, RLock, Condition, "
+            "Event, Semaphore, and Barrier. Threads share memory and the "
+            "GIL serializes Python bytecode execution. Daemon threads are "
+            "killed when the main thread exits."
+        ),
+    },
+    {
+        "slug": "prose_queue",
+        "text": (
+            "A thread-safe Queue supports put and get with optional "
+            "blocking and timeouts. Variants include LifoQueue for stack "
+            "semantics and PriorityQueue ordered by item value. Used as "
+            "a hand-off between producer and consumer threads."
+        ),
+    },
+    {
+        "slug": "prose_debounce",
+        "text": (
+            "Debounce postpones invoking a function until after a quiet "
+            "period has elapsed since the last call. Useful for resize and "
+            "input handlers where rapid events should collapse into a "
+            "single invocation when the burst ends."
+        ),
+    },
+    {
+        "slug": "prose_throttle",
+        "text": (
+            "Throttle limits how often a function can run regardless of "
+            "how many times it's called: at most once per interval. Unlike "
+            "debounce it does fire during a burst, just at a capped rate."
+        ),
+    },
+]
+
+
+COMMENT_TRIM = re.compile(r"^\s*//.*?$|^\s*#.*?$", re.MULTILINE)
+
+
+def cache_dir() -> str:
+    d = os.environ.get(
+        "LOADPROFILE_CACHE",
+        os.path.expanduser("~/.cache/levara-load-profiles/code"),
+    )
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def _download(slug: str, url: str, min_chars: int) -> str:
+    path = os.path.join(cache_dir(), f"{slug}.txt")
+    if os.path.exists(path) and os.path.getsize(path) >= min_chars:
+        return path
+    req = urllib.request.Request(url, headers={"User-Agent": "levara-loadprofile/1.0"})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        text = resp.read().decode("utf-8", "replace")
+    if len(text) < min_chars:
+        raise RuntimeError(f"code source {slug} short: {len(text)} < {min_chars}")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+    return path
+
+
+def _code_chunks(path: str, slug: str, language: str) -> list[dict[str, str]]:
+    """Split source by top-level definitions when we can spot them
+    (`func `, `def `, `class `, `function `, `export function`); else
+    fall back to fixed-size windows. Keep chunks ~800–1500 chars so
+    most fit a single function body."""
+    with open(path, encoding="utf-8") as f:
+        raw = f.read()
+    if language == "go":
+        pattern = re.compile(r"\n(?=func\s|type\s\w+\s+struct|type\s\w+\s+interface)")
+    elif language == "py":
+        pattern = re.compile(r"\n(?=def\s|class\s|async\s+def\s)")
+    else:  # js / generic
+        pattern = re.compile(r"\n(?=function\s|export\s+(?:function|const|default))")
+    parts = [p for p in pattern.split(raw) if p.strip()]
+    chunks: list[dict[str, str]] = []
+    for idx, part in enumerate(parts):
+        if len(part) < 200:
+            continue
+        # Cap long bodies; split into ~1200-char windows.
+        for off in range(0, len(part), 1200):
+            sub = part[off : off + 1400]
+            if len(sub) < 200:
+                break
+            chunks.append(
+                {
+                    "id": f"code:{slug}:{idx:03d}:{off:05d}",
+                    "text": sub,
+                    "metadata": json.dumps(
+                        {
+                            "source": "code",
+                            "kind": "code",
+                            "lang": language,
+                            "file": slug,
+                        }
+                    ),
+                }
+            )
+    return chunks
+
+
+def load_corpus(max_chunks_per_source: int = 60) -> list[dict[str, str]]:
+    out: list[dict[str, str]] = []
+    for slug, lang, url, min_chars in SOURCES:
+        path = _download(slug, url, min_chars)
+        chunks = _code_chunks(path, slug, lang)
+        out.extend(chunks[:max_chunks_per_source])
+    for p in PROSE:
+        out.append(
+            {
+                "id": f"prose:{p['slug']}",
+                "text": p["text"],
+                "metadata": json.dumps(
+                    {"source": "prose", "kind": "prose", "slug": p["slug"]}
+                ),
+            }
+        )
+    return out
+
+
+def corpus_fingerprint() -> str:
+    h = hashlib.sha256()
+    for slug, lang, url, min_chars in SOURCES:
+        h.update(f"{slug}:{lang}:{url}:{min_chars}\n".encode())
+    for p in PROSE:
+        h.update(f"prose:{p['slug']}:{len(p['text'])}\n".encode())
+    return h.hexdigest()[:12]
+
+
+# Mixed query set with explicit `target_kind` tag so the analyzer
+# can slice gap distributions by whether the right answer is code
+# or prose. The same conceptual query is duplicated in two shapes
+# (token-precise vs concept-paraphrase) so we can see how vector
+# vs rerank handle each.
+QUERIES: list[dict[str, str]] = [
+    # token-precise — should win on code chunks via lexical overlap
+    {"id": "q01", "text": "func (mu *Mutex) Lock()", "kind": "code-precise", "target_kind": "code"},
+    {"id": "q02", "text": "func (wg *WaitGroup) Wait()", "kind": "code-precise", "target_kind": "code"},
+    {"id": "q03", "text": "async def acquire(self)", "kind": "code-precise", "target_kind": "code"},
+    {"id": "q04", "text": "function debounce(func, wait, options)", "kind": "code-precise", "target_kind": "code"},
+    {"id": "q05", "text": "ServeMux Handle pattern", "kind": "code-precise", "target_kind": "code"},
+    {"id": "q06", "text": "class Queue put_nowait", "kind": "code-precise", "target_kind": "code"},
+    # concept-paraphrase — prose should win if rerank does its job
+    {"id": "q07", "text": "what happens when two threads grab the same lock at once", "kind": "concept-paraphrase", "target_kind": "prose"},
+    {"id": "q08", "text": "wait for a group of background tasks to all complete", "kind": "concept-paraphrase", "target_kind": "prose"},
+    {"id": "q09", "text": "non-blocking version of a mutex for coroutines", "kind": "concept-paraphrase", "target_kind": "prose"},
+    {"id": "q10", "text": "collapse a burst of events into one call at the end", "kind": "concept-paraphrase", "target_kind": "prose"},
+    {"id": "q11", "text": "how an HTTP server routes incoming requests to handlers", "kind": "concept-paraphrase", "target_kind": "prose"},
+    {"id": "q12", "text": "give consumer threads work without races", "kind": "concept-paraphrase", "target_kind": "prose"},
+    # mixed — both prose and code could plausibly answer
+    {"id": "q13", "text": "throttle vs debounce", "kind": "mixed", "target_kind": "either"},
+    {"id": "q14", "text": "GIL and threading in python", "kind": "mixed", "target_kind": "either"},
+    {"id": "q15", "text": "daemon threads in python", "kind": "mixed", "target_kind": "either"},
+    {"id": "q16", "text": "sync.WaitGroup add done wait", "kind": "mixed", "target_kind": "either"},
+    {"id": "q17", "text": "PriorityQueue vs LifoQueue", "kind": "mixed", "target_kind": "either"},
+    {"id": "q18", "text": "context cancellation in http handlers", "kind": "mixed", "target_kind": "either"},
+    # adversarial — query that looks code-shaped but isn't in corpus
+    {"id": "q19", "text": "fn render_widget(props: &Props) -> Element", "kind": "adversarial", "target_kind": "ooc"},
+    {"id": "q20", "text": "trait IteratorExt for Vec<T>", "kind": "adversarial", "target_kind": "ooc"},
+    # out-of-corpus
+    {"id": "q21", "text": "ottoman empire decline causes", "kind": "ooc", "target_kind": "ooc"},
+    {"id": "q22", "text": "knee surgery recovery timeline", "kind": "ooc", "target_kind": "ooc"},
+    {"id": "q23", "text": "espresso grind size for moka pot", "kind": "ooc", "target_kind": "ooc"},
+    {"id": "q24", "text": "rust borrow checker lifetime elision", "kind": "ooc", "target_kind": "ooc"},
+]

--- a/scripts/load-profiles/seed/docs_corpus.py
+++ b/scripts/load-profiles/seed/docs_corpus.py
@@ -1,0 +1,204 @@
+"""Technical-docs corpus seeder for P2 (ambiguous queries).
+
+Pulls a fixed set of Kubernetes and PostgreSQL doc pages whose
+content overlaps semantically — multiple pages describe related
+concepts in different framings (pods/replicasets/deployments,
+WAL/checkpoint/recovery, transaction isolation across multiple
+docs). That overlap is what makes the corpus useful for
+calibration: every ambiguous query has several plausible right
+answers, which is exactly the regime where rerank earns its keep.
+
+Mirrors are GitHub raw URLs against pinned commits to keep the
+corpus reproducible across runs and across hosts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import urllib.request
+
+# (slug, url, expected_min_chars). Pinned to specific commits.
+PAGES: list[tuple[str, str, int]] = [
+    (
+        "k8s_pods",
+        "https://raw.githubusercontent.com/kubernetes/website/main/content/en/docs/concepts/workloads/pods/_index.md",
+        4_000,
+    ),
+    (
+        "k8s_deployments",
+        "https://raw.githubusercontent.com/kubernetes/website/main/content/en/docs/concepts/workloads/controllers/deployment.md",
+        15_000,
+    ),
+    (
+        "k8s_replicasets",
+        "https://raw.githubusercontent.com/kubernetes/website/main/content/en/docs/concepts/workloads/controllers/replicaset.md",
+        6_000,
+    ),
+    (
+        "k8s_services",
+        "https://raw.githubusercontent.com/kubernetes/website/main/content/en/docs/concepts/services-networking/service.md",
+        20_000,
+    ),
+    (
+        "k8s_taints",
+        "https://raw.githubusercontent.com/kubernetes/website/main/content/en/docs/concepts/scheduling-eviction/taint-and-toleration.md",
+        8_000,
+    ),
+    (
+        "k8s_scheduler",
+        "https://raw.githubusercontent.com/kubernetes/website/main/content/en/docs/concepts/scheduling-eviction/kube-scheduler.md",
+        4_000,
+    ),
+    (
+        "k8s_configmap",
+        "https://raw.githubusercontent.com/kubernetes/website/main/content/en/docs/concepts/configuration/configmap.md",
+        6_000,
+    ),
+    (
+        "k8s_secrets",
+        "https://raw.githubusercontent.com/kubernetes/website/main/content/en/docs/concepts/configuration/secret.md",
+        10_000,
+    ),
+    (
+        "pg_mvcc",
+        "https://raw.githubusercontent.com/postgres/postgres/master/doc/src/sgml/mvcc.sgml",
+        8_000,
+    ),
+    (
+        "pg_wal",
+        "https://raw.githubusercontent.com/postgres/postgres/master/doc/src/sgml/wal.sgml",
+        8_000,
+    ),
+    (
+        "pg_backup",
+        "https://raw.githubusercontent.com/postgres/postgres/master/doc/src/sgml/backup.sgml",
+        20_000,
+    ),
+    (
+        "pg_isolation",
+        "https://raw.githubusercontent.com/postgres/postgres/master/doc/src/sgml/ref/set_transaction.sgml",
+        2_000,
+    ),
+]
+
+# Strip markdown front-matter, HTML/SGML tags, and Hugo shortcodes —
+# none of those help retrieval and they would distort BM25.
+FRONT_MATTER = re.compile(r"^---\s*\n.*?\n---\s*\n", re.DOTALL)
+HUGO_SHORTCODE = re.compile(r"{{[<%].*?[%>]}}", re.DOTALL)
+TAG_RE = re.compile(r"<[^>]+>")
+WS_RE = re.compile(r"[ \t]+")
+HEADING_SPLIT = re.compile(r"\n(?=#{1,3}\s)|\n(?=<sect[12])")
+
+
+def cache_dir() -> str:
+    d = os.environ.get(
+        "LOADPROFILE_CACHE",
+        os.path.expanduser("~/.cache/levara-load-profiles/docs"),
+    )
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def _download(slug: str, url: str, min_chars: int) -> str:
+    path = os.path.join(cache_dir(), f"{slug}.txt")
+    if os.path.exists(path) and os.path.getsize(path) >= min_chars:
+        return path
+    req = urllib.request.Request(url, headers={"User-Agent": "levara-loadprofile/1.0"})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        text = resp.read().decode("utf-8", "replace")
+    if len(text) < min_chars:
+        raise RuntimeError(
+            f"docs page {slug} short download: {len(text)} < {min_chars}"
+        )
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+    return path
+
+
+def _clean(raw: str) -> str:
+    text = FRONT_MATTER.sub("", raw)
+    text = HUGO_SHORTCODE.sub("", text)
+    text = TAG_RE.sub("", text)
+    text = WS_RE.sub(" ", text)
+    return text
+
+
+def _chunks_from_page(path: str, slug: str) -> list[dict[str, str]]:
+    with open(path, encoding="utf-8") as f:
+        raw = f.read()
+    text = _clean(raw)
+    parts = [p.strip() for p in HEADING_SPLIT.split(text) if p.strip()]
+    out: list[dict[str, str]] = []
+    for idx, part in enumerate(parts):
+        if len(part) < 120:
+            continue  # skip stub sections — they only add noise
+        while part:
+            chunk = part[:1400]
+            part = part[1400:]
+            if len(chunk) < 120:
+                break
+            out.append(
+                {
+                    "id": f"docs:{slug}:{idx:03d}:{len(out):03d}",
+                    "text": chunk,
+                    "metadata": json.dumps(
+                        {"source": "docs", "page": slug, "section_idx": idx}
+                    ),
+                }
+            )
+    return out
+
+
+def load_corpus(max_chunks_per_page: int = 80) -> list[dict[str, str]]:
+    out: list[dict[str, str]] = []
+    for slug, url, min_chars in PAGES:
+        path = _download(slug, url, min_chars)
+        ch = _chunks_from_page(path, slug)
+        out.extend(ch[:max_chunks_per_page])
+    return out
+
+
+def corpus_fingerprint() -> str:
+    h = hashlib.sha256()
+    for slug, url, min_chars in PAGES:
+        h.update(f"{slug}:{url}:{min_chars}\n".encode())
+    return h.hexdigest()[:12]
+
+
+# Ambiguous-heavy query set. Each query has >=2 plausible target
+# pages; the rerank pass is what should disambiguate. Also keeps a
+# few sharp factual queries and out-of-corpus tails so the gap
+# distribution covers all regimes.
+QUERIES: list[dict[str, str]] = [
+    # ambiguous — overlap across pages
+    {"id": "q01", "text": "how do I control where my workload is scheduled", "kind": "ambiguous"},
+    {"id": "q02", "text": "how do I run multiple replicas of a workload", "kind": "ambiguous"},
+    {"id": "q03", "text": "how do I expose my workload over the network", "kind": "ambiguous"},
+    {"id": "q04", "text": "how do I pass configuration into a workload", "kind": "ambiguous"},
+    {"id": "q05", "text": "what guarantees does the database give about concurrent transactions", "kind": "ambiguous"},
+    {"id": "q06", "text": "how does postgres recover after a crash", "kind": "ambiguous"},
+    {"id": "q07", "text": "how do I take a consistent backup of postgres", "kind": "ambiguous"},
+    {"id": "q08", "text": "what happens when two writers update the same row", "kind": "ambiguous"},
+    # factual / sharp
+    {"id": "q09", "text": "what is a NodeAffinity rule", "kind": "factual"},
+    {"id": "q10", "text": "kubectl rollout status deployment", "kind": "factual"},
+    {"id": "q11", "text": "headless service ClusterIP None", "kind": "factual"},
+    {"id": "q12", "text": "default repeatable read isolation level", "kind": "factual"},
+    {"id": "q13", "text": "what does a checkpoint do in postgres", "kind": "factual"},
+    {"id": "q14", "text": "Secret type kubernetes.io/dockerconfigjson", "kind": "factual"},
+    # paraphrase / vocabulary mismatch
+    {"id": "q15", "text": "make sure two pods don't land on the same machine", "kind": "paraphrase"},
+    {"id": "q16", "text": "keep N copies of my app running at all times", "kind": "paraphrase"},
+    {"id": "q17", "text": "let my service be reached from outside the cluster", "kind": "paraphrase"},
+    {"id": "q18", "text": "make the database see a snapshot of when my transaction started", "kind": "paraphrase"},
+    {"id": "q19", "text": "what file does postgres write before it touches the data files", "kind": "paraphrase"},
+    {"id": "q20", "text": "store a string of credentials so my pod can read it", "kind": "paraphrase"},
+    # out-of-corpus
+    {"id": "q21", "text": "victorian poetry meter analysis", "kind": "ooc"},
+    {"id": "q22", "text": "guitar chord voicing technique", "kind": "ooc"},
+    {"id": "q23", "text": "lasagne recipe with bechamel", "kind": "ooc"},
+    {"id": "q24", "text": "tide tables for the english channel", "kind": "ooc"},
+]

--- a/scripts/load-profiles/seed/gutenberg.py
+++ b/scripts/load-profiles/seed/gutenberg.py
@@ -1,0 +1,177 @@
+"""Gutenberg corpus seeder for narrative+factual profiles.
+
+Picks a curated set of public-domain books spanning genres
+(philosophy, science history, fiction, biography) so the corpus
+has semantic breadth — the calibration data must contain queries
+that are both unambiguous and ambiguous, and a single-genre corpus
+collapses that distribution.
+
+The seeder is idempotent: it hashes its plan and skips fetching
+when the cached corpus on disk matches.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import urllib.request
+
+# Each entry: (gutenberg_id, slug, expected_min_chars).
+# Min char guards against partial downloads being silently accepted.
+BOOKS: list[tuple[int, str, int]] = [
+    (1342, "pride_and_prejudice", 500_000),     # Austen, fiction/social
+    (84, "frankenstein", 350_000),              # Shelley, gothic/sci-fi
+    (1661, "sherlock_adventures", 500_000),     # Doyle, detective
+    (2701, "moby_dick", 1_000_000),             # Melville, philosophical/maritime
+    (5200, "metamorphosis", 90_000),            # Kafka, surreal
+    (74, "tom_sawyer", 350_000),                # Twain, americana
+    (1232, "the_prince", 250_000),              # Machiavelli, political philosophy
+    (43, "jekyll_and_hyde", 100_000),           # Stevenson, psychological
+]
+
+MIRROR = "https://www.gutenberg.org/cache/epub/{id}/pg{id}.txt"
+PARA_SPLIT = re.compile(r"\n\s*\n+")
+
+
+def cache_dir() -> str:
+    d = os.environ.get(
+        "LOADPROFILE_CACHE",
+        os.path.expanduser("~/.cache/levara-load-profiles/gutenberg"),
+    )
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def _download(book_id: int, slug: str, min_chars: int) -> str:
+    path = os.path.join(cache_dir(), f"{slug}.txt")
+    if os.path.exists(path) and os.path.getsize(path) >= min_chars:
+        return path
+    url = MIRROR.format(id=book_id)
+    req = urllib.request.Request(url, headers={"User-Agent": "levara-loadprofile/1.0"})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        text = resp.read().decode("utf-8", "replace")
+    if len(text) < min_chars:
+        raise RuntimeError(
+            f"gutenberg book {book_id} short download: {len(text)} < {min_chars}"
+        )
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+    return path
+
+
+def _strip_gutenberg_boilerplate(text: str) -> str:
+    """Remove the standard Project Gutenberg header/footer so chunks
+    don't get polluted with license boilerplate that would dominate
+    BM25 scoring."""
+    start = re.search(r"\*\*\*\s*START OF.*?\*\*\*", text)
+    end = re.search(r"\*\*\*\s*END OF.*?\*\*\*", text)
+    if start:
+        text = text[start.end() :]
+    if end:
+        text = text[: end.start() - (len(text) - len(text)) :]  # noop fallback
+        # Re-anchor against original by using end.start() before we
+        # mutated start. Simpler: re-split from scratch.
+    # Simpler safe re-derivation:
+    return text
+
+
+def _chunks_from_book(path: str, slug: str) -> list[dict[str, str]]:
+    with open(path, encoding="utf-8") as f:
+        raw = f.read()
+    # Trim PG boilerplate by slicing between the canonical markers.
+    s = re.search(r"\*\*\*\s*START OF.*?\*\*\*", raw)
+    e = re.search(r"\*\*\*\s*END OF.*?\*\*\*", raw)
+    body = raw[s.end() : e.start()] if (s and e) else raw
+    paras = [p.strip() for p in PARA_SPLIT.split(body) if p.strip()]
+    chunks: list[dict[str, str]] = []
+    buf: list[str] = []
+    buf_len = 0
+    para_idx = 0
+    for p in paras:
+        if buf_len + len(p) > 1200 and buf:
+            text = "\n\n".join(buf)
+            chunks.append(
+                {
+                    "id": f"gut:{slug}:{para_idx:05d}",
+                    "text": text,
+                    "metadata": json.dumps(
+                        {"source": "gutenberg", "book": slug, "para_idx": para_idx}
+                    ),
+                }
+            )
+            para_idx += 1
+            buf = [p]
+            buf_len = len(p)
+        else:
+            buf.append(p)
+            buf_len += len(p)
+    if buf:
+        text = "\n\n".join(buf)
+        chunks.append(
+            {
+                "id": f"gut:{slug}:{para_idx:05d}",
+                "text": text,
+                "metadata": json.dumps(
+                    {"source": "gutenberg", "book": slug, "para_idx": para_idx}
+                ),
+            }
+        )
+    return chunks
+
+
+def load_corpus(max_chunks_per_book: int = 250) -> list[dict[str, str]]:
+    """Return a flat list of `{id, text, metadata}` chunks across all
+    books in BOOKS, capped per book so a single long novel can't
+    dominate the corpus."""
+    out: list[dict[str, str]] = []
+    for book_id, slug, min_chars in BOOKS:
+        path = _download(book_id, slug, min_chars)
+        ch = _chunks_from_book(path, slug)
+        out.extend(ch[:max_chunks_per_book])
+    return out
+
+
+def corpus_fingerprint() -> str:
+    """Hash of (book_id, slug, max_chunks_per_book) so seeders can
+    detect drift and re-ingest only when the plan changes."""
+    h = hashlib.sha256()
+    for book_id, slug, min_chars in BOOKS:
+        h.update(f"{book_id}:{slug}:{min_chars}\n".encode())
+    return h.hexdigest()[:12]
+
+
+# Curated query set: mix of factual (single right answer), ambiguous
+# (multiple plausible passages), and out-of-corpus (should produce
+# low scores with wide gaps after rerank).
+QUERIES: list[dict[str, str]] = [
+    # factual / narrow
+    {"id": "q01", "text": "Elizabeth Bennet's first impression of Mr Darcy", "kind": "factual"},
+    {"id": "q02", "text": "creation of the monster in Victor Frankenstein's laboratory", "kind": "factual"},
+    {"id": "q03", "text": "the Hound of the Baskervilles legend", "kind": "factual"},
+    {"id": "q04", "text": "Ahab's first speech about the white whale", "kind": "factual"},
+    {"id": "q05", "text": "Gregor Samsa wakes transformed into an insect", "kind": "factual"},
+    {"id": "q06", "text": "Tom Sawyer whitewashing the fence", "kind": "factual"},
+    {"id": "q07", "text": "Machiavelli on fortune and virtue", "kind": "factual"},
+    {"id": "q08", "text": "Mr Hyde tramples the child in the street", "kind": "factual"},
+    # ambiguous / thematic
+    {"id": "q09", "text": "what does marriage mean for women in this novel", "kind": "ambiguous"},
+    {"id": "q10", "text": "creator's regret over his own creation", "kind": "ambiguous"},
+    {"id": "q11", "text": "deduction from a small physical detail", "kind": "ambiguous"},
+    {"id": "q12", "text": "obsession leading to destruction", "kind": "ambiguous"},
+    {"id": "q13", "text": "alienation from one's own family", "kind": "ambiguous"},
+    {"id": "q14", "text": "boys getting away with mischief", "kind": "ambiguous"},
+    {"id": "q15", "text": "how a ruler should treat his enemies", "kind": "ambiguous"},
+    {"id": "q16", "text": "the dual nature of a single person", "kind": "ambiguous"},
+    # paraphrased / vocabulary mismatch
+    {"id": "q17", "text": "a young lady is prejudiced against a wealthy gentleman", "kind": "paraphrase"},
+    {"id": "q18", "text": "a man stitches together a being from dead parts", "kind": "paraphrase"},
+    {"id": "q19", "text": "a detective explains his reasoning to his friend", "kind": "paraphrase"},
+    {"id": "q20", "text": "a captain hunts a sea creature that maimed him", "kind": "paraphrase"},
+    # out-of-corpus — gate should produce wide gap here
+    {"id": "q21", "text": "kubernetes pod scheduling and node taints", "kind": "ooc"},
+    {"id": "q22", "text": "postgres MVCC visibility rules", "kind": "ooc"},
+    {"id": "q23", "text": "react useEffect cleanup function semantics", "kind": "ooc"},
+    {"id": "q24", "text": "TLS handshake server hello", "kind": "ooc"},
+]

--- a/scripts/load-profiles/seed/memory_palace.py
+++ b/scripts/load-profiles/seed/memory_palace.py
@@ -1,0 +1,234 @@
+"""Synthetic memory-palace corpus for P4.
+
+Models the workload of an LLM-agent memory system: lots of short
+records tagged by `hall` (fact / decision / discovery / preference
+/ advice / event) and `room` (project subsystem). The dataset is
+generated deterministically from a seed so it's reproducible across
+hosts and over time — no external network dependency, which matters
+because P4 runs on the Pi where downloads are slow.
+
+The distribution shape is what matters for calibration: many
+records share vocabulary across rooms (the word "auth" appears in
+both auth and deploy rooms, with different meanings), and a small
+number of records are near-duplicates with subtle distinguishing
+detail. That's the regime where rerank gates earn or waste budget.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+from typing import Iterable
+
+# Hall vocabulary mirrors the mfs MCP contract — keep these aligned
+# with the project memory schema described in CLAUDE.md so the
+# distribution shape resembles real agent traffic.
+HALLS = ["fact", "decision", "discovery", "preference", "advice", "event"]
+ROOMS = [
+    "auth",
+    "deploy",
+    "mcp",
+    "rerank",
+    "ingest",
+    "graph",
+    "ui",
+    "observability",
+]
+
+# Templates: each (hall, list of templates with {tokens}). The {x_*}
+# placeholders are filled from disjoint vocab pools per room so the
+# resulting records have realistic room-specific content while still
+# overlapping enough to produce ambiguous queries.
+TEMPLATES: dict[str, list[str]] = {
+    "fact": [
+        "{room} service runs on port {port} with {protocol}",
+        "{room} endpoint /{path} returns {shape}",
+        "{room} requires environment variable {env}={val}",
+        "{room} component {comp} version {ver} is the current shipped build",
+    ],
+    "decision": [
+        "decided to use {choice} for {room} instead of {alt}. why: {reason}",
+        "rolled back {comp} change in {room} because {reason}",
+        "moved {workload} from {old_host} to {new_host}",
+        "adopted {pattern} pattern across {room} after {reason}",
+    ],
+    "discovery": [
+        "{room} bug: {symptom}. root cause: {cause}. fix: {fix}",
+        "found that {comp} silently fails when {condition}",
+        "{room} latency spike traced to {cause}",
+        "regression in {comp}: {symptom} after {trigger}",
+    ],
+    "preference": [
+        "user prefers {style} for {room} responses",
+        "user wants {behavior} when working on {room}",
+        "for {room} changes always {action} first",
+        "do not {antipattern} in {room} code",
+    ],
+    "advice": [
+        "before changing {room}, run {check}",
+        "when {room} alerts fire, look at {dashboard} first",
+        "to debug {comp} issues, enable {flag} and check {log}",
+        "rotate {secret} in {room} every {period}",
+    ],
+    "event": [
+        "{date}: shipped {feature} to {room}",
+        "{date}: incident in {room} — {symptom} for {duration}",
+        "{date}: cut release {version} of {comp}",
+        "{date}: {room} migration step {step} completed",
+    ],
+}
+
+POOLS: dict[str, dict[str, list[str]]] = {
+    "default": {
+        "port": ["8080", "8443", "9090", "50051", "7777", "8888", "11434"],
+        "protocol": ["HTTP", "HTTPS", "gRPC", "stdio MCP", "TCP"],
+        "path": ["search", "auth/login", "rerank/info", "datasets", "memory/save"],
+        "shape": ["JSON", "JSONL", "protobuf", "SSE stream", "msgpack"],
+        "env": ["JWT_SECRET", "RERANK_ENDPOINT", "EMBED_ENDPOINT", "LLM_API_KEY", "DB_DSN"],
+        "val": ["set", "required", "auto-generated", "loaded from vault"],
+        "comp": ["levara-server", "memoryfs", "mem0", "ollama", "qwen-rerank"],
+        "ver": ["b4fface", "0.4.2", "v2.1.0", "dev"],
+        "choice": ["sqlite", "postgres", "neo4j", "redis", "in-memory cache"],
+        "alt": ["lancedb", "qdrant", "weaviate", "pinecone", "filesystem"],
+        "reason": [
+            "performance was 5x better",
+            "ops complexity dropped",
+            "license required it",
+            "user explicitly asked",
+            "test data was inconclusive",
+            "production traffic showed the limit",
+        ],
+        "workload": ["embedding model", "rerank model", "LLM inference", "metric scraping"],
+        "old_host": ["10.23.0.53", "10.23.0.64", "Mac local", "docker host"],
+        "new_host": ["10.23.0.53", "10.23.0.64", "GPU node", "managed cloud"],
+        "pattern": ["circuit breaker", "outbox", "event sourcing", "saga", "two-phase"],
+        "symptom": [
+            "p99 latency over 5s",
+            "OOM on insert",
+            "embedding mismatch",
+            "404 on existing keys",
+            "duplicate writes",
+            "missing audit lines",
+        ],
+        "cause": [
+            "WAL fsync blocking",
+            "GPU memory fragmentation",
+            "HNSW rebuild thrashing",
+            "rate limiter misconfig",
+            "JWT clock skew",
+            "embedding dim mismatch",
+        ],
+        "fix": ["batched fsync", "pinned worker count", "explicit cache eviction", "added retry budget"],
+        "condition": ["payload exceeds 1MB", "embedding is null", "rerank times out"],
+        "trigger": ["dependency bump", "model swap", "config reload"],
+        "style": ["terse", "step-by-step", "with code samples", "diagram-first"],
+        "behavior": ["no summaries at the end", "show diff inline", "explain trade-offs"],
+        "action": ["run tests", "check audit log", "snapshot DB", "warn user"],
+        "antipattern": ["mock the embedder", "skip JWT checks", "log secrets", "swallow errors"],
+        "check": ["go test ./...", "make swag", "pytest tests/ -v", "k6 smoke"],
+        "dashboard": ["grafana p99 board", "rerank-outcome dashboard", "ingest queue depth"],
+        "flag": ["DEBUG=1", "LEVARA_TRACE=true", "RERANK_VERBOSE=1"],
+        "log": ["/var/log/levara.log", "audit log", "ollama stderr"],
+        "secret": ["JWT_SECRET", "DB password", "LLM API key", "service JWTs"],
+        "period": ["90 days", "30 days", "before each release"],
+        "date": ["2026-03-15", "2026-04-02", "2026-04-28", "2026-05-10", "2026-05-25"],
+        "feature": ["rerank gate threshold", "audit log rotation", "MCP tool groups", "P0 plan"],
+        "duration": ["15 minutes", "2 hours", "until reboot"],
+        "version": ["v0.4.0", "v0.4.1", "v0.5.0", "b4fface"],
+        "step": ["1 of 4", "2 of 4", "3 of 4", "final"],
+    },
+}
+
+
+def _rng(seed: str) -> random.Random:
+    return random.Random(int(hashlib.sha256(seed.encode()).hexdigest(), 16) % (2**32))
+
+
+def _fill(template: str, rng: random.Random, room: str) -> str:
+    pool = POOLS["default"]
+    out = template
+    for token in [t for t in pool if "{" + t + "}" in template]:
+        out = out.replace("{" + token + "}", rng.choice(pool[token]))
+    out = out.replace("{room}", room)
+    return out
+
+
+def load_corpus(per_room_per_hall: int = 12) -> list[dict[str, str]]:
+    """Generate per_room_per_hall × |ROOMS| × |HALLS| records.
+
+    Defaults produce 12 × 8 × 6 = 576 short records. Each gets a
+    stable id derived from (room, hall, index, content hash) so
+    re-running the seeder is a no-op when the plan hasn't changed.
+    """
+    out: list[dict[str, str]] = []
+    for room in ROOMS:
+        for hall in HALLS:
+            for i in range(per_room_per_hall):
+                rng = _rng(f"{room}:{hall}:{i}")
+                tpl = rng.choice(TEMPLATES[hall])
+                text = _fill(tpl, rng, room)
+                rec_id = f"mem:{room}:{hall}:{i:03d}"
+                out.append(
+                    {
+                        "id": rec_id,
+                        "text": text,
+                        "metadata": json.dumps(
+                            {
+                                "source": "memory_palace",
+                                "room": room,
+                                "hall": hall,
+                                "kind": "memory",
+                            }
+                        ),
+                    }
+                )
+    return out
+
+
+def corpus_fingerprint() -> str:
+    h = hashlib.sha256()
+    h.update(f"halls={'|'.join(HALLS)}\n".encode())
+    h.update(f"rooms={'|'.join(ROOMS)}\n".encode())
+    for hall, tpls in TEMPLATES.items():
+        for t in tpls:
+            h.update(f"{hall}:{t}\n".encode())
+    return h.hexdigest()[:12]
+
+
+# Recall-shaped query set: agent prompts probing the corpus from
+# multiple angles. Tag with expected_room / expected_hall when known
+# so the analyzer can verify filter-aware rerank actually improves
+# precision on filtered queries.
+QUERIES: list[dict[str, str | None]] = [
+    # broad — many plausible answers across rooms
+    {"id": "q01", "text": "what decisions have we made about deployment", "kind": "broad", "expected_hall": "decision"},
+    {"id": "q02", "text": "any preferences the user has shared", "kind": "broad", "expected_hall": "preference"},
+    {"id": "q03", "text": "recent events on the rerank stack", "kind": "broad", "expected_hall": "event", "expected_room": "rerank"},
+    {"id": "q04", "text": "discoveries about ingest latency", "kind": "broad", "expected_hall": "discovery", "expected_room": "ingest"},
+    {"id": "q05", "text": "facts about authentication setup", "kind": "broad", "expected_hall": "fact", "expected_room": "auth"},
+    {"id": "q06", "text": "advice for working on observability", "kind": "broad", "expected_hall": "advice", "expected_room": "observability"},
+    # narrow / sharp
+    {"id": "q07", "text": "what port does the gRPC server listen on", "kind": "sharp", "expected_hall": "fact"},
+    {"id": "q08", "text": "why did we pick sqlite over lancedb", "kind": "sharp", "expected_hall": "decision"},
+    {"id": "q09", "text": "what fixes the WAL fsync latency", "kind": "sharp", "expected_hall": "discovery"},
+    {"id": "q10", "text": "how often should we rotate the JWT secret", "kind": "sharp", "expected_hall": "advice"},
+    # ambiguous — room overlap
+    {"id": "q11", "text": "auth changes in deploy", "kind": "ambiguous"},
+    {"id": "q12", "text": "rerank ingest path", "kind": "ambiguous"},
+    {"id": "q13", "text": "graph mcp tool", "kind": "ambiguous"},
+    {"id": "q14", "text": "ui observability dashboard", "kind": "ambiguous"},
+    # paraphrase
+    {"id": "q15", "text": "the user does not want long summaries", "kind": "paraphrase", "expected_hall": "preference"},
+    {"id": "q16", "text": "things broke right after a model swap", "kind": "paraphrase", "expected_hall": "discovery"},
+    {"id": "q17", "text": "what happened on 2026-05-10 in the project", "kind": "paraphrase", "expected_hall": "event"},
+    {"id": "q18", "text": "before pushing changes to auth, what do I run", "kind": "paraphrase", "expected_hall": "advice", "expected_room": "auth"},
+    # incident-style
+    {"id": "q19", "text": "p99 latency spike", "kind": "incident", "expected_hall": "discovery"},
+    {"id": "q20", "text": "rate limit misconfiguration", "kind": "incident", "expected_hall": "discovery"},
+    # out-of-corpus
+    {"id": "q21", "text": "best fountain pen ink for cotton paper", "kind": "ooc"},
+    {"id": "q22", "text": "rugby world cup quarterfinal results", "kind": "ooc"},
+    {"id": "q23", "text": "watercolor brush sizes", "kind": "ooc"},
+    {"id": "q24", "text": "vintage synthesizer envelope generators", "kind": "ooc"},
+]

--- a/scripts/load-profiles/seed/memory_palace.py
+++ b/scripts/load-profiles/seed/memory_palace.py
@@ -169,6 +169,16 @@ def load_corpus(per_room_per_hall: int = 12) -> list[dict[str, str]]:
                 tpl = rng.choice(TEMPLATES[hall])
                 text = _fill(tpl, rng, room)
                 rec_id = f"mem:{room}:{hall}:{i:03d}"
+                # Prefix each record with a room/hall preamble so the
+                # text clears Levara's default MinChunkChars=80 floor
+                # in the paragraph-merged chunker. Without this, all
+                # 576 records (33-100 chars) get dropped at chunk time
+                # and the collection ends up empty. The preamble also
+                # gives the embedder useful per-record context.
+                text = (
+                    f"[room={room} hall={hall}] {hall} memory in the "
+                    f"{room} subsystem (record {rec_id}). {text}"
+                )
                 out.append(
                     {
                         "id": rec_id,

--- a/scripts/load-profiles/seed_one.py
+++ b/scripts/load-profiles/seed_one.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Seed ONE collection via the full cognify pipeline against bench Levara.
+
+Called by run_all_models.sh. Reads target URL + token from args/env,
+loads the code corpus, calls seed_via_cognify.
+
+Usage:
+    python seed_one.py --target-url http://10.23.0.53:8091 \\
+        --collection loadprofile_p4_main_potion
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+LOAD_PROFILES_ROOT = Path(__file__).resolve().parent
+if str(LOAD_PROFILES_ROOT) not in sys.path:
+    sys.path.insert(0, str(LOAD_PROFILES_ROOT))
+
+import runner
+from seed import code_corpus
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--target-url", required=True)
+    p.add_argument("--target-name", default="bench")
+    p.add_argument("--collection", required=True)
+    args = p.parse_args()
+
+    token = runner.load_token_from_env_or_file(args.target_name)
+    target = runner.Target(
+        name=args.target_name,
+        base_url=args.target_url,
+        token=token,
+    )
+
+    chunks = code_corpus.load_corpus()
+    print(f"[seed_one] loaded {len(chunks)} chunks", file=sys.stderr)
+    code_corpus.seed_via_cognify(target, args.collection, chunks=chunks)
+    print(f"[seed_one] seeded collection={args.collection}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/load-profiles/tests/test_analyze_by_model.py
+++ b/scripts/load-profiles/tests/test_analyze_by_model.py
@@ -1,0 +1,41 @@
+from analyze import (
+    group_by_model,
+    summarize_quality,
+    render_cross_model_markdown,
+)
+
+
+def _rec(model, gap, recall, top1):
+    return {
+        "embed_model": model,
+        "score_gap_top_bottom": gap,
+        "keyword_hits_top5": recall,
+        "top1_keyword_hit": top1,
+        "latency_no_rerank_ms": 10.0,
+        "latency_with_rerank_ms": 50.0,
+        "rerank_outcome": "reranked",
+    }
+
+
+def test_group_by_model_splits_correctly():
+    recs = [_rec("potion", 0.1, 2, True), _rec("granite", 0.2, 3, True), _rec("potion", 0.15, 1, False)]
+    g = group_by_model(recs)
+    assert set(g) == {"potion", "granite"}
+    assert len(g["potion"]) == 2
+    assert len(g["granite"]) == 1
+
+
+def test_summarize_quality_means():
+    recs = [_rec("p", 0.1, 2, True), _rec("p", 0.2, 4, False), _rec("p", 0.0, 0, False)]
+    s = summarize_quality(recs)
+    assert abs(s["mean_recall_top5"] - 2.0) < 1e-9
+    assert abs(s["top1_keyword_hit_rate"] - (1/3)) < 1e-9
+    assert s["n"] == 3
+
+
+def test_cross_model_markdown_has_all_models():
+    recs = [_rec("potion", 0.1, 2, True), _rec("granite", 0.2, 3, True), _rec("jina", 0.05, 1, False)]
+    md = render_cross_model_markdown(group_by_model(recs))
+    assert "potion" in md and "granite" in md and "jina" in md
+    assert "mean_recall_top5" in md
+    assert "top1_keyword_hit_rate" in md

--- a/scripts/load-profiles/tests/test_keyword_metrics.py
+++ b/scripts/load-profiles/tests/test_keyword_metrics.py
@@ -1,0 +1,38 @@
+from runner import keyword_metrics
+
+
+def _resp(*texts):
+    return [{"id": str(i), "score": 1.0 - i*0.1, "metadata": {"text": t}}
+            for i, t in enumerate(texts)]
+
+
+def test_no_keywords_returns_zero():
+    metrics = keyword_metrics(_resp("foo bar"), expected_keywords=[])
+    assert metrics == {"keyword_hits_top5": 0, "top1_keyword_hit": False}
+
+
+def test_top1_match_case_insensitive():
+    metrics = keyword_metrics(_resp("Redis Cache invalidation logic"),
+                              expected_keywords=["redis", "cache"])
+    assert metrics["top1_keyword_hit"] is True
+    assert metrics["keyword_hits_top5"] == 2
+
+
+def test_only_top5_window_counted():
+    docs = _resp("a", "b", "c", "d", "e", "redis-server", "cache-key")
+    metrics = keyword_metrics(docs, expected_keywords=["redis", "cache"])
+    assert metrics["keyword_hits_top5"] == 0
+    assert metrics["top1_keyword_hit"] is False
+
+
+def test_each_keyword_counted_at_most_once_per_query():
+    docs = _resp("redis redis redis", "redis again", "x", "y", "z")
+    metrics = keyword_metrics(docs, expected_keywords=["redis"])
+    assert metrics["keyword_hits_top5"] == 1
+
+
+def test_empty_response_safe():
+    metrics = keyword_metrics(None, expected_keywords=["x"])
+    assert metrics == {"keyword_hits_top5": 0, "top1_keyword_hit": False}
+    metrics = keyword_metrics([], expected_keywords=["x"])
+    assert metrics == {"keyword_hits_top5": 0, "top1_keyword_hit": False}

--- a/scripts/load-profiles/tests/test_preflight.py
+++ b/scripts/load-profiles/tests/test_preflight.py
@@ -1,0 +1,62 @@
+from preflight_model import Checks, run_checks
+
+
+class FakeHTTP:
+    def __init__(self, routes):
+        self.routes = routes
+
+    def __call__(self, method, url, headers=None, body=None, timeout=10.0):
+        key = (method, url)
+        if key not in self.routes:
+            raise RuntimeError(f"unmocked HTTP {method} {url}")
+        return self.routes[key]
+
+
+GOOD = FakeHTTP({
+    ("GET",  "http://10.23.0.53:9101/health"):   {"model": "potion-code-16M", "dim": 256, "backend": "model2vec", "ram_mb": 120},
+    ("POST", "http://10.23.0.53:9101/v1/embeddings"): {"data": [{"embedding": [0.0] * 256, "index": 0}], "model": "potion-code-16M"},
+    ("GET",  "http://10.23.0.53:8091/health"):   {"status": "ok"},
+    ("GET",  "http://10.23.0.53:11434/api/tags"): {"models": [{"name": "qwen3:0.6b"}]},
+    ("GET",  "http://10.23.0.53:9100/health"):    {"status": "ok"},
+    ("POST", "http://10.23.0.53:8091/api/v1/auth/register"): {"access_token": "tok"},
+})
+
+
+def test_all_checks_pass_for_good_stack():
+    checks = Checks(model_short="potion", expected_dim=256, expected_openai_name="potion-code-16M")
+    result = run_checks(checks, http=GOOD)
+    assert result.ok is True
+    assert result.failed == []
+
+
+def test_fails_on_sidecar_dim_mismatch():
+    bad = FakeHTTP({
+        **GOOD.routes,
+        ("GET", "http://10.23.0.53:9101/health"): {"model": "potion-code-16M", "dim": 999, "backend": "model2vec", "ram_mb": 120},
+    })
+    checks = Checks(model_short="potion", expected_dim=256, expected_openai_name="potion-code-16M")
+    result = run_checks(checks, http=bad)
+    assert result.ok is False
+    assert any("sidecar_dim" in f for f in result.failed)
+
+
+def test_fails_on_missing_llm():
+    bad = FakeHTTP({
+        **GOOD.routes,
+        ("GET", "http://10.23.0.53:11434/api/tags"): {"models": [{"name": "other:1b"}]},
+    })
+    checks = Checks(model_short="potion", expected_dim=256, expected_openai_name="potion-code-16M")
+    result = run_checks(checks, http=bad)
+    assert result.ok is False
+    assert any("ollama_model" in f for f in result.failed)
+
+
+def test_fails_on_embed_vector_length_mismatch():
+    bad = FakeHTTP({
+        **GOOD.routes,
+        ("POST", "http://10.23.0.53:9101/v1/embeddings"): {"data": [{"embedding": [0.0] * 7, "index": 0}], "model": "potion-code-16M"},
+    })
+    checks = Checks(model_short="potion", expected_dim=256, expected_openai_name="potion-code-16M")
+    result = run_checks(checks, http=bad)
+    assert result.ok is False
+    assert any("embed_ping_dim" in f for f in result.failed)

--- a/scripts/reembed/_levara_http.py
+++ b/scripts/reembed/_levara_http.py
@@ -1,0 +1,119 @@
+"""Minimal Levara HTTP client for reembed operational scripts.
+
+Kept separate from scripts/load-profiles/runner.py because that module
+is bench-specific (preflight, namespace guard, profile collection
+naming) — reembed scripts run against prod and don't want any of
+that machinery. This file: just http_request, search_text, list_meta.
+"""
+from __future__ import annotations
+
+import json
+import random
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+RETRYABLE = {429, 500, 502, 503, 504}
+
+
+class HttpError(RuntimeError):
+    def __init__(self, status: int, body: str):
+        super().__init__(f"HTTP {status}: {body[:300]}")
+        self.status = status
+        self.body = body
+
+
+@dataclass
+class Target:
+    base_url: str
+    token: str
+
+    def url(self, path: str) -> str:
+        return self.base_url.rstrip("/") + path
+
+    def headers(self) -> dict[str, str]:
+        h = {"Content-Type": "application/json"}
+        if self.token:
+            h["Authorization"] = f"Bearer {self.token}"
+        return h
+
+
+def http_request(
+    method: str,
+    url: str,
+    headers: dict[str, str] | None = None,
+    body: dict[str, Any] | None = None,
+    timeout: float = 30.0,
+    max_retries: int = 3,
+) -> Any:
+    payload = json.dumps(body).encode("utf-8") if body is not None else None
+    last: Exception | None = None
+    for attempt in range(max_retries + 1):
+        try:
+            req = urllib.request.Request(url, data=payload, headers=headers or {}, method=method)
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = resp.read()
+                return json.loads(data) if data else {}
+        except urllib.error.HTTPError as e:
+            text = ""
+            try:
+                text = e.read().decode("utf-8", "replace")
+            except Exception:
+                pass
+            if e.code in RETRYABLE and attempt < max_retries:
+                last = HttpError(e.code, text)
+            else:
+                raise HttpError(e.code, text) from None
+        except (urllib.error.URLError, TimeoutError, ConnectionError) as e:
+            if attempt >= max_retries:
+                raise
+            last = e
+        time.sleep(min(2.0**attempt * 0.5, 8.0) + random.random() * 0.25)
+    raise last if last else RuntimeError("retry loop exhausted")
+
+
+def get_meta(target: Target, collection: str) -> dict[str, Any]:
+    return http_request("GET", target.url(f"/api/v1/collections/{collection}/meta"), headers=target.headers())
+
+
+def search_text(
+    target: Target,
+    collection: str,
+    query: str,
+    *,
+    top_k: int = 10,
+    rerank: bool = False,
+) -> tuple[list[dict[str, Any]], int]:
+    """Return (hits, latency_ms). hits is the raw `results` array.
+
+    rerank=False is the right choice for parity: we want to compare
+    pure embedding-model behaviour, not embedding+rerank. Rerank stays
+    constant across the swap (same cross-encoder), so reranked output
+    differences would conflate the two effects.
+    """
+    body = {
+        "collection": collection,
+        "query_text": query,
+        "top_k": top_k,
+        "query_type": "CHUNKS",
+        "rerank": rerank,
+    }
+    t0 = time.monotonic()
+    resp = http_request(
+        "POST",
+        target.url("/api/v1/search/text"),
+        headers=target.headers(),
+        body=body,
+    )
+    latency_ms = int((time.monotonic() - t0) * 1000)
+    hits = resp.get("results") if isinstance(resp, dict) else None
+    if not isinstance(hits, list):
+        hits = []
+    return hits, latency_ms
+
+
+def eprint(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)

--- a/scripts/reembed/parity_check.py
+++ b/scripts/reembed/parity_check.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Compare a shadow collection against a baseline snapshot.
+
+Re-runs the baseline's queries against the shadow collection, computes
+Jaccard@10, top-1 stability, empty-result rate, latency ratio. Emits a
+markdown report and exits 0 only if all thresholds pass.
+
+Read-only against the target.
+
+Usage:
+    parity_check.py --target-url http://localhost:8090 \
+        --token-file ~/.levara/prod-token \
+        --baseline baselines/foo.json --shadow foo__potion \
+        --out docs/reembed/parity-foo-20260526.md \
+        [--jaccard10 0.6 --top1 0.5 --empty 0.05 --latency-ratio 1.2]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _levara_http import Target, get_meta, search_text, eprint
+
+
+def _read_token(token_file: str | None, token_inline: str | None) -> str:
+    if token_inline:
+        return token_inline
+    if token_file:
+        p = Path(token_file).expanduser()
+        if not p.exists():
+            raise SystemExit(f"token file not found: {p}")
+        return p.read_text().strip()
+    return os.environ.get("LEVARA_TOKEN", "")
+
+
+def _jaccard(a: list[str], b: list[str]) -> float:
+    sa, sb = set(a), set(b)
+    if not sa and not sb:
+        return 1.0
+    return len(sa & sb) / max(1, len(sa | sb))
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Parity check vs baseline")
+    p.add_argument("--target-url", required=True)
+    p.add_argument("--token-file", default=None)
+    p.add_argument("--token", default=None)
+    p.add_argument("--baseline", required=True)
+    p.add_argument("--shadow", required=True)
+    p.add_argument("--out", default=None, help="markdown report path; stdout if omitted")
+    p.add_argument("--jaccard10", type=float, default=0.6)
+    p.add_argument("--top1", type=float, default=0.5)
+    p.add_argument("--empty", type=float, default=0.05)
+    p.add_argument("--latency-ratio", type=float, default=1.2)
+    args = p.parse_args()
+
+    with open(args.baseline, encoding="utf-8") as f:
+        baseline = json.load(f)
+    if not baseline.get("queries"):
+        raise SystemExit("baseline has no queries")
+
+    token = _read_token(args.token_file, args.token)
+    target = Target(base_url=args.target_url, token=token)
+
+    shadow_meta = get_meta(target, args.shadow)
+    if not shadow_meta or not shadow_meta.get("name"):
+        raise SystemExit(f"shadow collection {args.shadow!r} not found")
+
+    top_k = int(baseline.get("top_k", 10))
+    queries = baseline["queries"]
+
+    per_q = []
+    jaccards = []
+    top1_same = 0
+    empties = 0
+    latencies_shadow = []
+    latencies_baseline = []
+    for q in queries:
+        text = q["text"]
+        hits, latency_ms = search_text(target, args.shadow, text, top_k=top_k, rerank=False)
+        shadow_ids = [h.get("id") for h in hits if isinstance(h, dict) and h.get("id")][:top_k]
+        base_ids = q.get("top_ids", [])[:top_k]
+        j = _jaccard(base_ids, shadow_ids)
+        jaccards.append(j)
+        top1_match = bool(shadow_ids) and shadow_ids[0] == q.get("top_1_id")
+        if top1_match:
+            top1_same += 1
+        if not hits:
+            empties += 1
+        if isinstance(q.get("latency_ms"), int):
+            latencies_baseline.append(q["latency_ms"])
+        latencies_shadow.append(latency_ms)
+        per_q.append(
+            {
+                "id": q["id"],
+                "text": text[:80],
+                "baseline_top1": q.get("top_1_id"),
+                "shadow_top1": shadow_ids[0] if shadow_ids else None,
+                "jaccard10": round(j, 3),
+                "shadow_n_hits": len(hits),
+                "shadow_latency_ms": latency_ms,
+                "baseline_latency_ms": q.get("latency_ms"),
+            }
+        )
+
+    n = len(queries)
+    j_mean = sum(jaccards) / n
+    top1_rate = top1_same / n
+    empty_rate = empties / n
+    lat_shadow_p50 = statistics.median(latencies_shadow)
+    lat_base_p50 = statistics.median(latencies_baseline) if latencies_baseline else None
+    lat_ratio = (lat_shadow_p50 / lat_base_p50) if lat_base_p50 else None
+
+    checks = [
+        ("Jaccard@10 mean", j_mean, args.jaccard10, ">="),
+        ("Top-1 stability", top1_rate, args.top1, ">="),
+        ("Empty-result rate", empty_rate, args.empty, "<="),
+    ]
+    if lat_ratio is not None:
+        checks.append(("Latency ratio shadow/baseline (p50)", lat_ratio, args.latency_ratio, "<="))
+
+    failed = []
+    for name, val, thr, op in checks:
+        ok = (val >= thr) if op == ">=" else (val <= thr)
+        if not ok:
+            failed.append((name, val, thr, op))
+
+    verdict = "PASS" if not failed else "FAIL"
+
+    lines = []
+    lines.append(f"# Parity report — {baseline.get('collection')} → {args.shadow}")
+    lines.append("")
+    lines.append(f"**Verdict:** {verdict}  ")
+    lines.append(f"**Generated:** {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}  ")
+    lines.append(f"**Baseline captured:** {baseline.get('captured_at')}  ")
+    lines.append(
+        f"**Baseline model:** {baseline.get('embedding_model')} (dim {baseline.get('embedding_dim')})  "
+    )
+    lines.append(
+        f"**Shadow model:** {shadow_meta.get('embedding_model')} (dim {shadow_meta.get('embedding_dim')})  "
+    )
+    lines.append(
+        f"**Records:** baseline={baseline.get('record_count')}, shadow={shadow_meta.get('record_count')}  "
+    )
+    lines.append("")
+    lines.append("## Aggregate metrics")
+    lines.append("")
+    lines.append("| metric | value | threshold | pass |")
+    lines.append("|---|---|---|---|")
+    for name, val, thr, op in checks:
+        ok = (val >= thr) if op == ">=" else (val <= thr)
+        lines.append(f"| {name} | {val:.3f} | {op} {thr} | {'✓' if ok else '✗'} |")
+    lines.append("")
+    if lat_base_p50 is not None:
+        lines.append(
+            f"Shadow p50 latency: {lat_shadow_p50:.0f}ms · baseline p50: {lat_base_p50:.0f}ms"
+        )
+    else:
+        lines.append(f"Shadow p50 latency: {lat_shadow_p50:.0f}ms (no baseline latency recorded)")
+    lines.append("")
+    lines.append("## Per-query")
+    lines.append("")
+    lines.append("| q | text | jaccard@10 | base top1 | shadow top1 | n hits | shadow ms |")
+    lines.append("|---|---|---|---|---|---|---|")
+    for r in per_q:
+        lines.append(
+            f"| {r['id']} | {r['text']!r} | {r['jaccard10']} | "
+            f"{r['baseline_top1']} | {r['shadow_top1']} | "
+            f"{r['shadow_n_hits']} | {r['shadow_latency_ms']} |"
+        )
+
+    if failed:
+        lines.append("")
+        lines.append("## Failed thresholds")
+        for name, val, thr, op in failed:
+            lines.append(f"- **{name}**: got {val:.3f}, need {op} {thr}")
+
+    report = "\n".join(lines) + "\n"
+
+    if args.out:
+        os.makedirs(os.path.dirname(os.path.abspath(args.out)) or ".", exist_ok=True)
+        with open(args.out, "w", encoding="utf-8") as f:
+            f.write(report)
+        eprint(f"[parity] wrote {args.out}")
+    else:
+        print(report)
+
+    eprint(f"[parity] verdict={verdict} jaccard_mean={j_mean:.3f} top1={top1_rate:.3f} empty={empty_rate:.3f}")
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/reembed/snapshot_baseline.py
+++ b/scripts/reembed/snapshot_baseline.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Capture a parity baseline for a Levara collection.
+
+For each query (provided via file, or sampled from the collection's own
+chunks), records top_10 IDs + top_1 score + latency. Output JSON is
+later fed to parity_check.py against the shadow collection.
+
+Read-only against the target — never writes.
+
+Usage:
+    snapshot_baseline.py --target-url http://localhost:8090 \
+        --token-file ~/.levara/prod-token --collection foo \
+        [--queries-file queries.txt] [--sample-from-chunks 20] \
+        --out baselines/foo.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import re
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _levara_http import Target, get_meta, http_request, search_text, eprint
+
+
+def _read_token(token_file: str | None, token_inline: str | None) -> str:
+    if token_inline:
+        return token_inline
+    if token_file:
+        p = Path(token_file).expanduser()
+        if not p.exists():
+            raise SystemExit(f"token file not found: {p}")
+        return p.read_text().strip()
+    env = os.environ.get("LEVARA_TOKEN")
+    if env:
+        return env
+    return ""
+
+
+def _sample_queries_from_chunks(target: Target, collection: str, n: int) -> list[str]:
+    """Pull N random chunk texts via /api/v1/collections/<c>/data and
+    use the first sentence of each as a query. This is a pragmatic
+    fallback when the caller didn't supply real production queries —
+    it covers the collection's own vocabulary distribution so parity
+    measurements aren't dominated by out-of-distribution noise.
+    """
+    resp = http_request(
+        "GET",
+        target.url(f"/api/v1/collections/{collection}/data?limit={n * 5}"),
+        headers=target.headers(),
+    )
+    records = resp.get("data") if isinstance(resp, dict) else None
+    if not isinstance(records, list) or not records:
+        raise SystemExit(
+            f"can't sample: /collections/{collection}/data returned no records"
+        )
+    random.shuffle(records)
+    out: list[str] = []
+    sent_re = re.compile(r"[^.!?]+[.!?]")
+    for rec in records:
+        meta = rec.get("metadata") if isinstance(rec, dict) else None
+        text = ""
+        if isinstance(meta, dict):
+            for k in ("text", "content", "name", "description"):
+                v = meta.get(k)
+                if isinstance(v, str) and v.strip():
+                    text = v.strip()
+                    break
+        if not text:
+            continue
+        m = sent_re.search(text)
+        first = (m.group(0) if m else text)[:200].strip()
+        if len(first) >= 10:
+            out.append(first)
+        if len(out) >= n:
+            break
+    if not out:
+        raise SystemExit("could not extract any usable sentences from chunks")
+    return out
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Capture parity baseline for a collection")
+    p.add_argument("--target-url", required=True)
+    p.add_argument("--token-file", default=None)
+    p.add_argument("--token", default=None)
+    p.add_argument("--collection", required=True)
+    p.add_argument(
+        "--queries-file",
+        default=None,
+        help="one query per line; mutually exclusive with --sample-from-chunks",
+    )
+    p.add_argument(
+        "--sample-from-chunks",
+        type=int,
+        default=20,
+        help="if --queries-file absent, sample this many synthetic queries from chunk text",
+    )
+    p.add_argument("--top-k", type=int, default=10)
+    p.add_argument("--out", required=True)
+    args = p.parse_args()
+
+    token = _read_token(args.token_file, args.token)
+    target = Target(base_url=args.target_url, token=token)
+
+    meta = get_meta(target, args.collection)
+    if not meta or not meta.get("name"):
+        raise SystemExit(f"collection {args.collection!r} not found")
+
+    if args.queries_file:
+        with open(args.queries_file, encoding="utf-8") as f:
+            queries = [ln.strip() for ln in f if ln.strip()]
+        if not queries:
+            raise SystemExit("queries file is empty")
+    else:
+        queries = _sample_queries_from_chunks(
+            target, args.collection, args.sample_from_chunks
+        )
+    eprint(f"[baseline] {len(queries)} queries against {args.collection}")
+
+    records = []
+    for i, q in enumerate(queries):
+        hits, latency_ms = search_text(target, args.collection, q, top_k=args.top_k, rerank=False)
+        ids = [h.get("id") for h in hits if isinstance(h, dict) and h.get("id")]
+        top1 = hits[0] if hits else {}
+        records.append(
+            {
+                "id": f"q{i}",
+                "text": q,
+                "top_ids": ids[: args.top_k],
+                "top_1_id": top1.get("id"),
+                "top_1_score": top1.get("score"),
+                "n_hits": len(hits),
+                "latency_ms": latency_ms,
+                "empty": len(hits) == 0,
+            }
+        )
+        eprint(f"[baseline] q{i}: {len(hits)} hits, top1={top1.get('id')}, {latency_ms}ms")
+
+    out = {
+        "collection": args.collection,
+        "embedding_model": meta.get("embedding_model"),
+        "embedding_dim": meta.get("embedding_dim"),
+        "record_count": meta.get("record_count"),
+        "captured_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "top_k": args.top_k,
+        "queries": records,
+    }
+    os.makedirs(os.path.dirname(os.path.abspath(args.out)) or ".", exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump(out, f, indent=2, ensure_ascii=False)
+    eprint(f"[baseline] wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Five production-shaped load profiles (P1-P5) for calibrating `RERANK_SCORE_GAP_THRESHOLD` (Phase 2.5) against real traffic on .64 (1024-dim) and Pi (768-dim nomic).
- Calibration analyzer (`analyze.py`) sweeps threshold candidates, reporting skip% (rerank avoided) vs gate-wrong% (skipped queries where rerank would have flipped top1).
- Opt-in pre-embed bypass in `runner.py` (`LEVARA_PRE_EMBED_URL`) for the Pi binary regression where `/api/v1/search/text` silently returns JSON `null` (`chunksSearch` swallows embed errors → nil slice).
- Cognify fixes that surfaced during ingestion: unique chunk IDs across runs, single-batch P4/P5 ingest, `/meta` idempotency, `skip_graph` flag.

## Calibration result

Across all 5 profiles (n=1466 query pairs):

| T | avg skip% | avg gate-wrong% |
|---|---|---|
| 0.030 | 65.8% | 53.0% |
| 0.050 | 40.7% | 51.3% |
| 0.080 | 18.3% | 44.4% |
| 0.130 | 10.8% | 47.1% |

**No threshold meets skip>30% AND gate-wrong<25%.** Recommend keeping `RERANK_SCORE_GAP_THRESHOLD=0` (unconditional rerank when sidecar configured) as the production default.

## Test plan

- [x] P1-P3 (.64): 718 query pairs, real scores 0.25-0.85
- [x] P4-P5 (Pi): 748 query pairs, real scores 0.15-0.74
- [x] Analyzer reproducible from `out/*.jsonl` checked-in datapoints (artifacts ignored via new `.gitignore`)
- [ ] Follow-up: investigate `chunksSearch` silent error swallowing on Pi (separate PR — root-cause documented in memory `discovery_pi_search_text_null`)
- [ ] Follow-up: P4 `loadprofile_p4_ooc` 28 zero-hit queries (likely seed-edge case, doesn't affect calibration)