### PR TITLE
feat(sync): chunk oversized records on collection re-embed import

### DIFF
--- a/Levara/internal/http/sync.go
+++ b/Levara/internal/http/sync.go
@@ -596,13 +596,25 @@ func syncImportCollectionHandler(cfg APIConfig) fiber.Handler {
 			bgCtx, bgCancel := backgroundTaskContext()
 			defer bgCancel()
 
+			// Split records that exceed the embed context into overlapping
+			// chunks; records that fit pass through unchanged. Each unit is
+			// embedded and stored as its own vector.
+			units, skippedNoText := expandRecordsToUnits(export.Records, reembedMaxRunes, reembedMaxRunes/5)
+			status.Skipped += skippedNoText
+			if len(units) == 0 {
+				status.Status = "COMPLETED"
+				status.Message = "no embeddable text in records"
+				return
+			}
+			status.Total = len(units)
+
 			// Custom batch size means we keep constructing a one-off
 			// client here — production-shared cfg.EmbedClient uses
 			// batchSize=16 which is wrong for the bulk re-embed path.
 			embedClient := embed.NewClient(cfg.EmbedEndpoint, cfg.EmbedModel, batchSize, 3)
 
 			// Auto-detect target dimension
-			testVecs, err := embedClient.EmbedTexts(bgCtx, []string{export.Records[0].Text})
+			testVecs, err := embedClient.EmbedTexts(bgCtx, []string{units[0].text})
 			if err != nil || len(testVecs) == 0 {
 				status.Status = "FAILED"
 				status.Message = fmt.Sprintf("embed test failed: %v", err)
@@ -619,20 +631,20 @@ func syncImportCollectionHandler(cfg APIConfig) fiber.Handler {
 				}
 			}
 
-			log.Printf("[sync-import] %s: %d records, source=%s/%d → target=%s/%d",
-				export.Collection, len(export.Records), export.SourceModel, export.SourceDim, cfg.EmbedModel, targetDim)
+			log.Printf("[sync-import] %s: %d records → %d units, source=%s/%d → target=%s/%d",
+				export.Collection, len(export.Records), len(units), export.SourceModel, export.SourceDim, cfg.EmbedModel, targetDim)
 
 			// Process in batches
-			for i := 0; i < len(export.Records); i += batchSize {
+			for i := 0; i < len(units); i += batchSize {
 				end := i + batchSize
-				if end > len(export.Records) {
-					end = len(export.Records)
+				if end > len(units) {
+					end = len(units)
 				}
-				batch := export.Records[i:end]
+				batch := units[i:end]
 
 				texts := make([]string, len(batch))
-				for j, r := range batch {
-					texts[j] = r.Text
+				for j, u := range batch {
+					texts[j] = u.text
 				}
 
 				vecs, err := embedClient.EmbedTexts(bgCtx, texts)
@@ -644,7 +656,7 @@ func syncImportCollectionHandler(cfg APIConfig) fiber.Handler {
 
 				for j, vec := range vecs {
 					if j < len(batch) {
-						if err := cfg.Collections.Insert(export.Collection, batch[j].ID, vec, batch[j].Metadata); err != nil {
+						if err := cfg.Collections.Insert(export.Collection, batch[j].id, vec, batch[j].meta); err != nil {
 							status.Failed++
 						} else {
 							status.Processed++
@@ -657,8 +669,8 @@ func syncImportCollectionHandler(cfg APIConfig) fiber.Handler {
 
 			status.Status = "COMPLETED"
 			status.ElapsedMs = time.Since(start).Milliseconds()
-			status.Message = fmt.Sprintf("imported %d/%d records (%s dim=%d → %s dim=%d) in %dms",
-				status.Processed, status.Total, export.SourceModel, export.SourceDim, cfg.EmbedModel, targetDim, status.ElapsedMs)
+			status.Message = fmt.Sprintf("imported %d/%d units from %d records (%s dim=%d → %s dim=%d) in %dms",
+				status.Processed, len(units), len(export.Records), export.SourceModel, export.SourceDim, cfg.EmbedModel, targetDim, status.ElapsedMs)
 			log.Printf("[sync-import] %s", status.Message)
 		}()
 

--- a/Levara/internal/http/sync.go
+++ b/Levara/internal/http/sync.go
@@ -582,7 +582,6 @@ func syncImportCollectionHandler(cfg APIConfig) fiber.Handler {
 		}
 		syncImportRuns.Store(runID, status)
 
-		batchSize := 50
 
 		go func() {
 			defer func() {
@@ -599,7 +598,7 @@ func syncImportCollectionHandler(cfg APIConfig) fiber.Handler {
 			// Split records that exceed the embed context into overlapping
 			// chunks; records that fit pass through unchanged. Each unit is
 			// embedded and stored as its own vector.
-			units, skippedNoText := expandRecordsToUnits(export.Records, reembedMaxRunes, reembedMaxRunes/5)
+			units, skippedNoText, chunked := expandRecordsToUnits(export.Records, reembedMaxRunes, reembedMaxRunes/5)
 			status.Skipped += skippedNoText
 			if len(units) == 0 {
 				status.Status = "COMPLETED"
@@ -608,10 +607,19 @@ func syncImportCollectionHandler(cfg APIConfig) fiber.Handler {
 			}
 			status.Total = len(units)
 
-			// Custom batch size means we keep constructing a one-off
-			// client here — production-shared cfg.EmbedClient uses
-			// batchSize=16 which is wrong for the bulk re-embed path.
-			embedClient := embed.NewClient(cfg.EmbedEndpoint, cfg.EmbedModel, batchSize, 3)
+			// Re-embed throughput is tuned to unit size. Short memory texts
+			// keep the high-throughput defaults (batch 50, concurrency 3).
+			// When a document was split into large chunks, a batch of 50 at
+			// concurrency 3 overruns the embed client's 30s HTTP timeout on
+			// modest hardware (Ollama on a Pi), so shrink the batch, drop to
+			// sequential, and extend the timeout for that path only.
+			// WithTimeout(0) is a no-op, leaving the default for the fast path.
+			batchSize, embedConcurrency, embedTimeout := 50, 3, time.Duration(0)
+			if chunked {
+				batchSize, embedConcurrency, embedTimeout = 16, 1, 5*time.Minute
+			}
+			embedClient := embed.NewClient(cfg.EmbedEndpoint, cfg.EmbedModel, batchSize, embedConcurrency).
+				WithTimeout(embedTimeout)
 
 			// Auto-detect target dimension
 			testVecs, err := embedClient.EmbedTexts(bgCtx, []string{units[0].text})

--- a/Levara/internal/http/sync_collection_chunk.go
+++ b/Levara/internal/http/sync_collection_chunk.go
@@ -34,11 +34,14 @@ type embedUnit struct {
 // expandRecordsToUnits turns import records into embeddable units. Records whose
 // text fits maxRunes pass through unchanged. Oversized records are split with
 // the shared sliding chunker (snap-to-sentence on) into units with deterministic
-// chunk IDs and chunk-scoped metadata. Returns the units and the count of
-// records dropped because they held no embeddable text.
-func expandRecordsToUnits(records []syncCollectionRecord, maxRunes, overlap int) ([]embedUnit, int) {
+// chunk IDs and chunk-scoped metadata. Returns the units, the count of records
+// dropped because they held no embeddable text, and whether any record was
+// split into chunks (the caller uses this to pick conservative embed settings,
+// since large chunks embed far slower than short records).
+func expandRecordsToUnits(records []syncCollectionRecord, maxRunes, overlap int) ([]embedUnit, int, bool) {
 	units := make([]embedUnit, 0, len(records))
 	skipped := 0
+	chunked := false
 	for _, r := range records {
 		if utf8.RuneCountInString(r.Text) <= maxRunes {
 			units = append(units, embedUnit{id: r.ID, text: r.Text, meta: r.Metadata})
@@ -49,6 +52,7 @@ func expandRecordsToUnits(records []syncCollectionRecord, maxRunes, overlap int)
 			skipped++
 			continue
 		}
+		chunked = true
 		for _, ch := range chunks {
 			units = append(units, embedUnit{
 				id:   ch.ID,
@@ -57,7 +61,7 @@ func expandRecordsToUnits(records []syncCollectionRecord, maxRunes, overlap int)
 			})
 		}
 	}
-	return units, skipped
+	return units, skipped, chunked
 }
 
 // chunkMeta builds metadata for a chunk. When the source metadata is a JSON

--- a/Levara/internal/http/sync_collection_chunk.go
+++ b/Levara/internal/http/sync_collection_chunk.go
@@ -1,0 +1,98 @@
+package http
+
+// Document chunking for the collection re-embed path. Collection records can
+// hold whole documents whose text exceeds the embed model's context window,
+// which makes a single-vector re-embed fail with "input length exceeds the
+// context length". Such records are split into overlapping chunks here, each
+// embedded and stored as its own vector; records that already fit pass through
+// unchanged.
+
+import (
+	"encoding/json"
+	"unicode/utf8"
+
+	"github.com/stek0v/levara/pkg/chunker"
+)
+
+// reembedMaxRunes is the per-record text budget for a single embed call during
+// collection import. A BPE token always covers at least one byte, so a record
+// of at most 4000 runes (<= ~8000 bytes even for 2-byte scripts) stays under
+// nomic-embed's 8192-token context regardless of language. Records above this
+// are split into overlapping chunks. It mirrors the repo's sliding-chunk
+// convention (overlap = window/5).
+const reembedMaxRunes = 4000
+
+// embedUnit is one text to embed and store: either a whole record (original ID
+// and metadata preserved) or a chunk of an oversized record (derived ID and
+// chunk-scoped metadata).
+type embedUnit struct {
+	id   string
+	text string
+	meta json.RawMessage
+}
+
+// expandRecordsToUnits turns import records into embeddable units. Records whose
+// text fits maxRunes pass through unchanged. Oversized records are split with
+// the shared sliding chunker (snap-to-sentence on) into units with deterministic
+// chunk IDs and chunk-scoped metadata. Returns the units and the count of
+// records dropped because they held no embeddable text.
+func expandRecordsToUnits(records []syncCollectionRecord, maxRunes, overlap int) ([]embedUnit, int) {
+	units := make([]embedUnit, 0, len(records))
+	skipped := 0
+	for _, r := range records {
+		if utf8.RuneCountInString(r.Text) <= maxRunes {
+			units = append(units, embedUnit{id: r.ID, text: r.Text, meta: r.Metadata})
+			continue
+		}
+		chunks := chunker.ChunkBySliding(r.Text, maxRunes, overlap, r.ID)
+		if len(chunks) == 0 {
+			skipped++
+			continue
+		}
+		for _, ch := range chunks {
+			units = append(units, embedUnit{
+				id:   ch.ID,
+				text: ch.Text,
+				meta: chunkMeta(r.Metadata, r.ID, ch.Text, ch.ChunkIndex, len(chunks)),
+			})
+		}
+	}
+	return units, skipped
+}
+
+// chunkMeta builds metadata for a chunk. When the source metadata is a JSON
+// object, the field that textFromMetadata would have read is replaced with the
+// chunk text (so the stored payload matches the chunk vector and the full
+// document is not duplicated once per chunk) and chunk lineage is added
+// (_source_id, _chunk_index, _chunk_total). Non-object metadata is wrapped in a
+// minimal object.
+func chunkMeta(orig json.RawMessage, sourceID, chunkText string, idx, total int) json.RawMessage {
+	m := map[string]json.RawMessage{}
+	if len(orig) == 0 || json.Unmarshal(orig, &m) != nil {
+		m = map[string]json.RawMessage{}
+	}
+	set := func(k string, v any) {
+		if b, err := json.Marshal(v); err == nil {
+			m[k] = b
+		}
+	}
+	// Replace the same field textFromMetadata reads, mirroring its priority.
+	replaced := false
+	for _, k := range []string{"text", "name", "description", "content", "value", "key"} {
+		if _, ok := m[k]; ok {
+			set(k, chunkText)
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		set("text", chunkText)
+	}
+	set("_source_id", sourceID)
+	set("_chunk_index", idx)
+	set("_chunk_total", total)
+	if out, err := json.Marshal(m); err == nil {
+		return out
+	}
+	return orig
+}

--- a/Levara/internal/http/sync_collection_chunk_test.go
+++ b/Levara/internal/http/sync_collection_chunk_test.go
@@ -1,0 +1,143 @@
+package http
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestExpandRecordsToUnits_ShortPassthrough(t *testing.T) {
+	recs := []syncCollectionRecord{
+		{ID: "rec-1", Text: "short text", Metadata: json.RawMessage(`{"text":"short text","k":1}`)},
+	}
+	units, skipped := expandRecordsToUnits(recs, 100, 20)
+	if skipped != 0 {
+		t.Fatalf("skipped = %d, want 0", skipped)
+	}
+	if len(units) != 1 {
+		t.Fatalf("len(units) = %d, want 1", len(units))
+	}
+	if units[0].id != "rec-1" {
+		t.Errorf("id = %q, want unchanged %q", units[0].id, "rec-1")
+	}
+	if units[0].text != "short text" {
+		t.Errorf("text = %q, want unchanged", units[0].text)
+	}
+	if string(units[0].meta) != `{"text":"short text","k":1}` {
+		t.Errorf("meta = %s, want unchanged", units[0].meta)
+	}
+}
+
+func TestExpandRecordsToUnits_LongSplits(t *testing.T) {
+	maxRunes := 100
+	long := strings.Repeat("word ", 200) // 1000 runes, well over the limit
+	recs := []syncCollectionRecord{
+		{ID: "doc-A", Text: long, Metadata: json.RawMessage(`{"text":"FULL DOCUMENT"}`)},
+	}
+	units, skipped := expandRecordsToUnits(recs, maxRunes, maxRunes/5)
+	if skipped != 0 {
+		t.Fatalf("skipped = %d, want 0", skipped)
+	}
+	if len(units) < 2 {
+		t.Fatalf("len(units) = %d, want >= 2 chunks", len(units))
+	}
+	seen := map[string]bool{}
+	for i, u := range units {
+		if n := utf8.RuneCountInString(u.text); n > maxRunes {
+			t.Errorf("unit %d text has %d runes, want <= %d", i, n, maxRunes)
+		}
+		if u.id == "doc-A" {
+			t.Errorf("unit %d kept the raw record ID; chunk IDs must be derived", i)
+		}
+		if seen[u.id] {
+			t.Errorf("duplicate chunk ID %q", u.id)
+		}
+		seen[u.id] = true
+
+		var m map[string]any
+		if err := json.Unmarshal(u.meta, &m); err != nil {
+			t.Fatalf("unit %d meta not an object: %v", i, err)
+		}
+		if m["_source_id"] != "doc-A" {
+			t.Errorf("unit %d _source_id = %v, want doc-A", i, m["_source_id"])
+		}
+		if _, ok := m["_chunk_index"]; !ok {
+			t.Errorf("unit %d missing _chunk_index", i)
+		}
+		if got := m["_chunk_total"]; got != float64(len(units)) {
+			t.Errorf("unit %d _chunk_total = %v, want %d", i, got, len(units))
+		}
+		if m["text"] == "FULL DOCUMENT" {
+			t.Errorf("unit %d still carries the full document text in metadata", i)
+		}
+	}
+}
+
+func TestExpandRecordsToUnits_SkipsOversizedWhitespace(t *testing.T) {
+	recs := []syncCollectionRecord{
+		{ID: "blank", Text: strings.Repeat(" ", 500), Metadata: json.RawMessage(`{}`)},
+	}
+	units, skipped := expandRecordsToUnits(recs, 100, 20)
+	if skipped != 1 {
+		t.Errorf("skipped = %d, want 1", skipped)
+	}
+	if len(units) != 0 {
+		t.Errorf("len(units) = %d, want 0", len(units))
+	}
+}
+
+func TestChunkMeta_ReplacesMatchedTextField(t *testing.T) {
+	orig := json.RawMessage(`{"text":"whole doc","author":"x"}`)
+	out := chunkMeta(orig, "src-1", "chunk piece", 2, 5)
+
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("not an object: %v", err)
+	}
+	if m["text"] != "chunk piece" {
+		t.Errorf("text = %v, want chunk piece", m["text"])
+	}
+	if m["author"] != "x" {
+		t.Errorf("author = %v, want preserved", m["author"])
+	}
+	if m["_source_id"] != "src-1" {
+		t.Errorf("_source_id = %v, want src-1", m["_source_id"])
+	}
+	if m["_chunk_index"] != float64(2) {
+		t.Errorf("_chunk_index = %v, want 2", m["_chunk_index"])
+	}
+	if m["_chunk_total"] != float64(5) {
+		t.Errorf("_chunk_total = %v, want 5", m["_chunk_total"])
+	}
+}
+
+func TestChunkMeta_ContentFieldPreferredWhenNoText(t *testing.T) {
+	orig := json.RawMessage(`{"content":"whole doc"}`)
+	out := chunkMeta(orig, "src-2", "piece", 0, 1)
+
+	var m map[string]any
+	_ = json.Unmarshal(out, &m)
+	if m["content"] != "piece" {
+		t.Errorf("content = %v, want piece (matched field replaced)", m["content"])
+	}
+	if _, ok := m["text"]; ok {
+		t.Errorf("unexpected text key added when content was the matched field")
+	}
+}
+
+func TestChunkMeta_NonObjectWraps(t *testing.T) {
+	orig := json.RawMessage(`"just a json string"`)
+	out := chunkMeta(orig, "src-3", "piece", 1, 3)
+
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("non-object metadata was not wrapped into an object: %v", err)
+	}
+	if m["text"] != "piece" {
+		t.Errorf("text = %v, want piece", m["text"])
+	}
+	if m["_source_id"] != "src-3" {
+		t.Errorf("_source_id = %v, want src-3", m["_source_id"])
+	}
+}

--- a/Levara/internal/http/sync_collection_chunk_test.go
+++ b/Levara/internal/http/sync_collection_chunk_test.go
@@ -11,9 +11,12 @@ func TestExpandRecordsToUnits_ShortPassthrough(t *testing.T) {
 	recs := []syncCollectionRecord{
 		{ID: "rec-1", Text: "short text", Metadata: json.RawMessage(`{"text":"short text","k":1}`)},
 	}
-	units, skipped := expandRecordsToUnits(recs, 100, 20)
+	units, skipped, chunked := expandRecordsToUnits(recs, 100, 20)
 	if skipped != 0 {
 		t.Fatalf("skipped = %d, want 0", skipped)
+	}
+	if chunked {
+		t.Errorf("chunked = true, want false for short passthrough record")
 	}
 	if len(units) != 1 {
 		t.Fatalf("len(units) = %d, want 1", len(units))
@@ -35,9 +38,12 @@ func TestExpandRecordsToUnits_LongSplits(t *testing.T) {
 	recs := []syncCollectionRecord{
 		{ID: "doc-A", Text: long, Metadata: json.RawMessage(`{"text":"FULL DOCUMENT"}`)},
 	}
-	units, skipped := expandRecordsToUnits(recs, maxRunes, maxRunes/5)
+	units, skipped, chunked := expandRecordsToUnits(recs, maxRunes, maxRunes/5)
 	if skipped != 0 {
 		t.Fatalf("skipped = %d, want 0", skipped)
+	}
+	if !chunked {
+		t.Errorf("chunked = false, want true when a record was split")
 	}
 	if len(units) < 2 {
 		t.Fatalf("len(units) = %d, want >= 2 chunks", len(units))
@@ -78,9 +84,12 @@ func TestExpandRecordsToUnits_SkipsOversizedWhitespace(t *testing.T) {
 	recs := []syncCollectionRecord{
 		{ID: "blank", Text: strings.Repeat(" ", 500), Metadata: json.RawMessage(`{}`)},
 	}
-	units, skipped := expandRecordsToUnits(recs, 100, 20)
+	units, skipped, chunked := expandRecordsToUnits(recs, 100, 20)
 	if skipped != 1 {
 		t.Errorf("skipped = %d, want 1", skipped)
+	}
+	if chunked {
+		t.Errorf("chunked = true, want false when oversized record produced no chunks")
 	}
 	if len(units) != 0 {
 		t.Errorf("len(units) = %d, want 0", len(units))

--- a/Levara/pkg/embed/client.go
+++ b/Levara/pkg/embed/client.go
@@ -53,6 +53,17 @@ func (c *Client) WithCache(cache *Cache) *Client {
 	return c
 }
 
+// WithTimeout overrides the per-request HTTP timeout (default 30s). Bulk
+// re-embedding of large document chunks on modest hardware can take far longer
+// than embedding short memory texts, so that path opts into a larger timeout.
+// A non-positive d leaves the existing timeout unchanged.
+func (c *Client) WithTimeout(d time.Duration) *Client {
+	if d > 0 {
+		c.httpClient.Timeout = d
+	}
+	return c
+}
+
 // embeddingRequest is the OpenAI-compatible request format.
 type embeddingRequest struct {
 	Input []string `json:"input"`

--- a/Levara/pkg/embed/client_test.go
+++ b/Levara/pkg/embed/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 const (
@@ -177,5 +178,23 @@ func BenchmarkEmbedSingle(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		client.EmbedSingle(ctx, "тестовый текст для бенчмарка эмбеддинга")
+	}
+}
+
+func TestWithTimeoutOverridesDefault(t *testing.T) {
+	c := NewClient("http://localhost:9001/v1/embeddings", embedModel, 16, 1)
+	if c.httpClient.Timeout != 30*time.Second {
+		t.Fatalf("default timeout = %v, want 30s", c.httpClient.Timeout)
+	}
+	if got := c.WithTimeout(5 * time.Minute); got != c {
+		t.Errorf("WithTimeout should return the same client for chaining")
+	}
+	if c.httpClient.Timeout != 5*time.Minute {
+		t.Errorf("timeout = %v, want 5m after WithTimeout", c.httpClient.Timeout)
+	}
+	// Non-positive duration must leave the timeout unchanged.
+	c.WithTimeout(0)
+	if c.httpClient.Timeout != 5*time.Minute {
+		t.Errorf("timeout = %v, want unchanged 5m after WithTimeout(0)", c.httpClient.Timeout)
 	}
 }


### PR DESCRIPTION
## Summary
- Collection import re-embeds each record's text as one vector; records holding whole documents exceed the embed model's context window, so import failed with `input length exceeds the context length` (the `uploads` collection never synced).
- Records above a safe rune budget are now split into overlapping chunks via the shared `pkg/chunker` (sliding, snap-to-sentence, `overlap = window/5`); each chunk is embedded and stored as its own vector with a deterministic UUID5 chunk ID.
- Records that fit (`<= reembedMaxRunes = 4000`) pass through unchanged (original ID + metadata) — **no existing collection changes behavior**. The embed dimension test now runs on the first chunk-sized unit instead of a raw document.
- Chunk metadata replaces the matched text field (mirroring `textFromMetadata` priority) with the chunk text and adds `_source_id` / `_chunk_index` / `_chunk_total` lineage, so the full document isn't stored once per chunk.

`reembedMaxRunes = 4000` keeps every unit under nomic's 8192-token context for any script (a BPE token covers ≥1 byte). Reuses the existing chunker already on `main` — no new dependency.

## Notes
- Server-side: takes effect once deployed to the Pi (the receiver re-embeds).
- `uploads` will still need a small client `BATCH_RECORDS` in `scripts/sync_collections.sh` to stay under the 8 MB inbound body limit (413) — an orthogonal request-size concern, not addressed here.

## Test Plan
- [x] `go build ./...`
- [x] `go vet ./internal/http/` clean
- [x] `go test ./pkg/chunker/`
- [x] `go test ./internal/http/` full package (no regressions)
- [x] New unit tests for `expandRecordsToUnits` and `chunkMeta` (passthrough, splitting, skip-empty, field replacement, content-field priority, non-object wrapping)
- [ ] Deploy to Pi and re-run `uploads` sync end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)