### PR TITLE
test(isolation): tenant negative tests + S0-S4/RC make gates (Harden tests/gates)

### DIFF
--- a/Levara/Makefile
+++ b/Levara/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build run test benchmark clean docker arm64 proto proto-go proto-python swag contract contract-check
+.PHONY: all build run test test-commit test-release-candidate benchmark clean docker arm64 proto proto-go proto-python swag contract contract-check
 
 # Regenerate OpenAPI spec from swaggo annotations (T13).
 # Requires `go install github.com/swaggo/swag/cmd/swag@latest` once.
@@ -39,6 +39,45 @@ test:
 benchmark:
 	@echo "Running Benchmark Suite..."
 	@go run ./cmd/benchmark/main.go
+
+# --- Test gates (docs/full-testing-scenarios.md) ---
+
+# Every-commit gate: the focused S0-S4 suites a change must pass before it is
+# committed. Ordered cheapest-first so a static/docs slip fails fast. Each suite
+# is its own recipe line, so the first failure aborts the target.
+test-commit:
+	@echo "[S0] static + docs"
+	@git diff --check
+	@go test ./docs
+	@echo "[S1] unit packages (access, profile, audit, workspace, mcp)"
+	@go test ./pkg/access ./pkg/profile ./pkg/audit ./pkg/workspace ./pkg/mcp
+	@echo "[S2] core engine (store, vectorstore, bm25)"
+	@go test ./internal/store ./pkg/vectorstore ./pkg/bm25
+	@echo "[S3] HTTP / MCP surface (internal/http)"
+	@go test ./internal/http
+	@echo "[S4] server bootstrap (cmd/server)"
+	@go test ./cmd/server
+	@echo "test-commit: S0-S4 green."
+
+# Release-candidate gate: the heavier, ship-decision checks. Runs fresh
+# (-count=1, no cached results) over profile smoke, sync + backup, and the
+# workspace retrieval-quality eval. Pi-hardware smoke and the two-server S3 mock
+# harness are NOT automated here — they remain manual per the runbook; this
+# target logs that rather than silently implying full coverage.
+test-release-candidate:
+	@echo "[RC] profile smoke (pkg/profile + cmd/server runtime profile/audit)"
+	@go test -count=1 ./pkg/profile
+	@go test -count=1 ./cmd/server -run 'Profile|AuditSink'
+	@echo "[RC] sync flow (internal/http TestSync*)"
+	@go test -count=1 ./internal/http -run 'TestSync'
+	@echo "[RC] backup / restore (pkg/backup)"
+	@go test -count=1 ./pkg/backup
+	@echo "[RC] workspace retrieval-quality eval"
+	@go test -count=1 ./internal/http -run 'TestWorkspaceRetrievalQualityEval|TestWorkspaceEvalMetricsEmpty'
+	@echo "test-release-candidate: automated gates green."
+	@echo "NOTE: not automated by this target (run manually — see docs/full-testing-scenarios.md):"
+	@echo "  - Pi-hardware edge smoke (10.23.0.53)"
+	@echo "  - two-server sync/backup mock harness (S3 cross-instance)"
 
 # --- Cross-compile ---
 

--- a/Levara/internal/http/graph_search.go
+++ b/Levara/internal/http/graph_search.go
@@ -1109,10 +1109,20 @@ func graphContextFromPostgres(ctx context.Context, cfg APIConfig, names []string
 	// Build query with optional dataset_id filter
 	var dsFilter string
 	if allowedDatasetIDs != nil {
-		dsPlaceholders := make([]string, len(allowedDatasetIDs))
+		// Build two independent placeholder sets — one per endpoint. Q()
+		// rewrites $N to positional '?' for the sqlite dialect, where each '?'
+		// consumes the next arg rather than referring back to a reused index;
+		// reusing one placeholder set across both IN clauses would emit more
+		// '?' than args and fail with "expected N arguments, got M". Appending
+		// the ids once per endpoint keeps the count aligned on both dialects.
+		srcPlaceholders := make([]string, len(allowedDatasetIDs))
 		for i, id := range allowedDatasetIDs {
-			idx := len(names) + i + 1
-			dsPlaceholders[i] = fmt.Sprintf("$%d", idx)
+			srcPlaceholders[i] = fmt.Sprintf("$%d", len(args)+1)
+			args = append(args, id)
+		}
+		tgtPlaceholders := make([]string, len(allowedDatasetIDs))
+		for i, id := range allowedDatasetIDs {
+			tgtPlaceholders[i] = fmt.Sprintf("$%d", len(args)+1)
 			args = append(args, id)
 		}
 		// Filter both endpoints (gn = source, gn2 = target). A cross-dataset
@@ -1120,7 +1130,7 @@ func graphContextFromPostgres(ctx context.Context, cfg APIConfig, names []string
 		dsFilter = fmt.Sprintf(
 			" AND (gn.dataset_id IS NULL OR gn.dataset_id = '' OR gn.dataset_id IN (%s))"+
 				" AND (gn2.dataset_id IS NULL OR gn2.dataset_id = '' OR gn2.dataset_id IN (%s))",
-			strings.Join(dsPlaceholders, ","), strings.Join(dsPlaceholders, ","))
+			strings.Join(srcPlaceholders, ","), strings.Join(tgtPlaceholders, ","))
 	}
 
 	limitIdx := len(args) + 1

--- a/Levara/internal/http/tenant_isolation_test.go
+++ b/Levara/internal/http/tenant_isolation_test.go
@@ -1,0 +1,227 @@
+// tenant_isolation_test.go — negative tests for tenant isolation across the
+// three request surfaces called out in docs/full-testing-scenarios.md (P4
+// Enterprise + the S8 security-isolation suite): graph, search, workspace.
+//
+// The existing RBAC tests (rbac_search_test.go, workspace_test.go) prove the
+// dataset-share axis end to end. These tests cover the *tenant* axis instead,
+// and only its failure modes:
+//
+//   - Search surface: a spoofed X-Tenant-Id for a tenant the caller does not
+//     belong to is rejected at the TenantMiddleware boundary; the search
+//     handler never runs, so no downstream tenant_id is established (P4:
+//     "expect HTTP 403 and no downstream tenant_id local"), and the generic
+//     denial leaks neither the spoofed tenant id nor the target collection.
+//   - Graph surface: a cross-dataset graph edge from a visible node to a
+//     foreign-tenant node must not leak the foreign node's name into the
+//     caller's graph context (the both-endpoints filter in
+//     graphContextFromPostgres).
+//   - Workspace surface: a spoofed X-Tenant-Id on a workspace mutation is
+//     intercepted by the tenant gate before any workspace handler runs, and
+//     the denial leaks no project id or file path.
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	_ "github.com/ncruces/go-sqlite3/driver"
+)
+
+// Search surface: a foreign X-Tenant-Id is rejected before the search handler
+// runs, no downstream tenant_id is established, and the denial leaks nothing.
+func TestTenantIsolation_SearchForeignTenantHeaderRejectedNoLeak(t *testing.T) {
+	db := newTenantTestDB(t) // seeds user_tenant with (user-a, tenant-a) only
+
+	var reached bool
+	var downstreamTenant string
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("user_id", "user-a")
+		return c.Next()
+	})
+	app.Use(TenantMiddleware(db))
+	app.Post("/search/text", func(c *fiber.Ctx) error {
+		reached = true
+		downstreamTenant = ResolveTenantID(c)
+		return c.JSON(fiber.Map{"results": []any{}})
+	})
+
+	const foreignTenant = "tenant-b"
+	const privateColl = "tenant-b-private-collection"
+	payload, _ := json.Marshal(map[string]any{
+		"query_text": "find competitor secrets",
+		"query_type": "CHUNKS",
+		"collection": privateColl,
+	})
+
+	req := httptest.NewRequest("POST", "/search/text", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Tenant-Id", foreignTenant)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusForbidden {
+		t.Fatalf("foreign-tenant search status=%d, want 403; body=%s", resp.StatusCode, body)
+	}
+	if reached {
+		t.Fatalf("search handler ran under spoofed tenant (downstream tenant_id=%q)", downstreamTenant)
+	}
+	for _, leak := range []string{foreignTenant, privateColl} {
+		if bytes.Contains(body, []byte(leak)) {
+			t.Fatalf("denied response leaked %q: %s", leak, body)
+		}
+	}
+
+	// Positive control: the user's own tenant resolves and reaches the handler,
+	// proving the 403 above is the isolation gate, not an unrelated failure.
+	reached, downstreamTenant = false, ""
+	req2 := httptest.NewRequest("POST", "/search/text", bytes.NewReader(payload))
+	req2.Header.Set("Content-Type", "application/json")
+	req2.Header.Set("X-Tenant-Id", "tenant-a")
+	resp2, err := app.Test(req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp2.Body.Close()
+	if resp2.StatusCode != fiber.StatusOK || !reached {
+		t.Fatalf("own-tenant search status=%d reached=%v, want 200/true", resp2.StatusCode, reached)
+	}
+	if downstreamTenant != "tenant-a" {
+		t.Fatalf("own-tenant downstream tenant_id=%q, want tenant-a", downstreamTenant)
+	}
+}
+
+// Graph surface: a cross-dataset edge must not leak the foreign node's name
+// into the caller's graph context. The caller (user-b) can see only ds-b; a
+// graph edge from their node (ds-b) to a foreign node (ds-a) is dropped by the
+// both-endpoints dataset filter in graphContextFromPostgres, while a same-tenant
+// edge stays visible.
+func TestTenantIsolation_GraphContextDoesNotLeakForeignDatasetNode(t *testing.T) {
+	env := newSearchTestEnv(t)
+	env.cfg.LLMProvider = nil
+	t.Setenv("LLM_ENDPOINT", "")
+	t.Setenv("LLM_MODEL", "")
+	env.startWithUser("user-b")
+
+	env.insertUser("user-a", "a@example.com", false)
+	env.insertUser("user-b", "b@example.com", false)
+	env.insertDataset("ds-a", "user-a") // foreign tenant's dataset
+	env.insertDataset("ds-b", "user-b") // caller's own dataset
+
+	vec := []float32{1, 0, 0, 0}
+	// Vector hit in the caller's dataset; its name seeds the graph expansion.
+	env.insertVector("entities", "e-mine", vec, map[string]any{
+		"name": "my-entity", "dataset_id": "ds-b",
+	})
+
+	const foreignName = "secret-foreign-entity"
+	env.insertNode("n-mine", "my-entity", "Person", "ds-b")
+	env.insertNode("n-friend", "my-friend", "Person", "ds-b")
+	env.insertNode("n-foreign", foreignName, "Person", "ds-a")
+	env.insertEdge("e-ok", "n-mine", "n-friend", "KNOWS")    // same tenant → visible
+	env.insertEdge("e-leak", "n-mine", "n-foreign", "KNOWS") // cross-tenant → must be filtered
+
+	_, body := env.postSearch(map[string]any{
+		"query_text": "my-entity",
+		"query_type": "GRAPH_COMPLETION",
+		"collection": "entities",
+	})
+
+	raw, _ := json.Marshal(body)
+	if strings.Contains(string(raw), foreignName) {
+		t.Fatalf("foreign-dataset node leaked into graph response: %s", raw)
+	}
+	// Positive control: the same-tenant edge must still surface, proving the
+	// graph expansion ran and only the cross-dataset edge was filtered.
+	ctxArr, _ := body["context"].([]any)
+	var sawFriend bool
+	for _, c := range ctxArr {
+		if s, _ := c.(string); strings.Contains(s, "my-friend") {
+			sawFriend = true
+		}
+	}
+	if !sawFriend {
+		t.Fatalf("same-tenant graph edge missing from context %v; expansion may not have run", ctxArr)
+	}
+}
+
+// Workspace surface: a foreign X-Tenant-Id on a workspace mutation is rejected
+// by the tenant gate before any workspace handler runs, and the generic denial
+// leaks neither the project id nor the file path.
+func TestTenantIsolation_WorkspaceForeignTenantHeaderRejectedNoLeak(t *testing.T) {
+	cfg, closeFn := newWorkspaceACLTestConfig(t)
+	defer closeFn()
+	if _, err := cfg.DB.Exec(`CREATE TABLE user_tenant (user_id TEXT, tenant_id TEXT)`); err != nil {
+		t.Fatalf("create user_tenant: %v", err)
+	}
+	if _, err := cfg.DB.Exec(`INSERT INTO user_tenant(user_id, tenant_id) VALUES ('user-a', 'tenant-a')`); err != nil {
+		t.Fatalf("seed user_tenant: %v", err)
+	}
+
+	app := fiber.New(fiber.Config{DisableStartupMessage: true})
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("user_id", "user-a")
+		return c.Next()
+	})
+	app.Use(TenantMiddleware(cfg.DB))
+	RegisterWorkspaceAPI(app, cfg)
+
+	const foreignTenant = "tenant-b"
+	const foreignProject = "tenant-b-private-project"
+	const secretPath = "docs/secret-roadmap.md"
+	payload, _ := json.Marshal(map[string]any{
+		"project_id": foreignProject,
+		"branch":     "main",
+		"path":       secretPath,
+		"text":       "# Secret\n\nForeign tenant content.",
+		"index":      false,
+	})
+
+	req := httptest.NewRequest("POST", "/workspace/write", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Tenant-Id", foreignTenant)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusForbidden {
+		t.Fatalf("foreign-tenant workspace write status=%d, want 403; body=%s", resp.StatusCode, body)
+	}
+	// The tenant gate intercepts before the workspace handler: the denial is the
+	// generic tenant message, never a workspace response.
+	if !bytes.Contains(body, []byte("not a member of this tenant")) {
+		t.Fatalf("workspace denial did not come from the tenant gate: %s", body)
+	}
+	for _, leak := range []string{foreignTenant, foreignProject, secretPath} {
+		if bytes.Contains(body, []byte(leak)) {
+			t.Fatalf("denied workspace response leaked %q: %s", leak, body)
+		}
+	}
+
+	// Positive control: the caller's own tenant clears the tenant gate (whatever
+	// the workspace handler then decides), proving the 403 above is isolation.
+	req2 := httptest.NewRequest("POST", "/workspace/write", bytes.NewReader(payload))
+	req2.Header.Set("Content-Type", "application/json")
+	req2.Header.Set("X-Tenant-Id", "tenant-a")
+	resp2, err := app.Test(req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	_ = resp2.Body.Close()
+	if bytes.Contains(body2, []byte("not a member of this tenant")) {
+		t.Fatalf("own-tenant workspace request wrongly blocked by the tenant gate: %s", body2)
+	}
+}

--- a/from_cod.md
+++ b/from_cod.md
@@ -252,15 +252,15 @@ Acceptance criteria:
 - [x] Add docs coverage for the product-ladder testing plan.
 - [x] Validate focused packages after current PR merges:
   `go test ./internal/http ./pkg/embed ./cmd/server`.
-- [ ] Add `make test-commit` for S0-S4 focused checks.
-- [ ] Add `make test-release-candidate` for profile smoke, sync/backup,
+- [x] Add `make test-commit` for S0-S4 focused checks.
+- [x] Add `make test-release-candidate` for profile smoke, sync/backup,
   workspace eval, and Pi smoke gates.
 - [x] Add strict profile tests under `pkg/profile` and `cmd/server`.
 - [x] Add REST/MCP policy parity tests under `internal/http`.
 - [x] Add enterprise audit export contract tests under `pkg/audit`
   (`export_test.go`: no-block/backpressure, retry-then-deliver, fail-after-retries,
   no-leak sanitization, JSONL write, retention prune).
-- [ ] Add tenant isolation negative tests covering graph/search/workspace
+- [x] Add tenant isolation negative tests covering graph/search/workspace
   surfaces.
 
 ## Immediate Next Sprint


### PR DESCRIPTION
## Summary

Final item of the 4-step sequential plan — **Harden tests/gates**. Adds tenant-isolation negative tests across all three request surfaces and wires the two documented make gates from `docs/full-testing-scenarios.md`.

### Tenant isolation negative tests (`internal/http/tenant_isolation_test.go`)

The existing suites cover the **dataset-share** RBAC axis thoroughly (`rbac_search_test.go`, the workspace ACL tests, the graph chunk filter). These three new tests cover the **tenant** axis and only its failure modes:

- **search** — a spoofed `X-Tenant-Id` for a tenant the caller doesn't belong to → HTTP 403, the search handler never runs (no downstream `tenant_id` local, per P4), and the generic denial leaks neither the spoofed tenant id nor the target collection. Positive control: own-tenant header resolves and reaches the handler.
- **graph** — a cross-dataset edge from a visible node to a foreign-tenant node must not leak the foreign node's name into the caller's graph context. Positive control: the same-tenant edge still surfaces (proves expansion ran, only the cross-dataset edge was filtered).
- **workspace** — a spoofed `X-Tenant-Id` on a workspace mutation is intercepted by the tenant gate before any workspace handler runs; the denial leaks no project id or file path.

### Bug fix surfaced by the graph test — `graphContextFromPostgres`

The dataset leak-guard reused **one** placeholder set for **both** edge endpoints (`gn`, `gn2`). That works on Postgres (a positional `$N` can be referenced twice) but fails on the **sqlite** dialect: `Q()` rewrites `$N → '?'` positionally, so each `?` consumes a fresh arg → `expected N arguments, got M`. On a `DB_PROVIDER=sqlite` deployment this **silently dropped all graph context for any RBAC-filtered (non-superuser) user**. Fixed by building independent placeholder sets per endpoint so the arg count aligns on both dialects. Existing tests never caught it — they only exercised the nil-filter branch (superuser/anon).

### Make gates

- `make test-commit` — every-commit S0-S4 focused gate (static+docs → unit pkgs → core engine → HTTP/MCP → server bootstrap), cheapest-first so a static slip fails fast.
- `make test-release-candidate` — ship-decision gate (`-count=1`): profile smoke, sync flow, backup/restore, workspace retrieval-quality eval. **Logs** the not-yet-automated Pi-hardware smoke and two-server S3 mock harness rather than silently implying full coverage.

`from_cod.md` testing items marked done.

## Test plan

- `make test-commit` → S0-S4 green
- `make test-release-candidate` → automated gates green
- `go build ./...`, `go vet ./...`, `golangci-lint run ./internal/http/...` (0 issues), `make contract-check` (exit 0)
- full `go test ./...` → all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)