### PR TITLE
feat(audit): enterprise audit export adapter + local JSONL sink (Phase 4A)

### DIFF
--- a/Levara/cmd/server/bootstrap.go
+++ b/Levara/cmd/server/bootstrap.go
@@ -625,6 +625,37 @@ func initMCPAuditSink(path string, log *observe.Logger) audit.Sink {
 	return fl
 }
 
+// initWorkspaceAuditExporter constructs the optional enterprise audit-export
+// adapter that workspace handlers mirror sanitized events into (Phase 4A). It
+// is enabled by LEVARA_WORKSPACE_AUDIT_EXPORT (truthy) — the same flag profile
+// validation reads via auditSinkConfigured, so "export configured" stays a
+// single source of truth. Events are written as daily-rolled, gzipped JSONL
+// under LEVARA_WORKSPACE_AUDIT_EXPORT_DIR, defaulting to <dataDir>/audit/
+// workspace; retention is LEVARA_WORKSPACE_AUDIT_RETENTION_DAYS (default 30).
+//
+// Returns nil when disabled or on init failure — a broken audit sink must never
+// abort startup, matching the "audit failures are observable but do not break
+// core operations" acceptance. The returned *audit.AsyncExporter is both the
+// EventSink to wire into APIConfig.WorkspaceAuditSink and the closer to drain
+// on shutdown.
+func initWorkspaceAuditExporter(dataDir string, log *observe.Logger) *audit.AsyncExporter {
+	if !truthyEnv("LEVARA_WORKSPACE_AUDIT_EXPORT") {
+		return nil
+	}
+	dir := strings.TrimSpace(os.Getenv("LEVARA_WORKSPACE_AUDIT_EXPORT_DIR"))
+	if dir == "" {
+		dir = filepath.Join(dataDir, "audit", "workspace")
+	}
+	retention := intEnv("LEVARA_WORKSPACE_AUDIT_RETENTION_DAYS", 30)
+	exp, err := audit.NewJSONLExporter(dir, retention, audit.ExportConfig{})
+	if err != nil {
+		log.Warn("workspace_audit_export_init_failed", map[string]any{"dir": dir, "err": err.Error()})
+		return nil
+	}
+	log.Info("workspace_audit_export_ready", map[string]any{"dir": dir, "retention_days": retention})
+	return exp
+}
+
 // evaluateRuntimeProfile is the pure decision core for profile validation: it
 // returns the findings to log and whether startup must fail fast. In strict
 // mode the profile requirements are error-level and any of them is fatal; the

--- a/Levara/cmd/server/main.go
+++ b/Levara/cmd/server/main.go
@@ -69,6 +69,7 @@ import (
 	"github.com/stek0v/levara/internal/store"
 
 	_ "github.com/stek0v/levara/docs" // swaggo-generated OpenAPI spec (T13)
+	"github.com/stek0v/levara/pkg/audit"
 	"github.com/stek0v/levara/pkg/consolidate"
 	"github.com/stek0v/levara/pkg/embed"
 	"github.com/stek0v/levara/pkg/graphdb"
@@ -455,6 +456,16 @@ func main() {
 	rerankCfg := rerankConfigFromEnv()
 	workspaceWatcher := vectorHttp.NewWorkspaceWatchState()
 
+	// Optional enterprise audit-export adapter (Phase 4A). When enabled it sits
+	// in the WorkspaceAuditSink slot the workspace handlers already mirror
+	// sanitized events into — pluggable without editing those handlers. Shared
+	// (concurrency-safe) across the REST and MCP configs; drained on shutdown.
+	var wsAuditSink audit.EventSink
+	if wsAuditExporter := initWorkspaceAuditExporter(*dataDir, srvLog); wsAuditExporter != nil {
+		wsAuditSink = wsAuditExporter
+		defer wsAuditExporter.Close()
+	}
+
 	apiCfg := vectorHttp.APIConfig{
 		PostgresDSN:             pgDSN,
 		StoragePath:             *dataDir + "/uploads",
@@ -484,6 +495,7 @@ func main() {
 		AdaptiveWeights:         adaptiveWeights,
 		Runs:                    runs,
 		SearchStrategies:        searchStrategies,
+		WorkspaceAuditSink:      wsAuditSink,
 	}
 
 	// Protected routes: Levara API (datasets, upload, cognify, search)
@@ -512,6 +524,7 @@ func main() {
 		Runs:                    runs,
 		MCPAudit:                initMCPAuditSink(*mcpAuditPath, srvLog),
 		MCPAgentBucket:          metrics.NewUserBucket(20, time.Minute),
+		WorkspaceAuditSink:      wsAuditSink,
 	}
 
 	// MCP (Model Context Protocol) server — JSON-RPC 2.0 for AI agent integration

--- a/Levara/pkg/audit/export.go
+++ b/Levara/pkg/audit/export.go
@@ -1,0 +1,298 @@
+// Audit export boundary. Where audit.go records MCP tool calls to a local
+// JSON-line log, this file defines the *adapter* seam an enterprise deployment
+// plugs a SIEM/log pipeline into: a generic Exporter that accepts sanitized
+// audit.Event values, never blocks the calling request, retries transient
+// delivery failures with bounded backoff, and sheds load by dropping (with a
+// counter) rather than growing unbounded. The first concrete adapter is the
+// local JSONL sink in export_jsonl.go.
+//
+// Two invariants hold regardless of adapter:
+//   - LogEvent must never block the caller. Delivery happens on a background
+//     worker; a full buffer drops the event and increments Dropped.
+//   - Events are sanitized at the boundary (SanitizeEvent) as defense in depth,
+//     so a careless upstream caller still cannot export markdown bodies,
+//     private file paths, raw snippets, secrets, or raw tokens.
+package audit
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// maxMetaValueChars bounds an exported metadata string. Anything longer is
+// treated as a potential content/snippet leak and redacted rather than
+// truncated — truncation could still emit the first 120 chars of a private
+// document, redaction cannot.
+const maxMetaValueChars = 120
+
+// ExportStats is a point-in-time snapshot of an exporter's lifetime counters.
+// All fields are monotonic. Delivered+Dropped+Failed need not equal Enqueued
+// at any instant because in-flight events sit between the channel and the sink.
+type ExportStats struct {
+	Enqueued  uint64 `json:"enqueued"`  // accepted into the buffer
+	Delivered uint64 `json:"delivered"` // written to the sink (eventually) successfully
+	Dropped   uint64 `json:"dropped"`   // shed because the buffer was full (backpressure)
+	Retried   uint64 `json:"retried"`   // individual delivery attempts that failed and were retried
+	Failed    uint64 `json:"failed"`    // events abandoned after exhausting retries
+}
+
+// Exporter is the audit-export adapter contract. It is an EventSink (so it
+// drops into the existing WorkspaceAuditSink slot without handler changes),
+// plus lifecycle and observability: Stats for monitoring, Close for graceful
+// drain on shutdown.
+type Exporter interface {
+	EventSink
+	Stats() ExportStats
+	Close() error
+}
+
+// ExportConfig tunes an AsyncExporter. The zero value is usable — withDefaults
+// fills sane bounds — so callers can pass ExportConfig{} and override only what
+// they care about.
+type ExportConfig struct {
+	// BufferSize bounds the in-memory queue. When full, LogEvent drops rather
+	// than blocks. Default 1024.
+	BufferSize int
+	// MaxRetries is the number of *additional* delivery attempts after the
+	// first failure. Default 3 (so up to 4 attempts total).
+	MaxRetries int
+	// RetryBackoff is the initial sleep between retries; it doubles each retry,
+	// capped at retryBackoffCap. Default 50ms.
+	RetryBackoff time.Duration
+	// OnDrop, if set, is called for each event shed due to a full buffer. It
+	// runs on the caller's goroutine and must not block.
+	OnDrop func(Event)
+	// OnClose, if set, runs after the worker has drained on Close — used to
+	// close the underlying sink (e.g. the JSONL file).
+	OnClose func() error
+}
+
+const retryBackoffCap = 2 * time.Second
+
+func (c ExportConfig) withDefaults() ExportConfig {
+	if c.BufferSize <= 0 {
+		c.BufferSize = 1024
+	}
+	if c.MaxRetries < 0 {
+		c.MaxRetries = 0
+	} else if c.MaxRetries == 0 {
+		c.MaxRetries = 3
+	}
+	if c.RetryBackoff <= 0 {
+		c.RetryBackoff = 50 * time.Millisecond
+	}
+	return c
+}
+
+// deliverFunc writes one already-sanitized event to the underlying sink,
+// returning an error on transient failure so the exporter can retry. A nil
+// return means delivered.
+type deliverFunc func(Event) error
+
+// AsyncExporter is a non-blocking, bounded, retrying EventSink. It owns a
+// background worker that pulls events off a buffered channel and hands each to
+// a deliverFunc with bounded retry. Concurrent LogEvent calls are safe; Close
+// is safe to call once and makes subsequent LogEvent calls no-ops.
+type AsyncExporter struct {
+	cfg     ExportConfig
+	deliver deliverFunc
+
+	ch chan Event
+	wg sync.WaitGroup
+
+	// mu guards closed and gates send-vs-close on ch: LogEvent holds RLock
+	// while doing its non-blocking send, Close holds Lock before close(ch), so
+	// a send can never race the close into a send-on-closed-channel panic.
+	mu     sync.RWMutex
+	closed bool
+
+	enqueued  atomic.Uint64
+	delivered atomic.Uint64
+	dropped   atomic.Uint64
+	retried   atomic.Uint64
+	failed    atomic.Uint64
+}
+
+// NewAsyncExporter starts an exporter that delivers via deliver. The worker
+// runs until Close. deliver must be safe to call from a single goroutine; it is
+// never called concurrently with itself.
+func NewAsyncExporter(deliver deliverFunc, cfg ExportConfig) *AsyncExporter {
+	cfg = cfg.withDefaults()
+	e := &AsyncExporter{
+		cfg:     cfg,
+		deliver: deliver,
+		ch:      make(chan Event, cfg.BufferSize),
+	}
+	e.wg.Add(1)
+	go e.run()
+	return e
+}
+
+// LogEvent sanitizes and enqueues e for background delivery. It never blocks:
+// if the buffer is full the event is dropped and Dropped is incremented. After
+// Close it is a no-op. Safe for concurrent use.
+func (e *AsyncExporter) LogEvent(ev Event) {
+	if e == nil {
+		return
+	}
+	clean := SanitizeEvent(ev)
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if e.closed {
+		return
+	}
+	select {
+	case e.ch <- clean:
+		e.enqueued.Add(1)
+	default:
+		e.dropped.Add(1)
+		if e.cfg.OnDrop != nil {
+			e.cfg.OnDrop(clean)
+		}
+	}
+}
+
+func (e *AsyncExporter) run() {
+	defer e.wg.Done()
+	for ev := range e.ch {
+		e.deliverWithRetry(ev)
+	}
+}
+
+// deliverWithRetry attempts delivery up to 1+MaxRetries times with doubling
+// backoff (capped). Events are pre-sanitized on enqueue, so this only owns
+// transport. A final failure increments Failed and drops the event — delivery
+// must never wedge the worker forever.
+func (e *AsyncExporter) deliverWithRetry(ev Event) {
+	backoff := e.cfg.RetryBackoff
+	for attempt := 0; ; attempt++ {
+		if err := e.deliver(ev); err == nil {
+			e.delivered.Add(1)
+			return
+		}
+		if attempt >= e.cfg.MaxRetries {
+			e.failed.Add(1)
+			return
+		}
+		e.retried.Add(1)
+		time.Sleep(backoff)
+		if backoff *= 2; backoff > retryBackoffCap {
+			backoff = retryBackoffCap
+		}
+	}
+}
+
+// Stats returns a snapshot of lifetime counters.
+func (e *AsyncExporter) Stats() ExportStats {
+	return ExportStats{
+		Enqueued:  e.enqueued.Load(),
+		Delivered: e.delivered.Load(),
+		Dropped:   e.dropped.Load(),
+		Retried:   e.retried.Load(),
+		Failed:    e.failed.Load(),
+	}
+}
+
+// Close stops accepting events, drains the buffer through the worker, then runs
+// OnClose (e.g. to close the file sink). Idempotent. Safe to call once after
+// which LogEvent is a no-op.
+func (e *AsyncExporter) Close() error {
+	if e == nil {
+		return nil
+	}
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		return nil
+	}
+	e.closed = true
+	close(e.ch)
+	e.mu.Unlock()
+
+	e.wg.Wait()
+	if e.cfg.OnClose != nil {
+		return e.cfg.OnClose()
+	}
+	return nil
+}
+
+// SanitizeEvent returns a copy of e safe to export off-box: secret-keyed
+// metadata is dropped, vectors are collapsed to a descriptor, and any string
+// value that looks like content (long, multiline, a file path, or markdown) is
+// replaced with "<redacted>". Controlled top-level fields are truncated. This
+// is defense in depth — workspace events are already narrow and sanitized at
+// their source — so an export adapter can never become a content exfiltration
+// path even if a future caller mirrors a careless event.
+func SanitizeEvent(e Event) Event {
+	out := e
+	out.Source = truncate(e.Source)
+	out.Type = truncate(e.Type)
+	out.Subject = truncate(e.Subject)
+	out.ActorID = truncate(e.ActorID)
+	out.Outcome = truncate(e.Outcome)
+	if len(e.Metadata) > 0 {
+		md := make(map[string]any, len(e.Metadata))
+		for k, v := range e.Metadata {
+			if sv, keep := sanitizeMetaValue(k, v); keep {
+				md[k] = sv
+			}
+		}
+		out.Metadata = md
+	}
+	return out
+}
+
+func sanitizeMetaValue(k string, v any) (any, bool) {
+	if isSecretKey(k) {
+		return nil, false
+	}
+	if isVectorKey(k) {
+		return vectorDescriptor(v), true
+	}
+	switch vv := v.(type) {
+	case string:
+		if looksUnsafeMetaValue(vv) {
+			return "<redacted>", true
+		}
+		return vv, true
+	case map[string]any, []any:
+		b, err := json.Marshal(vv)
+		if err != nil {
+			return "<unmarshalable>", true
+		}
+		if s := string(b); looksUnsafeMetaValue(s) {
+			return "<redacted>", true
+		} else {
+			return s, true
+		}
+	default:
+		// Numbers, bools, nil — safe scalars, no content to leak.
+		return v, true
+	}
+}
+
+// looksUnsafeMetaValue reports whether s could carry sensitive content that
+// must not leave the box via the audit channel: anything long, multiline, that
+// embeds a filesystem path, or that carries markdown structure (fenced code,
+// bold, links, headings) reads as document/snippet content rather than a short
+// scalar tag.
+func looksUnsafeMetaValue(s string) bool {
+	if len(s) > maxMetaValueChars {
+		return true
+	}
+	if strings.ContainsAny(s, "\n\r") {
+		return true
+	}
+	if strings.ContainsAny(s, "/\\") {
+		return true
+	}
+	for _, marker := range []string{"```", "**", "](", "# "} {
+		if strings.Contains(s, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/Levara/pkg/audit/export_jsonl.go
+++ b/Levara/pkg/audit/export_jsonl.go
@@ -1,0 +1,195 @@
+package audit
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// errSinkClosed is returned by WriteEvent after Close. As a delivery error it
+// lets the AsyncExporter's retry loop treat a shutdown race as transient
+// without panicking on a closed file.
+var errSinkClosed = errors.New("audit: event sink closed")
+
+// EventFileSink writes sanitized audit.Event values as JSON lines to a daily
+// file under dir, named audit-YYYY-MM-DD.jsonl. It mirrors FileLogger's
+// rotation/retention discipline (gzip the prior day on rotation, prune files
+// older than retentionDays) but for the generic Event stream and with a
+// synchronous, error-returning WriteEvent so an AsyncExporter can retry
+// transient write failures. The active file is never pruned.
+type EventFileSink struct {
+	dir           string
+	retentionDays int
+
+	mu          sync.Mutex
+	currentDay  string
+	currentFile *os.File
+	enc         *json.Encoder
+	closed      bool
+}
+
+// NewEventFileSink opens (or creates) a daily-rolling JSONL event log under
+// dir. retentionDays <= 0 defaults to 30.
+func NewEventFileSink(dir string, retentionDays int) (*EventFileSink, error) {
+	if retentionDays <= 0 {
+		retentionDays = 30
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("audit: mkdir %s: %w", dir, err)
+	}
+	s := &EventFileSink{dir: dir, retentionDays: retentionDays}
+	if err := s.rotate(time.Now().UTC()); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// WriteEvent sanitizes and appends one event as a JSON line, rotating first if
+// the UTC day changed. It returns an error on a real write failure so the
+// exporter can retry; after Close it returns errSinkClosed.
+func (s *EventFileSink) WriteEvent(e Event) error {
+	if s == nil {
+		return errSinkClosed
+	}
+	clean := SanitizeEvent(e)
+	if clean.TS == "" {
+		clean.TS = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	now := time.Now().UTC()
+	day := now.Format("2006-01-02")
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return errSinkClosed
+	}
+	if day != s.currentDay {
+		if err := s.rotateLocked(now); err != nil {
+			return err
+		}
+	}
+	if s.enc == nil {
+		return errSinkClosed
+	}
+	return s.enc.Encode(clean)
+}
+
+// LogEvent satisfies EventSink by swallowing the error — for direct use as a
+// best-effort sink. Prefer WriteEvent (via NewJSONLExporter) when retries and
+// backpressure are wanted.
+func (s *EventFileSink) LogEvent(e Event) {
+	_ = s.WriteEvent(e)
+}
+
+// Close flushes and closes the current file. Subsequent writes return
+// errSinkClosed.
+func (s *EventFileSink) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	if s.currentFile == nil {
+		return nil
+	}
+	err := s.currentFile.Close()
+	s.currentFile = nil
+	s.enc = nil
+	return err
+}
+
+func (s *EventFileSink) rotate(now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.rotateLocked(now)
+}
+
+func (s *EventFileSink) rotateLocked(now time.Time) error {
+	if s.currentFile != nil {
+		prevPath := s.currentFile.Name()
+		_ = s.currentFile.Close()
+		s.currentFile = nil
+		s.enc = nil
+		if err := gzipFile(prevPath); err != nil {
+			fmt.Fprintf(os.Stderr, "audit: gzip %s failed: %v\n", prevPath, err)
+		}
+	}
+	day := now.Format("2006-01-02")
+	path := filepath.Join(s.dir, "audit-"+day+".jsonl")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("audit: open %s: %w", path, err)
+	}
+	enc := json.NewEncoder(f)
+	enc.SetEscapeHTML(false)
+	s.currentFile = f
+	s.currentDay = day
+	s.enc = enc
+	s.pruneOldLocked(now)
+	return nil
+}
+
+// pruneOldLocked removes audit-* files whose mod time predates the retention
+// cutoff. The freshly-opened active file (audit-<today>.jsonl) carries a
+// current mod time, so it is never a prune candidate; we also skip it by name
+// as belt-and-suspenders.
+func (s *EventFileSink) pruneOldLocked(now time.Time) {
+	cutoff := now.AddDate(0, 0, -s.retentionDays)
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return
+	}
+	activeName := ""
+	if s.currentFile != nil {
+		activeName = filepath.Base(s.currentFile.Name())
+	}
+	type aged struct {
+		name string
+		mod  time.Time
+	}
+	var olds []aged
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, "audit-") {
+			continue
+		}
+		if name == activeName {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			olds = append(olds, aged{name: name, mod: info.ModTime()})
+		}
+	}
+	sort.Slice(olds, func(i, j int) bool { return olds[i].mod.Before(olds[j].mod) })
+	for _, o := range olds {
+		_ = os.Remove(filepath.Join(s.dir, o.name))
+	}
+}
+
+// NewJSONLExporter wires an EventFileSink behind an AsyncExporter: events are
+// sanitized, buffered, and delivered to the daily JSONL file with retry and
+// drop-on-overflow backpressure. Close drains the buffer then closes the file.
+// This is the first concrete enterprise audit adapter; a SIEM adapter would
+// follow the same shape (a WriteEvent-style deliverFunc behind AsyncExporter).
+func NewJSONLExporter(dir string, retentionDays int, cfg ExportConfig) (*AsyncExporter, error) {
+	sink, err := NewEventFileSink(dir, retentionDays)
+	if err != nil {
+		return nil, err
+	}
+	cfg.OnClose = sink.Close
+	return NewAsyncExporter(sink.WriteEvent, cfg), nil
+}

--- a/Levara/pkg/audit/export_test.go
+++ b/Levara/pkg/audit/export_test.go
@@ -1,0 +1,251 @@
+package audit
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestAsyncExporterNeverBlocks proves the core invariant: a slow/stuck sink
+// must never block the calling request. With the worker wedged in a blocking
+// deliver, a flood of LogEvent calls returns near-instantly and the overflow is
+// dropped (and counted), not queued unbounded or blocked.
+func TestAsyncExporterNeverBlocks(t *testing.T) {
+	release := make(chan struct{})
+	var started atomic.Bool
+	deliver := func(Event) error {
+		started.Store(true)
+		<-release
+		return nil
+	}
+	e := NewAsyncExporter(deliver, ExportConfig{BufferSize: 4})
+
+	const n = 1000
+	start := time.Now()
+	for i := 0; i < n; i++ {
+		e.LogEvent(Event{Source: "t", Type: "op"})
+	}
+	elapsed := time.Since(start)
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("LogEvent loop blocked behind a stuck sink: %v", elapsed)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for !started.Load() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if !started.Load() {
+		t.Fatal("worker never engaged the sink")
+	}
+
+	if got := e.Stats().Dropped; got == 0 {
+		t.Fatalf("expected events dropped under backpressure, got Dropped=0 (stats=%+v)", e.Stats())
+	}
+
+	close(release)
+	if err := e.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := e.Stats().Delivered; got == 0 {
+		t.Fatalf("expected drained events delivered after release, got Delivered=0")
+	}
+	// Sanity: nothing is created/delivered beyond what was enqueued.
+	st := e.Stats()
+	if st.Delivered > st.Enqueued {
+		t.Fatalf("delivered %d > enqueued %d", st.Delivered, st.Enqueued)
+	}
+}
+
+func TestAsyncExporterRetriesThenDelivers(t *testing.T) {
+	var attempts atomic.Int32
+	deliver := func(Event) error {
+		if attempts.Add(1) < 3 {
+			return errors.New("transient")
+		}
+		return nil
+	}
+	e := NewAsyncExporter(deliver, ExportConfig{BufferSize: 8, MaxRetries: 5, RetryBackoff: time.Millisecond})
+	e.LogEvent(Event{Source: "t"})
+	if err := e.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	st := e.Stats()
+	if st.Delivered != 1 {
+		t.Fatalf("Delivered = %d, want 1 (stats=%+v)", st.Delivered, st)
+	}
+	if st.Failed != 0 {
+		t.Fatalf("Failed = %d, want 0", st.Failed)
+	}
+	if st.Retried != 2 {
+		t.Fatalf("Retried = %d, want 2 (two failures before the third attempt succeeded)", st.Retried)
+	}
+}
+
+func TestAsyncExporterFailsAfterMaxRetries(t *testing.T) {
+	deliver := func(Event) error { return errors.New("always") }
+	e := NewAsyncExporter(deliver, ExportConfig{BufferSize: 8, MaxRetries: 2, RetryBackoff: time.Millisecond})
+	e.LogEvent(Event{Source: "t"})
+	if err := e.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	st := e.Stats()
+	if st.Failed != 1 {
+		t.Fatalf("Failed = %d, want 1 (stats=%+v)", st.Failed, st)
+	}
+	if st.Delivered != 0 {
+		t.Fatalf("Delivered = %d, want 0", st.Delivered)
+	}
+	if st.Retried != 2 {
+		t.Fatalf("Retried = %d, want 2 (MaxRetries) before giving up", st.Retried)
+	}
+}
+
+// TestSanitizeEventScrubsLeaks asserts the export boundary cannot emit markdown
+// bodies, private file paths, raw snippets, secrets, or raw tokens, while
+// preserving short safe scalar tags.
+func TestSanitizeEventScrubsLeaks(t *testing.T) {
+	e := Event{
+		Source:  "workspace.write",
+		Type:    "operation",
+		Subject: "proj-1",
+		ActorID: "user-1",
+		Outcome: "ok",
+		Metadata: map[string]any{
+			"path":          "/Users/stek0v/private/secret.md",
+			"snippet":       "line one\nline two with detail",
+			"markdown":      "# Heading\n**bold** text",
+			"api_key":       "sk-supersecretvalue",
+			"session_token": "tok-raw-deadbeef",
+			"embedding":     []float64{0.11, 0.22, 0.33},
+			"branch":        "main",
+			"status":        200,
+			"access":        "granted",
+		},
+	}
+	clean := SanitizeEvent(e)
+	b, err := json.Marshal(clean)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := string(b)
+	for _, leak := range []string{
+		"private", "secret.md", "/Users", // private path
+		"line two with detail", // raw snippet body
+		"Heading", "**bold**",  // markdown content
+		"sk-supersecretvalue", // secret value
+		"tok-raw-deadbeef",    // raw token value
+		"0.22",                // raw vector component
+	} {
+		if strings.Contains(js, leak) {
+			t.Fatalf("leaked %q in exported event JSON: %s", leak, js)
+		}
+	}
+
+	// Secret-keyed metadata is dropped entirely.
+	if _, ok := clean.Metadata["api_key"]; ok {
+		t.Fatal("api_key not dropped")
+	}
+	if _, ok := clean.Metadata["session_token"]; ok {
+		t.Fatal("session_token not dropped")
+	}
+	// Vector collapsed to a descriptor, not raw components.
+	if v, _ := clean.Metadata["embedding"].(string); !strings.HasPrefix(v, "<vector") {
+		t.Fatalf("embedding = %v, want <vector …> descriptor", clean.Metadata["embedding"])
+	}
+	// Short safe scalars survive — the audit stays useful.
+	if clean.Metadata["branch"] != "main" {
+		t.Fatalf("branch = %v, want main", clean.Metadata["branch"])
+	}
+	if clean.Metadata["access"] != "granted" {
+		t.Fatalf("access = %v, want granted", clean.Metadata["access"])
+	}
+	if clean.Metadata["status"] != 200 {
+		t.Fatalf("status = %v, want 200", clean.Metadata["status"])
+	}
+	// Unsafe values are redacted (present as a marker, not dropped) so the
+	// event still records that a field existed.
+	if clean.Metadata["path"] != "<redacted>" {
+		t.Fatalf("path = %v, want <redacted>", clean.Metadata["path"])
+	}
+}
+
+func TestEventFileSinkWritesJSONL(t *testing.T) {
+	dir := t.TempDir()
+	sink, err := NewEventFileSink(dir, 30)
+	if err != nil {
+		t.Fatalf("NewEventFileSink: %v", err)
+	}
+	if err := sink.WriteEvent(Event{
+		Source:   "workspace.write",
+		Type:     "operation",
+		Subject:  "p",
+		ActorID:  "u",
+		Outcome:  "ok",
+		Metadata: map[string]any{"branch": "main"},
+	}); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	files, _ := filepath.Glob(filepath.Join(dir, "audit-*.jsonl"))
+	if len(files) != 1 {
+		t.Fatalf("want 1 jsonl file, got %v", files)
+	}
+	data, err := os.ReadFile(files[0])
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var ev Event
+	if err := json.Unmarshal(data, &ev); err != nil {
+		t.Fatalf("decode line %q: %v", data, err)
+	}
+	if ev.Source != "workspace.write" || ev.Subject != "p" || ev.Outcome != "ok" {
+		t.Fatalf("decoded event = %+v", ev)
+	}
+	if ev.TS == "" {
+		t.Fatal("TS not auto-stamped on write")
+	}
+	if ev.Metadata["branch"] != "main" {
+		t.Fatalf("metadata = %v", ev.Metadata)
+	}
+
+	// After Close, writes fail rather than panic on a closed file.
+	if err := sink.WriteEvent(Event{Source: "x"}); !errors.Is(err, errSinkClosed) {
+		t.Fatalf("WriteEvent after Close = %v, want errSinkClosed", err)
+	}
+}
+
+func TestEventFileSinkRetentionPrunes(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "audit-2000-01-01.jsonl")
+	if err := os.WriteFile(oldPath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().AddDate(0, 0, -100)
+	if err := os.Chtimes(oldPath, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	// Construction rotates → prunes files older than retentionDays(30).
+	sink, err := NewEventFileSink(dir, 30)
+	if err != nil {
+		t.Fatalf("NewEventFileSink: %v", err)
+	}
+	defer sink.Close()
+
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("old file not pruned (stat err=%v)", err)
+	}
+	// The freshly-opened active file survives the prune.
+	files, _ := filepath.Glob(filepath.Join(dir, "audit-*.jsonl"))
+	if len(files) != 1 {
+		t.Fatalf("want only the active file after prune, got %v", files)
+	}
+}

--- a/from_cod.md
+++ b/from_cod.md
@@ -184,18 +184,31 @@ Goal: prepare audit export without hard-coding SIEM behavior.
 
 - [x] Add generic `audit.EventSink`.
 - [x] Mirror sanitized workspace audit events into optional `WorkspaceAuditSink`.
-- [ ] Add an audit adapter interface with retry/backpressure semantics.
-- [ ] Add local JSONL export adapter as the first concrete implementation.
-- [ ] Add tests proving audit export never blocks or breaks a user request.
-- [ ] Add tests proving exported audit events contain no markdown content,
-  private file paths, raw search snippets, secrets, or raw tokens.
-- [ ] Add retention configuration proposal and tests for local audit files.
+- [x] Add an audit adapter interface with retry/backpressure semantics
+  (`audit.Exporter` + `AsyncExporter`: bounded buffer, drop-on-full backpressure
+  with a `Dropped` counter, bounded retry with doubling backoff capped at 2s,
+  `ExportStats` for observability).
+- [x] Add local JSONL export adapter as the first concrete implementation
+  (`audit.EventFileSink` daily-rolled `audit-YYYY-MM-DD.jsonl` + gzip-on-rotation;
+  `audit.NewJSONLExporter` wires it behind the `AsyncExporter`). Wired into
+  startup via `initWorkspaceAuditExporter` (gated on `LEVARA_WORKSPACE_AUDIT_EXPORT`).
+- [x] Add tests proving audit export never blocks or breaks a user request
+  (`TestAsyncExporterNeverBlocks`: a wedged sink still returns LogEvent in µs and
+  sheds the overflow as drops).
+- [x] Add tests proving exported audit events contain no markdown content,
+  private file paths, raw search snippets, secrets, or raw tokens
+  (`TestSanitizeEventScrubsLeaks` + `SanitizeEvent` defense-in-depth at the boundary).
+- [x] Add retention configuration proposal and tests for local audit files
+  (`LEVARA_WORKSPACE_AUDIT_RETENTION_DAYS`, default 30; `TestEventFileSinkRetentionPrunes`).
 
 Acceptance criteria:
 
-- [ ] Enterprise audit export can be plugged in without editing workspace
-  handlers.
-- [ ] Audit failures are observable but do not break core operations.
+- [x] Enterprise audit export can be plugged in without editing workspace
+  handlers (the adapter drops into the existing `WorkspaceAuditSink` slot; only
+  bootstrap wiring changed, no handler edits).
+- [x] Audit failures are observable but do not break core operations (delivery
+  is async + best-effort with drop/retry/failed counters; a failed init returns
+  nil and startup continues).
 
 ### Phase 4B: Enterprise Identity Adapters
 
@@ -244,7 +257,9 @@ Acceptance criteria:
   workspace eval, and Pi smoke gates.
 - [x] Add strict profile tests under `pkg/profile` and `cmd/server`.
 - [x] Add REST/MCP policy parity tests under `internal/http`.
-- [ ] Add enterprise audit export contract tests under `pkg/audit`.
+- [x] Add enterprise audit export contract tests under `pkg/audit`
+  (`export_test.go`: no-block/backpressure, retry-then-deliver, fail-after-retries,
+  no-leak sanitization, JSONL write, retention prune).
 - [ ] Add tenant isolation negative tests covering graph/search/workspace
   surfaces.
 


### PR DESCRIPTION
## Phase 4A — Enterprise Audit Adapter Boundary

Adds the audit-export *adapter* seam an enterprise deployment plugs a SIEM/log pipeline into, plus its first concrete adapter (local JSONL), **without editing any workspace handler** — the adapter drops into the existing `WorkspaceAuditSink` slot the handlers already mirror sanitized events into.

### What's new

**`pkg/audit/export.go`**
- `Exporter` interface = `EventSink` + `Stats()` + `Close()`.
- `AsyncExporter`: bounded buffered channel, **drop-on-full backpressure** (counted), background worker, **bounded retry** with doubling backoff (capped 2s), `ExportStats{Enqueued,Delivered,Dropped,Retried,Failed}`. `LogEvent` **never blocks** the caller; `Close` drains then runs `OnClose`.
- `SanitizeEvent`: defense-in-depth at the boundary — drops secret-keyed metadata, collapses vectors to a descriptor, and **redacts any value that looks like content** (long, multiline, a file path, or markdown).

**`pkg/audit/export_jsonl.go`**
- `EventFileSink`: daily-rolled `audit-YYYY-MM-DD.jsonl`, gzip-on-rotation, retention prune (never prunes the active file), synchronous error-returning `WriteEvent` so the exporter can retry.
- `NewJSONLExporter` wires the sink behind the `AsyncExporter`.

**Bootstrap wiring (`cmd/server`)**
- `initWorkspaceAuditExporter`, gated on `LEVARA_WORKSPACE_AUDIT_EXPORT` (the same flag profile validation reads via `auditSinkConfigured`). Dir via `LEVARA_WORKSPACE_AUDIT_EXPORT_DIR` (default `<dataDir>/audit/workspace`), retention via `LEVARA_WORKSPACE_AUDIT_RETENTION_DAYS` (default 30). A failed init returns `nil` and startup continues. Shared (concurrency-safe) across the REST + MCP `APIConfig`; drained on shutdown.

### Tests (`pkg/audit/export_test.go`)
- `TestAsyncExporterNeverBlocks` — a wedged sink still returns `LogEvent` in µs; overflow is shed as drops.
- `TestAsyncExporterRetriesThenDelivers` / `TestAsyncExporterFailsAfterMaxRetries`.
- `TestSanitizeEventScrubsLeaks` — no markdown / private paths / raw snippets / secrets / raw tokens / raw vectors leave the boundary; short safe scalars survive.
- `TestEventFileSinkWritesJSONL` / `TestEventFileSinkRetentionPrunes`.

### Acceptance (from_cod.md, all now `[x]`)
- ✅ Enterprise audit export can be plugged in without editing workspace handlers.
- ✅ Audit failures are observable but do not break core operations.

### Verification
`gofmt` clean · `go build ./...` · `go vet` · `golangci-lint run` (0 issues) · `go test ./pkg/audit/... ./cmd/server/...` (incl. `-race`) · `make contract-check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)