### PR TITLE
refactor(access): finish Phase 2A — tenant auto-select, filter SQL & ACL vocab into pkg/access

### DIFF
--- a/Levara/internal/http/tenants.go
+++ b/Levara/internal/http/tenants.go
@@ -4,7 +4,6 @@ package http
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -49,15 +48,11 @@ func TenantMiddleware(db *sql.DB) fiber.Handler {
 			return c.Next()
 		}
 
-		// 2. Resolve from user's tenant memberships
+		// 2. Resolve from user's tenant memberships (policy decides; a query
+		// failure leaves the request in the no-isolation path, as before).
 		userID, _ := c.Locals("user_id").(string)
 		if userID != "" && db != nil {
-			var tid string
-			// If user belongs to exactly one tenant, auto-select it
-			err := db.QueryRowContext(c.UserContext(),
-				Q(`SELECT tenant_id FROM user_tenant WHERE user_id = $1 LIMIT 1`), userID,
-			).Scan(&tid)
-			if err == nil && tid != "" {
+			if tid, _ := tenantDefaultForUser(c.UserContext(), db, userID); tid != "" {
 				c.Locals("tenant_id", tid)
 			}
 		}
@@ -81,19 +76,11 @@ func TenantFilter(tenantID string) string {
 	return clause
 }
 
-// TenantFilterSQL returns a tenant-isolation SQL clause plus bind args.
+// TenantFilterSQL returns a tenant-isolation SQL clause plus bind args. The
+// clause shape and placeholder dialect are decided by the shared policy in
+// pkg/access; only the sqlite-vs-positional choice is a transport detail.
 func TenantFilterSQL(tenantID string, startIdx int) (string, []any) {
-	if tenantID == "" {
-		return "", nil
-	}
-	if startIdx <= 0 {
-		startIdx = 1
-	}
-	placeholder := fmt.Sprintf("$%d", startIdx)
-	if GetDBProvider() == DBSQLite {
-		placeholder = "?"
-	}
-	return " AND owner_id IN (SELECT user_id FROM user_tenant WHERE tenant_id = " + placeholder + ")", []any{tenantID}
+	return accesspkg.TenantOwnerFilterSQL(tenantID, startIdx, GetDBProvider() == DBSQLite)
 }
 
 // tenantUserIsMember delegates the membership decision to the shared
@@ -101,6 +88,13 @@ func TenantFilterSQL(tenantID string, startIdx int) (string, []any) {
 // authorization SQL of their own.
 func tenantUserIsMember(ctx context.Context, db *sql.DB, userID, tenantID string) (bool, error) {
 	return accesspkg.SQLPolicy{DB: db, Q: Q}.IsTenantMember(ctx, userID, tenantID)
+}
+
+// tenantDefaultForUser delegates the auto-select decision (which tenant to
+// activate when no X-Tenant-Id header is present) to the shared policy, keeping
+// the middleware free of tenant-resolution SQL.
+func tenantDefaultForUser(ctx context.Context, db *sql.DB, userID string) (string, error) {
+	return accesspkg.SQLPolicy{DB: db, Q: Q}.DefaultTenantForUser(ctx, userID)
 }
 
 // CollectionPrefix returns the tenant-scoped collection name.
@@ -252,8 +246,7 @@ func aclGrantHandler(cfg APIConfig) fiber.Handler {
 		if req.PrincipalID == "" || req.DatasetID == "" || req.PermissionType == "" {
 			return c.Status(400).JSON(fiber.Map{"detail": "principal_id, dataset_id, permission_type required"})
 		}
-		valid := map[string]bool{"read": true, "write": true, "delete": true, "share": true}
-		if !valid[req.PermissionType] {
+		if !accesspkg.ValidPermissionType(req.PermissionType) {
 			return c.Status(400).JSON(fiber.Map{"detail": "permission_type must be read, write, delete, or share"})
 		}
 		id := uuid.New().String()
@@ -274,7 +267,10 @@ func aclCheckHandler(cfg APIConfig) fiber.Handler {
 		if userID == "" || datasetID == "" {
 			return c.Status(400).JSON(fiber.Map{"detail": "user_id and dataset_id query params required"})
 		}
-		perms := map[string]bool{"read": false, "write": false, "delete": false, "share": false}
+		perms := map[string]bool{}
+		for _, pt := range accesspkg.PermissionTypes() {
+			perms[pt] = false
+		}
 		if cfg.DB != nil {
 			rows, err := cfg.DB.QueryContext(context.Background(),
 				Q("SELECT permission_type FROM acl WHERE principal_id = $1 AND dataset_id = $2"), userID, datasetID)

--- a/Levara/pkg/access/acl.go
+++ b/Levara/pkg/access/acl.go
@@ -1,0 +1,30 @@
+package access
+
+// ACL permission types grantable on a dataset. These are the canonical
+// permission vocabulary shared by the grant and check paths so the two cannot
+// drift; HTTP handlers validate and enumerate through these helpers instead of
+// carrying their own literal maps.
+const (
+	PermissionRead   = "read"
+	PermissionWrite  = "write"
+	PermissionDelete = "delete"
+	PermissionShare  = "share"
+)
+
+// PermissionTypes returns the canonical ordered list of grantable ACL
+// permissions. Callers building an "all permissions" result map (e.g. an ACL
+// check response) iterate this so the permission set stays single-sourced.
+func PermissionTypes() []string {
+	return []string{PermissionRead, PermissionWrite, PermissionDelete, PermissionShare}
+}
+
+// ValidPermissionType reports whether pt is a grantable ACL permission
+// (read, write, delete, share). Empty or unknown values are rejected.
+func ValidPermissionType(pt string) bool {
+	switch pt {
+	case PermissionRead, PermissionWrite, PermissionDelete, PermissionShare:
+		return true
+	default:
+		return false
+	}
+}

--- a/Levara/pkg/access/acl_test.go
+++ b/Levara/pkg/access/acl_test.go
@@ -1,0 +1,32 @@
+package access
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestValidPermissionType(t *testing.T) {
+	for _, ok := range []string{PermissionRead, PermissionWrite, PermissionDelete, PermissionShare} {
+		if !ValidPermissionType(ok) {
+			t.Fatalf("ValidPermissionType(%q) = false, want true", ok)
+		}
+	}
+	for _, bad := range []string{"", "admin", "READ", "owner", "execute"} {
+		if ValidPermissionType(bad) {
+			t.Fatalf("ValidPermissionType(%q) = true, want false", bad)
+		}
+	}
+}
+
+func TestPermissionTypes(t *testing.T) {
+	want := []string{"read", "write", "delete", "share"}
+	if got := PermissionTypes(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("PermissionTypes() = %v, want %v", got, want)
+	}
+	// Every enumerated type must also validate — the two helpers share one source.
+	for _, pt := range PermissionTypes() {
+		if !ValidPermissionType(pt) {
+			t.Fatalf("enumerated %q fails ValidPermissionType", pt)
+		}
+	}
+}

--- a/Levara/pkg/access/tenant.go
+++ b/Levara/pkg/access/tenant.go
@@ -1,0 +1,55 @@
+package access
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// DefaultTenantForUser resolves the tenant to auto-select for a request that did
+// not carry an explicit X-Tenant-Id header: the user's tenant membership. A nil
+// DB or empty userID yields ("", nil), preserving the dev-mode / single-user
+// path where tenant isolation is not enforced; a user with no membership also
+// yields ("", nil). Only a real query failure returns an error.
+//
+// The LIMIT 1 mirrors the prior HTTP behavior: a user belonging to several
+// tenants gets one auto-selected rather than failing — callers that need strict
+// single-tenant semantics check membership explicitly via IsTenantMember.
+func (p SQLPolicy) DefaultTenantForUser(ctx context.Context, userID string) (string, error) {
+	if p.DB == nil || userID == "" {
+		return "", nil
+	}
+	var tenantID string
+	err := p.DB.QueryRowContext(ctx,
+		p.rewrite("SELECT tenant_id FROM user_tenant WHERE user_id = $1 LIMIT 1"),
+		userID,
+	).Scan(&tenantID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return tenantID, nil
+}
+
+// TenantOwnerFilterSQL returns the SQL fragment that restricts a query to rows
+// whose owner_id belongs to tenantID, plus its bind args. An empty tenantID
+// yields ("", nil) — the no-isolation (dev / single-user) path. startIdx is the
+// 1-based positional placeholder index for the tenant argument; values <= 0 are
+// clamped to 1. sqlite selects "?" placeholders instead of "$N". The fragment is
+// prefixed with " AND " so it appends directly onto an existing WHERE clause.
+func TenantOwnerFilterSQL(tenantID string, startIdx int, sqlite bool) (string, []any) {
+	if tenantID == "" {
+		return "", nil
+	}
+	if startIdx <= 0 {
+		startIdx = 1
+	}
+	placeholder := fmt.Sprintf("$%d", startIdx)
+	if sqlite {
+		placeholder = "?"
+	}
+	return " AND owner_id IN (SELECT user_id FROM user_tenant WHERE tenant_id = " + placeholder + ")", []any{tenantID}
+}

--- a/Levara/pkg/access/tenant_test.go
+++ b/Levara/pkg/access/tenant_test.go
@@ -1,0 +1,87 @@
+package access
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/ncruces/go-sqlite3/driver"
+)
+
+func TestDefaultTenantForUser(t *testing.T) {
+	db := newDefaultTenantTestDB(t)
+	policy := SQLPolicy{DB: db, Q: sqliteQ}
+	ctx := context.Background()
+
+	if got, err := policy.DefaultTenantForUser(ctx, "user-single"); err != nil || got != "tenant-a" {
+		t.Fatalf("single membership = %q err=%v, want tenant-a nil", got, err)
+	}
+
+	// Multi-membership: any of the user's tenants is acceptable (LIMIT 1), but it
+	// must be one the user actually belongs to and never empty/erroring.
+	got, err := policy.DefaultTenantForUser(ctx, "user-multi")
+	if err != nil {
+		t.Fatalf("multi membership err=%v", err)
+	}
+	if got != "tenant-a" && got != "tenant-b" {
+		t.Fatalf("multi membership = %q, want one of tenant-a/tenant-b", got)
+	}
+
+	if got, err := policy.DefaultTenantForUser(ctx, "user-none"); err != nil || got != "" {
+		t.Fatalf("no membership = %q err=%v, want empty nil", got, err)
+	}
+	if got, err := policy.DefaultTenantForUser(ctx, ""); err != nil || got != "" {
+		t.Fatalf("empty user = %q err=%v, want empty nil", got, err)
+	}
+	if got, err := (SQLPolicy{}).DefaultTenantForUser(ctx, "user-single"); err != nil || got != "" {
+		t.Fatalf("nil-db = %q err=%v, want empty nil", got, err)
+	}
+}
+
+func TestTenantOwnerFilterSQL(t *testing.T) {
+	if clause, args := TenantOwnerFilterSQL("", 3, false); clause != "" || args != nil {
+		t.Fatalf("empty tenant = (%q, %v), want empty/nil", clause, args)
+	}
+
+	clause, args := TenantOwnerFilterSQL("tenant-a", 3, false)
+	want := " AND owner_id IN (SELECT user_id FROM user_tenant WHERE tenant_id = $3)"
+	if clause != want {
+		t.Fatalf("positional clause = %q, want %q", clause, want)
+	}
+	if len(args) != 1 || args[0] != "tenant-a" {
+		t.Fatalf("args = %v, want [tenant-a]", args)
+	}
+
+	clause, _ = TenantOwnerFilterSQL("tenant-a", 3, true)
+	wantSQLite := " AND owner_id IN (SELECT user_id FROM user_tenant WHERE tenant_id = ?)"
+	if clause != wantSQLite {
+		t.Fatalf("sqlite clause = %q, want %q", clause, wantSQLite)
+	}
+
+	// startIdx <= 0 clamps to $1 so the fragment never emits an invalid $0.
+	clause, _ = TenantOwnerFilterSQL("tenant-a", 0, false)
+	wantClamped := " AND owner_id IN (SELECT user_id FROM user_tenant WHERE tenant_id = $1)"
+	if clause != wantClamped {
+		t.Fatalf("clamped clause = %q, want %q", clause, wantClamped)
+	}
+}
+
+func newDefaultTenantTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", t.TempDir()+"/default_tenant.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	for _, stmt := range []string{
+		`CREATE TABLE user_tenant (user_id TEXT, tenant_id TEXT)`,
+		`INSERT INTO user_tenant(user_id, tenant_id) VALUES ('user-single', 'tenant-a')`,
+		`INSERT INTO user_tenant(user_id, tenant_id) VALUES ('user-multi', 'tenant-a')`,
+		`INSERT INTO user_tenant(user_id, tenant_id) VALUES ('user-multi', 'tenant-b')`,
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("exec %q: %v", stmt, err)
+		}
+	}
+	return db
+}

--- a/from_cod.md
+++ b/from_cod.md
@@ -27,11 +27,13 @@ runtime.
 - [x] Workspace audit can mirror sanitized events into a generic `audit.EventSink`.
 - [x] Full testing scenario design added for profiles, layers, release gates,
   and enterprise readiness.
-- [ ] Access-policy extraction is mostly done — workspace authorization,
-  dataset visibility/access, superuser lookup, dataset-share management, and
-  tenant membership now live in `pkg/access`. Remaining inline decisions:
-  tenant auto-select default (`tenants.go`), the tenant SQL filter fragment,
-  and the `acl.permission_type` check.
+- [x] Access-policy extraction complete — workspace authorization, dataset
+  visibility/access, superuser lookup, dataset-share management, tenant
+  membership, tenant auto-select (`SQLPolicy.DefaultTenantForUser`), the tenant
+  SQL filter fragment (`access.TenantOwnerFilterSQL`), and the
+  `acl.permission_type` vocabulary (`access.ValidPermissionType` /
+  `PermissionTypes`) now live in `pkg/access`. `internal/http/tenants.go`
+  delegates every policy decision; handlers only adapt request/response.
 - [x] Runtime profiles fail fast in strict mode (`LEVARA_PROFILE_STRICT=1`):
   unsafe `team`/`enterprise` configs exit non-zero. Warning-only remains the
   default during migration.
@@ -82,7 +84,7 @@ REST/MCP behavior.
 
 Acceptance criteria:
 
-- [ ] HTTP handlers adapt request/response only; they do not decide policy.
+- [x] HTTP handlers adapt request/response only; they do not decide policy.
 - [x] MCP workspace tools and REST workspace routes share the same policy code.
 - [x] Existing public REST/MCP/gRPC contracts remain unchanged.
 


### PR DESCRIPTION
## Что и зачем

Завершает извлечение access-границы Phase 2A из `from_cod.md`: последние inline-решения политики в `internal/http/tenants.go` теперь делегируются в общий transport-independent слой `pkg/access`. Закрывает acceptance-критерий **«HTTP handlers adapt request/response only; they do not decide policy»**.

## Изменения

**Новое в `pkg/access`:**
- `SQLPolicy.DefaultTenantForUser(ctx, userID)` — авто-выбор тенанта, когда нет заголовка `X-Tenant-Id`. Поведение `LIMIT 1` сохранено; `nil`-DB / пустой user / отсутствие членства → `("", nil)`; ошибку возвращает только реальный сбой запроса.
- `TenantOwnerFilterSQL(tenantID, startIdx, sqlite)` — фрагмент `AND owner_id IN (...)` с диалектами плейсхолдеров (positional `$N` / sqlite `?`); пустой `tenantID` → без клаузы.
- `ValidPermissionType` / `PermissionTypes` — единый источник словаря ACL-прав (`read`/`write`/`delete`/`share`), общий для grant- и check-обработчиков, чтобы они не разъезжались.

**`internal/http/tenants.go`:**
- `TenantMiddleware` авто-выбор, `TenantFilterSQL` и оба ACL-обработчика делегируют в `pkg/access` через тонкие обёртки (`tenantDefaultForUser`, по образцу существующего `tenantUserIsMember`).
- Публичное REST-поведение не меняется; убран ставший лишним импорт `fmt`.

## Тесты и гейты
- Новые unit-тесты `pkg/access`: `tenant_test.go` (auto-select по single/multi/none/nil-DB, фильтр-SQL диалекты + клампинг `startIdx`), `acl_test.go` (валидация и перечисление прав).
- Локально зелёные: `go build ./...`, `go vet`, `golangci-lint run` (0 issues), `go test ./pkg/access ./internal/http` (+ `-race` на `pkg/access`), `make contract-check` (без дрейфа), `gofmt -l` чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)