### PR TITLE
feat(mcp): add `levara mcp serve` stdio↔HTTP bridge

### DIFF
--- a/Levara/cmd/server/main.go
+++ b/Levara/cmd/server/main.go
@@ -146,6 +146,13 @@ func intEnv(key string, fallback int) int {
 }
 
 func main() {
+	if len(os.Args) >= 2 && os.Args[1] == "mcp" {
+		if err := runMCPStdio(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "mcp:", err)
+			os.Exit(1)
+		}
+		return
+	}
 	bootstrap := flag.Bool("bootstrap", false, "Bootstrap the Raft cluster (Leader only)")
 	standalone := flag.Bool("standalone", true, "Standalone mode: WAL-only, no Raft consensus (fastest)")
 	dim := flag.Int("dim", 128, "Vector dimension size (must match embedding model output)")

--- a/Levara/cmd/server/mcp_stdio.go
+++ b/Levara/cmd/server/mcp_stdio.go
@@ -1,0 +1,156 @@
+// mcp_stdio.go — `levara mcp serve` subcommand: stdio↔HTTP MCP bridge.
+//
+// Reads newline-delimited JSON-RPC messages from stdin, forwards each as
+// POST <backend>/mcp, writes the response to stdout (one JSON object per
+// line). The bridge tracks the Mcp-Session-Id header returned by the
+// HTTP MCP endpoint and replays it on every subsequent request so the
+// remote server keeps a single session for the lifetime of stdin.
+//
+// Use:
+//
+//	levara mcp serve --backend http://127.0.0.1:8080 [--token <jwt>]
+//
+// Auth: --token flag overrides LEVARA_TOKEN env. Empty token means no
+// Authorization header is sent (dev-mode servers without -require-auth).
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+func runMCPStdio(args []string) error {
+	fs := flag.NewFlagSet("mcp", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	var (
+		subcmd  string
+		backend string
+		token   string
+		apiKey  string
+		timeout time.Duration
+	)
+	fs.StringVar(&backend, "backend", "http://127.0.0.1:8080", "Levara HTTP base URL (the bridge POSTs to <backend>/mcp)")
+	fs.StringVar(&token, "token", os.Getenv("LEVARA_TOKEN"), "JWT bearer token (24h TTL); falls back to LEVARA_TOKEN env. Use --api-key for long-lived auth.")
+	fs.StringVar(&apiKey, "api-key", os.Getenv("LEVARA_API_KEY"), "Long-lived API key (X-API-Key header); falls back to LEVARA_API_KEY env. Mutually exclusive with --token.")
+	fs.DurationVar(&timeout, "timeout", 30*time.Second, "Per-request HTTP timeout")
+
+	if len(args) == 0 {
+		return fmt.Errorf("usage: levara mcp <serve> --backend <url> [--token <jwt>]")
+	}
+	subcmd, rest := args[0], args[1:]
+	if subcmd != "serve" {
+		return fmt.Errorf("unknown mcp subcommand %q (expected: serve)", subcmd)
+	}
+	if err := fs.Parse(rest); err != nil {
+		return err
+	}
+	backend = strings.TrimRight(backend, "/")
+	if backend == "" {
+		return fmt.Errorf("--backend required")
+	}
+	if token != "" && apiKey != "" {
+		return fmt.Errorf("--token and --api-key are mutually exclusive")
+	}
+
+	br := &bridge{
+		backend: backend + "/mcp",
+		token:   token,
+		apiKey:  apiKey,
+		client:  &http.Client{Timeout: timeout},
+	}
+	return br.run(os.Stdin, os.Stdout)
+}
+
+type bridge struct {
+	backend string
+	token   string
+	apiKey  string
+	client  *http.Client
+
+	mu        sync.Mutex
+	sessionID string
+}
+
+func (b *bridge) run(in io.Reader, out io.Writer) error {
+	scanner := bufio.NewScanner(in)
+	// MCP messages can be large (search results, cognify status). Allow up
+	// to 4 MiB per line — matches the HTTP body limit on the server side.
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	writer := bufio.NewWriter(out)
+	defer writer.Flush()
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		respBody, err := b.forward(line)
+		if err != nil {
+			// Forwarding errors are surfaced as JSON-RPC errors on stdout
+			// so the MCP client sees a structured failure instead of a
+			// dropped connection. The request ID is not recovered here —
+			// JSON-RPC permits id=null for transport-level errors.
+			fmt.Fprintf(writer, `{"jsonrpc":"2.0","id":null,"error":{"code":-32000,"message":%q}}`+"\n", err.Error())
+			writer.Flush()
+			continue
+		}
+		writer.Write(respBody)
+		writer.WriteByte('\n')
+		writer.Flush()
+	}
+	return scanner.Err()
+}
+
+func (b *bridge) forward(payload []byte) ([]byte, error) {
+	req, err := http.NewRequest("POST", b.backend, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if b.token != "" {
+		req.Header.Set("Authorization", "Bearer "+b.token)
+	}
+	if b.apiKey != "" {
+		req.Header.Set("X-API-Key", b.apiKey)
+	}
+	b.mu.Lock()
+	sid := b.sessionID
+	b.mu.Unlock()
+	if sid != "" {
+		req.Header.Set("Mcp-Session-Id", sid)
+	}
+
+	resp, err := b.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if newSID := resp.Header.Get("Mcp-Session-Id"); newSID != "" {
+		b.mu.Lock()
+		b.sessionID = newSID
+		b.mu.Unlock()
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("backend %s returned %d: %s", b.backend, resp.StatusCode, truncate(body, 200))
+	}
+	return body, nil
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "…"
+}

--- a/Levara/cmd/server/mcp_stdio_test.go
+++ b/Levara/cmd/server/mcp_stdio_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeMCPBackend captures forwarded requests and returns scripted bodies.
+type fakeMCPBackend struct {
+	mu          sync.Mutex
+	requests    []recordedRequest
+	responses   [][]byte
+	sessionToID string // value returned on first request via Mcp-Session-Id header
+	failStatus  int    // when >0, every request gets this HTTP status
+	authHeader  string
+}
+
+type recordedRequest struct {
+	body      []byte
+	sessionID string
+	authz     string
+	apiKey    string
+}
+
+func newFakeMCPBackend() (*fakeMCPBackend, *httptest.Server) {
+	f := &fakeMCPBackend{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mcp" {
+			http.NotFound(w, r)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		f.mu.Lock()
+		f.requests = append(f.requests, recordedRequest{
+			body:      body,
+			sessionID: r.Header.Get("Mcp-Session-Id"),
+			authz:     r.Header.Get("Authorization"),
+			apiKey:    r.Header.Get("X-API-Key"),
+		})
+		idx := len(f.requests) - 1
+		var resp []byte
+		if idx < len(f.responses) {
+			resp = f.responses[idx]
+		} else {
+			resp = []byte(`{"jsonrpc":"2.0","id":1,"result":{}}`)
+		}
+		fail := f.failStatus
+		sid := f.sessionToID
+		f.mu.Unlock()
+		if sid != "" && idx == 0 {
+			w.Header().Set("Mcp-Session-Id", sid)
+		}
+		if fail > 0 {
+			w.WriteHeader(fail)
+			w.Write(resp)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(resp)
+	}))
+	return f, srv
+}
+
+func TestBridge_ForwardsAndCapturesSessionID(t *testing.T) {
+	fake, srv := newFakeMCPBackend()
+	defer srv.Close()
+	fake.sessionToID = "sess-abc"
+	fake.responses = [][]byte{
+		[]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-26"}}`),
+		[]byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}`),
+	}
+
+	br := &bridge{backend: srv.URL + "/mcp", client: srv.Client()}
+	in := strings.NewReader(
+		`{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n" +
+			`{"jsonrpc":"2.0","id":2,"method":"tools/list"}` + "\n",
+	)
+	var out bytes.Buffer
+	if err := br.run(in, &out); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	if len(fake.requests) != 2 {
+		t.Fatalf("requests=%d, want 2", len(fake.requests))
+	}
+	if fake.requests[0].sessionID != "" {
+		t.Errorf("first request sent session id %q, want empty", fake.requests[0].sessionID)
+	}
+	if fake.requests[1].sessionID != "sess-abc" {
+		t.Errorf("second request session id = %q, want sess-abc", fake.requests[1].sessionID)
+	}
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("output lines=%d, want 2; got=%q", len(lines), out.String())
+	}
+	for i, line := range lines {
+		var r map[string]any
+		if err := json.Unmarshal([]byte(line), &r); err != nil {
+			t.Errorf("line[%d] not valid JSON: %v (%q)", i, err, line)
+		}
+	}
+}
+
+func TestBridge_SendsBearerToken(t *testing.T) {
+	fake, srv := newFakeMCPBackend()
+	defer srv.Close()
+	fake.responses = [][]byte{[]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`)}
+
+	br := &bridge{backend: srv.URL + "/mcp", token: "secret-jwt", client: srv.Client()}
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n")
+	if err := br.run(in, io.Discard); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := fake.requests[0].authz; got != "Bearer secret-jwt" {
+		t.Errorf("Authorization = %q, want Bearer secret-jwt", got)
+	}
+}
+
+func TestBridge_SendsAPIKey(t *testing.T) {
+	fake, srv := newFakeMCPBackend()
+	defer srv.Close()
+	fake.responses = [][]byte{[]byte(`{}`)}
+
+	br := &bridge{backend: srv.URL + "/mcp", apiKey: "k-1234", client: srv.Client()}
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n")
+	if err := br.run(in, io.Discard); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := fake.requests[0].apiKey; got != "k-1234" {
+		t.Errorf("X-API-Key = %q, want k-1234", got)
+	}
+	if got := fake.requests[0].authz; got != "" {
+		t.Errorf("Authorization = %q, want empty when only api-key set", got)
+	}
+}
+
+func TestRunMCPStdio_RejectsTokenAndAPIKeyTogether(t *testing.T) {
+	err := runMCPStdio([]string{"serve", "--backend", "http://x", "--token", "j", "--api-key", "k"})
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("err=%v, want mutually-exclusive error", err)
+	}
+}
+
+func TestBridge_OmitsAuthHeaderWhenTokenEmpty(t *testing.T) {
+	fake, srv := newFakeMCPBackend()
+	defer srv.Close()
+	fake.responses = [][]byte{[]byte(`{}`)}
+
+	br := &bridge{backend: srv.URL + "/mcp", client: srv.Client()}
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n")
+	_ = br.run(in, io.Discard)
+	if got := fake.requests[0].authz; got != "" {
+		t.Errorf("Authorization sent without token = %q, want empty", got)
+	}
+}
+
+func TestBridge_BackendErrorSurfacesAsJSONRPCError(t *testing.T) {
+	fake, srv := newFakeMCPBackend()
+	defer srv.Close()
+	fake.failStatus = 503
+	fake.responses = [][]byte{[]byte(`upstream down`)}
+
+	br := &bridge{backend: srv.URL + "/mcp", client: srv.Client()}
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n")
+	var out bytes.Buffer
+	if err := br.run(in, &out); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var r map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &r); err != nil {
+		t.Fatalf("output not JSON: %v (%q)", err, out.String())
+	}
+	errObj, ok := r["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("response missing error field: %v", r)
+	}
+	if code, _ := errObj["code"].(float64); code != -32000 {
+		t.Errorf("error.code = %v, want -32000", code)
+	}
+	msg, _ := errObj["message"].(string)
+	if !strings.Contains(msg, "503") {
+		t.Errorf("error.message = %q, want it to include 503 status", msg)
+	}
+}
+
+func TestBridge_SkipsBlankLines(t *testing.T) {
+	fake, srv := newFakeMCPBackend()
+	defer srv.Close()
+	fake.responses = [][]byte{[]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`)}
+
+	br := &bridge{backend: srv.URL + "/mcp", client: srv.Client()}
+	in := strings.NewReader("\n\n  \n" + `{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n\n")
+	var out bytes.Buffer
+	_ = br.run(in, &out)
+
+	if len(fake.requests) != 1 {
+		t.Errorf("requests=%d, want 1 (blank lines must be skipped)", len(fake.requests))
+	}
+	if got := strings.Count(strings.TrimSpace(out.String()), "\n") + 1; got != 1 {
+		t.Errorf("output lines=%d, want 1", got)
+	}
+}
+
+func TestRunMCPStdio_RejectsUnknownSubcommand(t *testing.T) {
+	if err := runMCPStdio([]string{"frobnicate"}); err == nil || !strings.Contains(err.Error(), "unknown") {
+		t.Errorf("err=%v, want unknown-subcommand error", err)
+	}
+}
+
+func TestRunMCPStdio_RequiresArgs(t *testing.T) {
+	if err := runMCPStdio(nil); err == nil {
+		t.Errorf("expected usage error for empty args")
+	}
+}


### PR DESCRIPTION
## Summary
- New `levara mcp serve` subcommand: forwards newline-delimited JSON-RPC from stdin to `<backend>/mcp` over HTTP and writes each response to stdout
- Captures `Mcp-Session-Id` from the first response and replays it on every subsequent request so a single MCP session spans the lifetime of stdin
- Auth: mutually-exclusive `--token` (Bearer JWT) and `--api-key` (X-API-Key, long-lived); `LEVARA_TOKEN` / `LEVARA_API_KEY` env fallbacks
- Enables registering the same Levara binary as an stdio MCP server for clients (Claude Code, etc.) without exposing an HTTP port, and routing a stdio MCP client to a remote backend via an ssh wrapper

## Test plan
- [x] `go test ./Levara/cmd/server/...` passes (9 tests in `mcp_stdio_test.go` covering session-ID capture/replay, both auth headers, blank-line skipping, backend error → JSON-RPC error, mutually-exclusive flags, unknown subcommands)
- [x] End-to-end smoke: `levara mcp serve --backend http://127.0.0.1:8090 --api-key …` registered as stdio MCP in Claude Code against Pi (10.23.0.53), session writes confirmed in DB
- [ ] Reviewer: verify the bridge does not leak the API key into request bodies / response stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)