### PR TITLE
feat(access): Phase 4B — enterprise identity adapters + activation gate

### DIFF
--- a/Levara/cmd/server/bootstrap.go
+++ b/Levara/cmd/server/bootstrap.go
@@ -708,16 +708,26 @@ func runtimeDBProvider(db *sql.DB) string {
 // flag, and the MCP audit path so the env reads stay co-located here.
 func buildRuntimeProfileConfig(db *sql.DB, requireAuth bool, mcpAuditPath string) profile.Config {
 	return profile.Config{
-		Profile:        os.Getenv("LEVARA_PROFILE"),
-		DBProvider:     runtimeDBProvider(db),
-		HasDB:          db != nil,
-		RequireAuth:    requireAuth,
-		JWTSecretSet:   strings.TrimSpace(os.Getenv("JWT_SECRET")) != "",
-		SyncEnabled:    strings.TrimSpace(os.Getenv("LEVARA_SYNC_REMOTE_URL")) != "",
-		SyncTokenSet:   strings.TrimSpace(os.Getenv("LEVARA_TOKEN")) != "",
-		TenantEnforced: truthyEnv("LEVARA_TENANT_ENFORCED"),
-		AuditSinkSet:   auditSinkConfigured(mcpAuditPath),
+		Profile:             os.Getenv("LEVARA_PROFILE"),
+		DBProvider:          runtimeDBProvider(db),
+		HasDB:               db != nil,
+		RequireAuth:         requireAuth,
+		JWTSecretSet:        strings.TrimSpace(os.Getenv("JWT_SECRET")) != "",
+		SyncEnabled:         strings.TrimSpace(os.Getenv("LEVARA_SYNC_REMOTE_URL")) != "",
+		SyncTokenSet:        strings.TrimSpace(os.Getenv("LEVARA_TOKEN")) != "",
+		TenantEnforced:      truthyEnv("LEVARA_TENANT_ENFORCED"),
+		AuditSinkSet:        auditSinkConfigured(mcpAuditPath),
+		SSOBridgeConfigured: ssoBridgeConfigured(),
 	}
+}
+
+// ssoBridgeConfigured reports whether an enterprise identity bridge (OIDC/SAML)
+// is wired, gated by LEVARA_SSO_BRIDGE. It satisfies the enterprise auth
+// requirement in profile validation in lieu of local required auth — an
+// SSO-fronted deployment authenticates at the bridge. The flag only feeds
+// validation today; no bridge is instantiated until the protocol adapters land.
+func ssoBridgeConfigured() bool {
+	return truthyEnv("LEVARA_SSO_BRIDGE")
 }
 
 // auditSinkConfigured mirrors initMCPAuditSink's enabling rule for profile

--- a/Levara/cmd/server/profile_config_test.go
+++ b/Levara/cmd/server/profile_config_test.go
@@ -21,6 +21,7 @@ func TestBuildRuntimeProfileConfigSameFacts(t *testing.T) {
 	t.Setenv("LEVARA_TOKEN", "lk_token")
 	t.Setenv("LEVARA_TENANT_ENFORCED", "1")
 	t.Setenv("LEVARA_WORKSPACE_AUDIT_EXPORT", "")
+	t.Setenv("LEVARA_SSO_BRIDGE", "1")
 
 	// A non-nil *sql.DB is what main() passes once SQL runtime is up; the helper
 	// only checks it for nil and reads DB_PROVIDER, so an empty handle is fine
@@ -29,15 +30,16 @@ func TestBuildRuntimeProfileConfigSameFacts(t *testing.T) {
 
 	got := buildRuntimeProfileConfig(db, true, "/var/log/levara/audit")
 	want := profile.Config{
-		Profile:        "enterprise",
-		DBProvider:     "postgres",
-		HasDB:          true,
-		RequireAuth:    true,
-		JWTSecretSet:   true,
-		SyncEnabled:    true,
-		SyncTokenSet:   true,
-		TenantEnforced: true,
-		AuditSinkSet:   true,
+		Profile:             "enterprise",
+		DBProvider:          "postgres",
+		HasDB:               true,
+		RequireAuth:         true,
+		JWTSecretSet:        true,
+		SyncEnabled:         true,
+		SyncTokenSet:        true,
+		TenantEnforced:      true,
+		AuditSinkSet:        true,
+		SSOBridgeConfigured: true,
 	}
 	if got != want {
 		t.Fatalf("buildRuntimeProfileConfig facts drifted\n got=%+v\nwant=%+v", got, want)
@@ -54,11 +56,36 @@ func TestBuildRuntimeProfileConfigPersonalDefaults(t *testing.T) {
 	t.Setenv("LEVARA_TOKEN", "")
 	t.Setenv("LEVARA_TENANT_ENFORCED", "")
 	t.Setenv("LEVARA_WORKSPACE_AUDIT_EXPORT", "")
+	t.Setenv("LEVARA_SSO_BRIDGE", "")
 
 	got := buildRuntimeProfileConfig(nil, false, "-")
 	want := profile.Config{} // all zero: no DB, no auth, no sync, audit disabled
 	if got != want {
 		t.Fatalf("personal defaults drifted\n got=%+v\nwant=%+v", got, want)
+	}
+}
+
+// TestSSOBridgeConfigured pins the LEVARA_SSO_BRIDGE truth table the enterprise
+// auth requirement relies on, so the bridge flag and the env read stay in sync.
+func TestSSOBridgeConfigured(t *testing.T) {
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"1", true},
+		{"true", true},
+		{"yes", true},
+		{"", false},
+		{"0", false},
+		{"off", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.val, func(t *testing.T) {
+			t.Setenv("LEVARA_SSO_BRIDGE", tc.val)
+			if got := ssoBridgeConfigured(); got != tc.want {
+				t.Fatalf("ssoBridgeConfigured() with LEVARA_SSO_BRIDGE=%q = %v, want %v", tc.val, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/Levara/internal/http/search_test_helpers.go
+++ b/Levara/internal/http/search_test_helpers.go
@@ -147,6 +147,7 @@ CREATE TABLE community_members (
 CREATE TABLE users (
 	id TEXT PRIMARY KEY,
 	email TEXT,
+	is_active INTEGER NOT NULL DEFAULT 1,
 	is_superuser INTEGER NOT NULL DEFAULT 0
 );
 CREATE TABLE datasets (

--- a/Levara/pkg/access/actor.go
+++ b/Levara/pkg/access/actor.go
@@ -49,20 +49,27 @@ func (p SQLPolicy) Authorize(ctx context.Context, actor Actor, res Resource, act
 		})
 	case ResourceDataset:
 		// Dataset access is binary per the existing Levara contract: ownership
-		// or any share row grants access regardless of role. API-key
-		// permissions still gate the action so denied keys cannot read or write.
-		allowed := APIKeyAllows(actor.APIKeyPermissions, action) &&
-			p.CanAccessDataset(ctx, res.ID, actor.UserID)
+		// or any share row grants access regardless of role. API-key permissions
+		// still gate the action so denied keys cannot read or write, and a
+		// deactivated account is denied first through the shared activation gate
+		// — the same IsActive check the workspace facade uses.
 		decision := Decision{
-			Allowed:       allowed,
 			Authenticated: actor.UserID != "",
 			APIKeyAllowed: APIKeyAllows(actor.APIKeyPermissions, action),
 		}
-		if !decision.APIKeyAllowed {
+		active, err := p.IsActive(ctx, actor.UserID)
+		if err != nil {
+			return decision, err
+		}
+		switch {
+		case !active:
+			decision.Reason = "user_inactive"
+		case !decision.APIKeyAllowed:
 			decision.Reason = "api_key_permissions_denied"
-		} else if allowed {
+		case p.CanAccessDataset(ctx, res.ID, actor.UserID):
+			decision.Allowed = true
 			decision.Reason = "dataset_access"
-		} else {
+		default:
 			decision.Reason = "denied"
 		}
 		return decision, nil

--- a/Levara/pkg/access/policy.go
+++ b/Levara/pkg/access/policy.go
@@ -66,6 +66,18 @@ func (p SQLPolicy) AuthorizeWorkspace(ctx context.Context, req WorkspaceRequest)
 		return decision, nil
 	}
 
+	// Deactivated accounts lose access here, in the shared policy layer: a user
+	// deprovisioned by SCIM (users.is_active = false) is denied regardless of
+	// ownership, share role, or superuser status. This runs only for
+	// authenticated requests against a real DB — dev-mode and anonymous paths
+	// already returned above.
+	if active, err := p.IsActive(ctx, req.UserID); err != nil {
+		return decision, err
+	} else if !active {
+		decision.Reason = "user_inactive"
+		return decision, nil
+	}
+
 	q := p.rewrite
 	if super, err := p.IsSuperuser(ctx, req.UserID); err != nil {
 		return decision, err
@@ -143,6 +155,28 @@ func (p SQLPolicy) IsSuperuser(ctx context.Context, userID string) (bool, error)
 		return false, err
 	}
 	return isSuperuser, nil
+}
+
+// IsActive reports whether userID's account is active. It is the canonical
+// activation lookup the policy facades route through so a SCIM-deprovisioned
+// user (users.is_active = false) is denied everywhere. A nil DB or empty user
+// is "active" (dev-mode/anonymous never reach the gate), and a missing user row
+// is fail-open active (COALESCE default true) — the deny path is an explicit
+// is_active = false, not the mere absence of a row, matching IsSuperuser's
+// ErrNoRows handling. Only a real query failure returns an error.
+func (p SQLPolicy) IsActive(ctx context.Context, userID string) (bool, error) {
+	if p.DB == nil || userID == "" {
+		return true, nil
+	}
+	var active bool
+	err := p.DB.QueryRowContext(ctx, p.rewrite("SELECT COALESCE(is_active, true) FROM users WHERE id = $1"), userID).Scan(&active)
+	if errors.Is(err, sql.ErrNoRows) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return active, nil
 }
 
 // AllowedDatasetIDs returns dataset IDs the user owns or has been granted.

--- a/Levara/pkg/access/policy_test.go
+++ b/Levara/pkg/access/policy_test.go
@@ -215,6 +215,44 @@ func TestIsSuperuser(t *testing.T) {
 	}
 }
 
+func TestIsActive(t *testing.T) {
+	db := newPolicyTestDB(t)
+	policy := SQLPolicy{DB: db, Q: sqliteQ}
+	ctx := context.Background()
+
+	// Deactivate user-a so the gate has an inactive row to find.
+	if _, err := db.Exec(`UPDATE users SET is_active = 0 WHERE id = 'user-a'`); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name   string
+		userID string
+		want   bool
+	}{
+		{"active user", "user-b", true},
+		{"deactivated user", "user-a", false},
+		{"missing user fails open active", "ghost", true},
+		{"empty user is active", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := policy.IsActive(ctx, tc.userID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("IsActive(%q)=%v, want %v", tc.userID, got, tc.want)
+			}
+		})
+	}
+
+	// A nil DB never queries and treats everyone as active — dev/single-user mode.
+	if got, err := (SQLPolicy{}).IsActive(ctx, "user-a"); !got || err != nil {
+		t.Fatalf("nil-db IsActive=%v,%v want true,nil", got, err)
+	}
+}
+
 func newPolicyTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	db, err := sql.Open("sqlite3", t.TempDir()+"/access.db")
@@ -223,7 +261,7 @@ func newPolicyTestDB(t *testing.T) *sql.DB {
 	}
 	t.Cleanup(func() { db.Close() })
 	for _, stmt := range []string{
-		`CREATE TABLE users (id TEXT PRIMARY KEY, is_superuser INTEGER NOT NULL DEFAULT 0)`,
+		`CREATE TABLE users (id TEXT PRIMARY KEY, is_active INTEGER NOT NULL DEFAULT 1, is_superuser INTEGER NOT NULL DEFAULT 0)`,
 		`CREATE TABLE datasets (id TEXT PRIMARY KEY, owner_id TEXT)`,
 		`CREATE TABLE dataset_shares (id TEXT PRIMARY KEY, dataset_id TEXT, user_id TEXT, role TEXT)`,
 		`INSERT INTO users(id, is_superuser) VALUES ('user-a', 0), ('user-b', 0), ('user-c', 0), ('root', 1)`,

--- a/Levara/pkg/access/provisioning.go
+++ b/Levara/pkg/access/provisioning.go
@@ -1,0 +1,218 @@
+package access
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+)
+
+// Phase 4B: enterprise provisioning (SCIM) boundary.
+//
+// A Provisioner is the seam an external directory drives to create, update, and
+// deactivate Levara users and their tenant memberships — the write-side mirror
+// of IdentityBridge's read-side mapping. Like the bridge it owns no policy
+// decisions: it only mutates the users / user_tenant tables that SQLPolicy
+// already consults, so deactivating a user here removes their access everywhere
+// through the shared policy layer, with no handler-specific branch. This also
+// covers the Phase 2B leftover — per-agent credentials can be modelled as
+// provisioned principals without adding per-handler code.
+//
+// The default deployment wires NoopProvisioner: provisioning is rejected, and
+// users are managed only through the local auth flows.
+
+var (
+	// ErrProvisioningDisabled is returned by the default NoopProvisioner: no
+	// external directory is wired, so provisioning calls are rejected.
+	ErrProvisioningDisabled = errors.New("access: external provisioning is not enabled")
+	// ErrUserNotFound is returned when a provisioning call targets a user id that
+	// does not exist locally (the SQL reference impl provisions existing users; it
+	// does not mint principals).
+	ErrUserNotFound = errors.New("access: user not found")
+	// ErrProvisioningNoDB is returned when a SQLProvisioner is used without a DB.
+	ErrProvisioningNoDB = errors.New("access: provisioner has no database handle")
+)
+
+// ProvisionedUser is the desired state an external directory pushes for a user.
+// It is intentionally small: the activation/superuser flags policy code reads,
+// plus the full set of tenant memberships to reconcile. Email is carried for
+// audit/correlation but the reference impl does not rewrite it (the local email
+// is unique and owned by the local auth flow).
+type ProvisionedUser struct {
+	UserID    string
+	Email     string
+	Active    bool
+	Superuser bool
+	// TenantIDs is the authoritative membership set. A nil slice means "leave
+	// memberships untouched"; a non-nil (possibly empty) slice is reconciled
+	// exactly — extra memberships are removed, missing ones added.
+	TenantIDs []string
+}
+
+// Provisioner is the write-side enterprise seam (SCIM-shaped): users and group/
+// tenant memberships flow in from an external directory.
+type Provisioner interface {
+	// ProvisionUser applies the desired activation/superuser state (and, when
+	// TenantIDs is non-nil, the membership set) to an existing user. Returns
+	// ErrUserNotFound when the user does not exist locally.
+	ProvisionUser(ctx context.Context, u ProvisionedUser) error
+	// DeactivateUser flips users.is_active to false so the shared policy layer
+	// denies the principal everywhere. Returns ErrUserNotFound on an unknown id.
+	DeactivateUser(ctx context.Context, userID string) error
+	// SyncTenantMembership reconciles user_tenant to exactly tenantIDs (add the
+	// missing, remove the extra) in a single transaction.
+	SyncTenantMembership(ctx context.Context, userID string, tenantIDs []string) error
+}
+
+// NoopProvisioner is the default: every call is rejected with
+// ErrProvisioningDisabled, so users are managed only via local auth.
+type NoopProvisioner struct{}
+
+// ProvisionUser always reports that provisioning is disabled.
+func (NoopProvisioner) ProvisionUser(context.Context, ProvisionedUser) error {
+	return ErrProvisioningDisabled
+}
+
+// DeactivateUser always reports that provisioning is disabled.
+func (NoopProvisioner) DeactivateUser(context.Context, string) error {
+	return ErrProvisioningDisabled
+}
+
+// SyncTenantMembership always reports that provisioning is disabled.
+func (NoopProvisioner) SyncTenantMembership(context.Context, string, []string) error {
+	return ErrProvisioningDisabled
+}
+
+// SQLProvisioner is the reference provisioner: it writes directly to the same
+// users / user_tenant tables SQLPolicy reads, so its effects are visible to
+// every access decision without any other code change. Q rewrites Postgres
+// `$N` placeholders to positional `?` for sqlite (nil = no rewrite); each
+// placeholder index is emitted once with its own argument — never reused —
+// per the sqlite positional-rewrite contract.
+type SQLProvisioner struct {
+	DB *sql.DB
+	Q  QueryRewriter
+}
+
+func (p SQLProvisioner) rewrite(q string) string {
+	if p.Q == nil {
+		return q
+	}
+	return p.Q(q)
+}
+
+// ProvisionUser updates the activation and superuser flags of an existing user
+// and, when TenantIDs is non-nil, reconciles their tenant memberships.
+func (p SQLProvisioner) ProvisionUser(ctx context.Context, u ProvisionedUser) error {
+	if p.DB == nil {
+		return ErrProvisioningNoDB
+	}
+	if u.UserID == "" {
+		return ErrUserNotFound
+	}
+	res, err := p.DB.ExecContext(ctx,
+		p.rewrite("UPDATE users SET is_active = $1, is_superuser = $2 WHERE id = $3"),
+		u.Active, u.Superuser, u.UserID)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrUserNotFound
+	}
+	if u.TenantIDs != nil {
+		return p.SyncTenantMembership(ctx, u.UserID, u.TenantIDs)
+	}
+	return nil
+}
+
+// DeactivateUser sets users.is_active = false; the shared policy layer then
+// denies the principal everywhere (search, memory, workspace).
+func (p SQLProvisioner) DeactivateUser(ctx context.Context, userID string) error {
+	if p.DB == nil {
+		return ErrProvisioningNoDB
+	}
+	if userID == "" {
+		return ErrUserNotFound
+	}
+	res, err := p.DB.ExecContext(ctx,
+		p.rewrite("UPDATE users SET is_active = $1 WHERE id = $2"),
+		false, userID)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrUserNotFound
+	}
+	return nil
+}
+
+// SyncTenantMembership reconciles user_tenant to exactly tenantIDs in one
+// transaction: rows present in tenantIDs but not in the table are inserted,
+// rows present in the table but not in tenantIDs are deleted. An empty (non-nil)
+// tenantIDs clears all memberships.
+func (p SQLProvisioner) SyncTenantMembership(ctx context.Context, userID string, tenantIDs []string) error {
+	if p.DB == nil {
+		return ErrProvisioningNoDB
+	}
+	if userID == "" {
+		return ErrUserNotFound
+	}
+	desired := make(map[string]bool, len(tenantIDs))
+	for _, t := range tenantIDs {
+		if t != "" {
+			desired[t] = true
+		}
+	}
+
+	rows, err := p.DB.QueryContext(ctx,
+		p.rewrite("SELECT tenant_id FROM user_tenant WHERE user_id = $1"), userID)
+	if err != nil {
+		return err
+	}
+	current := map[string]bool{}
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			rows.Close()
+			return err
+		}
+		current[t] = true
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	tx, err := p.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	for t := range desired {
+		if current[t] {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx,
+			p.rewrite("INSERT INTO user_tenant(user_id, tenant_id) VALUES ($1, $2)"),
+			userID, t); err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+	for t := range current {
+		if desired[t] {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx,
+			p.rewrite("DELETE FROM user_tenant WHERE user_id = $1 AND tenant_id = $2"),
+			userID, t); err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// Compile-time guarantees that both provisioners satisfy the interface.
+var (
+	_ Provisioner = NoopProvisioner{}
+	_ Provisioner = SQLProvisioner{}
+)

--- a/Levara/pkg/access/provisioning_test.go
+++ b/Levara/pkg/access/provisioning_test.go
@@ -1,0 +1,195 @@
+package access
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	_ "github.com/ncruces/go-sqlite3/driver"
+)
+
+// newProvisioningTestDB builds the users / datasets / tenants / user_tenant
+// surface the provisioner and the activation gate share. user-a is an active
+// owner of the "payments" dataset and a member of tenant t1; root is an active
+// superuser; t1/t2/t3 are tenants.
+func newProvisioningTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", t.TempDir()+"/provision.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	for _, stmt := range []string{
+		`CREATE TABLE users (id TEXT PRIMARY KEY, is_active INTEGER NOT NULL DEFAULT 1, is_superuser INTEGER NOT NULL DEFAULT 0)`,
+		`CREATE TABLE datasets (id TEXT PRIMARY KEY, owner_id TEXT)`,
+		`CREATE TABLE dataset_shares (id TEXT PRIMARY KEY, dataset_id TEXT, user_id TEXT, role TEXT)`,
+		`CREATE TABLE tenants (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE user_tenant (user_id TEXT, tenant_id TEXT, PRIMARY KEY(user_id, tenant_id))`,
+		`INSERT INTO users(id, is_active, is_superuser) VALUES ('user-a', 1, 0), ('root', 1, 1)`,
+		`INSERT INTO datasets(id, owner_id) VALUES ('payments', 'user-a')`,
+		`INSERT INTO tenants(id) VALUES ('t1'), ('t2'), ('t3')`,
+		`INSERT INTO user_tenant(user_id, tenant_id) VALUES ('user-a', 't1')`,
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("exec %q: %v", stmt, err)
+		}
+	}
+	return db
+}
+
+func TestProvisionerDeactivationDeniesThroughPolicy(t *testing.T) {
+	db := newProvisioningTestDB(t)
+	policy := SQLPolicy{DB: db, Q: sqliteQ}
+	prov := SQLProvisioner{DB: db, Q: sqliteQ}
+	ctx := context.Background()
+
+	wsReq := WorkspaceRequest{UserID: "user-a", ProjectID: "payments", Action: ActionWrite}
+	dsActor := Actor{UserID: "user-a"}
+	dsRes := Resource{Kind: ResourceDataset, ID: "payments"}
+
+	// Active owner is allowed through both facades.
+	if d, err := policy.AuthorizeWorkspace(ctx, wsReq); err != nil || !d.Allowed || d.Reason != "owner" {
+		t.Fatalf("pre-deactivation workspace decision=%+v err=%v, want owner allow", d, err)
+	}
+	if d, err := policy.Authorize(ctx, dsActor, dsRes, ActionRead); err != nil || !d.Allowed || d.Reason != "dataset_access" {
+		t.Fatalf("pre-deactivation dataset decision=%+v err=%v, want dataset_access allow", d, err)
+	}
+
+	// Deactivate through the provisioner; the shared policy layer now denies both.
+	if err := prov.DeactivateUser(ctx, "user-a"); err != nil {
+		t.Fatalf("DeactivateUser err=%v", err)
+	}
+	if d, err := policy.AuthorizeWorkspace(ctx, wsReq); err != nil || d.Allowed || d.Reason != "user_inactive" {
+		t.Fatalf("post-deactivation workspace decision=%+v err=%v, want user_inactive deny", d, err)
+	}
+	if d, err := policy.Authorize(ctx, dsActor, dsRes, ActionRead); err != nil || d.Allowed || d.Reason != "user_inactive" {
+		t.Fatalf("post-deactivation dataset decision=%+v err=%v, want user_inactive deny", d, err)
+	}
+
+	// Reactivating via ProvisionUser restores access.
+	if err := prov.ProvisionUser(ctx, ProvisionedUser{UserID: "user-a", Active: true}); err != nil {
+		t.Fatalf("ProvisionUser reactivate err=%v", err)
+	}
+	if d, err := policy.AuthorizeWorkspace(ctx, wsReq); err != nil || !d.Allowed || d.Reason != "owner" {
+		t.Fatalf("post-reactivation workspace decision=%+v err=%v, want owner allow", d, err)
+	}
+}
+
+func TestProvisionerDeactivatesSuperuser(t *testing.T) {
+	db := newProvisioningTestDB(t)
+	policy := SQLPolicy{DB: db, Q: sqliteQ}
+	prov := SQLProvisioner{DB: db, Q: sqliteQ}
+	ctx := context.Background()
+
+	req := WorkspaceRequest{UserID: "root", ProjectID: "payments", Action: ActionWrite}
+
+	// The superuser bypass applies while active...
+	if d, err := policy.AuthorizeWorkspace(ctx, req); err != nil || !d.Allowed || d.Reason != "superuser" {
+		t.Fatalf("active superuser decision=%+v err=%v, want superuser allow", d, err)
+	}
+	// ...but the activation gate runs first, so a deactivated superuser is denied.
+	if err := prov.DeactivateUser(ctx, "root"); err != nil {
+		t.Fatalf("DeactivateUser(root) err=%v", err)
+	}
+	if d, err := policy.AuthorizeWorkspace(ctx, req); err != nil || d.Allowed || d.Reason != "user_inactive" {
+		t.Fatalf("deactivated superuser decision=%+v err=%v, want user_inactive deny", d, err)
+	}
+}
+
+func TestProvisionerUnknownUser(t *testing.T) {
+	db := newProvisioningTestDB(t)
+	prov := SQLProvisioner{DB: db, Q: sqliteQ}
+	ctx := context.Background()
+
+	if err := prov.DeactivateUser(ctx, "ghost"); !errors.Is(err, ErrUserNotFound) {
+		t.Fatalf("DeactivateUser(ghost) err=%v, want ErrUserNotFound", err)
+	}
+	if err := prov.ProvisionUser(ctx, ProvisionedUser{UserID: "ghost", Active: true}); !errors.Is(err, ErrUserNotFound) {
+		t.Fatalf("ProvisionUser(ghost) err=%v, want ErrUserNotFound", err)
+	}
+	if err := prov.ProvisionUser(ctx, ProvisionedUser{Active: true}); !errors.Is(err, ErrUserNotFound) {
+		t.Fatalf("ProvisionUser(empty id) err=%v, want ErrUserNotFound", err)
+	}
+}
+
+func TestProvisionerTenantMembershipSync(t *testing.T) {
+	db := newProvisioningTestDB(t)
+	policy := SQLPolicy{DB: db, Q: sqliteQ}
+	prov := SQLProvisioner{DB: db, Q: sqliteQ}
+	ctx := context.Background()
+
+	member := func(tenant string) bool {
+		t.Helper()
+		ok, err := policy.IsTenantMember(ctx, "user-a", tenant)
+		if err != nil {
+			t.Fatalf("IsTenantMember(%q) err=%v", tenant, err)
+		}
+		return ok
+	}
+
+	// Seeded with t1 only.
+	if !member("t1") || member("t2") || member("t3") {
+		t.Fatalf("initial membership wrong: t1=%v t2=%v t3=%v", member("t1"), member("t2"), member("t3"))
+	}
+
+	// Add t2 (keep t1).
+	if err := prov.SyncTenantMembership(ctx, "user-a", []string{"t1", "t2"}); err != nil {
+		t.Fatalf("sync add err=%v", err)
+	}
+	if !member("t1") || !member("t2") {
+		t.Fatalf("after add: t1=%v t2=%v, want both true", member("t1"), member("t2"))
+	}
+
+	// Drop t1 (keep t2).
+	if err := prov.SyncTenantMembership(ctx, "user-a", []string{"t2"}); err != nil {
+		t.Fatalf("sync drop err=%v", err)
+	}
+	if member("t1") || !member("t2") {
+		t.Fatalf("after drop: t1=%v t2=%v, want false,true", member("t1"), member("t2"))
+	}
+
+	// Empty (non-nil) set clears all memberships.
+	if err := prov.SyncTenantMembership(ctx, "user-a", []string{}); err != nil {
+		t.Fatalf("sync clear err=%v", err)
+	}
+	if member("t2") {
+		t.Fatalf("after clear: t2 still a member")
+	}
+
+	// ProvisionUser with a non-nil TenantIDs reconciles memberships too.
+	if err := prov.ProvisionUser(ctx, ProvisionedUser{UserID: "user-a", Active: true, TenantIDs: []string{"t3"}}); err != nil {
+		t.Fatalf("ProvisionUser with tenants err=%v", err)
+	}
+	if !member("t3") || member("t1") || member("t2") {
+		t.Fatalf("after provision: t1=%v t2=%v t3=%v, want only t3", member("t1"), member("t2"), member("t3"))
+	}
+}
+
+func TestNoopProvisionerRejects(t *testing.T) {
+	var prov Provisioner = NoopProvisioner{}
+	ctx := context.Background()
+	if err := prov.ProvisionUser(ctx, ProvisionedUser{UserID: "user-a"}); !errors.Is(err, ErrProvisioningDisabled) {
+		t.Fatalf("ProvisionUser err=%v, want ErrProvisioningDisabled", err)
+	}
+	if err := prov.DeactivateUser(ctx, "user-a"); !errors.Is(err, ErrProvisioningDisabled) {
+		t.Fatalf("DeactivateUser err=%v, want ErrProvisioningDisabled", err)
+	}
+	if err := prov.SyncTenantMembership(ctx, "user-a", nil); !errors.Is(err, ErrProvisioningDisabled) {
+		t.Fatalf("SyncTenantMembership err=%v, want ErrProvisioningDisabled", err)
+	}
+}
+
+func TestSQLProvisionerNoDB(t *testing.T) {
+	prov := SQLProvisioner{}
+	ctx := context.Background()
+	if err := prov.ProvisionUser(ctx, ProvisionedUser{UserID: "user-a"}); !errors.Is(err, ErrProvisioningNoDB) {
+		t.Fatalf("ProvisionUser err=%v, want ErrProvisioningNoDB", err)
+	}
+	if err := prov.DeactivateUser(ctx, "user-a"); !errors.Is(err, ErrProvisioningNoDB) {
+		t.Fatalf("DeactivateUser err=%v, want ErrProvisioningNoDB", err)
+	}
+	if err := prov.SyncTenantMembership(ctx, "user-a", nil); !errors.Is(err, ErrProvisioningNoDB) {
+		t.Fatalf("SyncTenantMembership err=%v, want ErrProvisioningNoDB", err)
+	}
+}

--- a/Levara/pkg/access/sso.go
+++ b/Levara/pkg/access/sso.go
@@ -1,0 +1,166 @@
+package access
+
+import (
+	"context"
+	"errors"
+)
+
+// Phase 4B: enterprise identity adapter boundary.
+//
+// An IdentityBridge maps an externally-authenticated subject (OIDC sub, SAML
+// NameID, …) onto a Levara Principal. The bridge owns only the mapping; it does
+// NOT verify the upstream assertion (that is the protocol adapter's job) and it
+// does NOT decide access — activation, ownership, and roles stay in SQLPolicy.
+// This keeps enterprise SSO addable as an adapter without touching core search,
+// memory, workspace, or MCP code: a new bridge is constructed and consulted at
+// the auth seam, the rest of the system keeps seeing a plain Actor.
+//
+// The default deployment wires LocalIdentityBridge, which performs no external
+// mapping at all — JWT and API keys remain the only credentials for personal,
+// solo_pro, and team profiles.
+
+var (
+	// ErrExternalIdentityUnsupported is returned by bridges that do not accept
+	// external identities (the local/default deployment). Callers treat it as
+	// "no SSO configured" and fall back to JWT/API-key auth.
+	ErrExternalIdentityUnsupported = errors.New("access: external identity not supported by this bridge")
+	// ErrSubjectNotMapped is returned when a bridge recognises the request shape
+	// but no local principal is linked to the external subject (and
+	// auto-provisioning is not configured).
+	ErrSubjectNotMapped = errors.New("access: external subject is not mapped to a Levara principal")
+	// ErrInvalidExternalIdentity is returned when the external identity is
+	// missing the issuer or subject needed to resolve it.
+	ErrInvalidExternalIdentity = errors.New("access: external identity must carry an issuer and subject")
+)
+
+// ExternalIdentity is the normalised claim set a protocol adapter (OIDC/SAML)
+// presents after it has verified the upstream assertion. It is transport- and
+// protocol-agnostic so the bridge interface is identical for OIDC and SAML.
+type ExternalIdentity struct {
+	// Issuer is the upstream identity provider (OIDC iss / SAML EntityID).
+	Issuer string
+	// Subject is the stable external subject (OIDC sub / SAML NameID). Together
+	// with Issuer it is the lookup key for the local principal.
+	Subject string
+	// Email and DisplayName are convenience claims; mapping must not rely on
+	// Email for identity because it can be reassigned upstream.
+	Email       string
+	DisplayName string
+	// Groups are the upstream group/role claims an adapter may translate into
+	// tenant memberships or the superuser flag.
+	Groups []string
+	// Attributes carries any remaining provider-specific claims verbatim.
+	Attributes map[string]string
+}
+
+// Validate reports whether the external identity carries the issuer+subject a
+// bridge needs to resolve it.
+func (e ExternalIdentity) Validate() error {
+	if e.Issuer == "" || e.Subject == "" {
+		return ErrInvalidExternalIdentity
+	}
+	return nil
+}
+
+// Principal is the resolved Levara identity a bridge maps an ExternalIdentity
+// onto. UserID is the canonical Levara user id policy code consumes. TenantIDs
+// lists every tenant the principal belongs to (the *active* tenant for a request
+// is still selected per-request by the tenant middleware, not by the bridge),
+// so Actor() deliberately does not pick one.
+type Principal struct {
+	UserID     string
+	Email      string
+	TenantIDs  []string
+	Superuser  bool
+	AuthMethod string // "oidc" | "saml" — stamped onto Actor.AuthMethod
+}
+
+// Actor projects the resolved principal into the shared Actor shape so policy
+// code never has to know the request originated from an SSO bridge. TenantID is
+// left empty on purpose: the active tenant is resolved per request, and a
+// principal may belong to several tenants (Principal.TenantIDs).
+func (p Principal) Actor() Actor {
+	return Actor{
+		UserID:     p.UserID,
+		AuthMethod: p.AuthMethod,
+		Superuser:  p.Superuser,
+	}
+}
+
+// IdentityBridge maps a verified external identity to a Levara principal.
+type IdentityBridge interface {
+	// ResolveExternal maps a verified external identity to a Levara principal.
+	// It returns ErrExternalIdentityUnsupported when the bridge does not accept
+	// external identities, ErrSubjectNotMapped when no local principal is linked,
+	// and ErrInvalidExternalIdentity when the identity lacks an issuer/subject.
+	ResolveExternal(ctx context.Context, ext ExternalIdentity) (Principal, error)
+	// Method is the auth-method label the bridge stamps onto resolved actors
+	// ("oidc", "saml", or "local" for the default bridge).
+	Method() string
+}
+
+// LocalIdentityBridge is the default bridge: it accepts no external identities,
+// so JWT and API keys remain the only credentials. Wiring it is equivalent to
+// "enterprise SSO not configured" and keeps the local-auth contract for
+// personal, solo_pro, and team profiles.
+type LocalIdentityBridge struct{}
+
+// ResolveExternal always reports that external identities are unsupported.
+func (LocalIdentityBridge) ResolveExternal(context.Context, ExternalIdentity) (Principal, error) {
+	return Principal{}, ErrExternalIdentityUnsupported
+}
+
+// Method returns "local".
+func (LocalIdentityBridge) Method() string { return "local" }
+
+// SubjectResolver maps a verified external identity to a Levara principal. An
+// enterprise deployment supplies its own resolver (backed by a directory, a
+// link table, or an attribute mapping); the resolver is the only thing an SSO
+// integration has to write — the rest of the bridge is generic.
+type SubjectResolver func(ext ExternalIdentity) (Principal, bool)
+
+// MappedIdentityBridge is the reusable reference bridge: it validates the
+// external identity, delegates the issuer+subject→principal mapping to an
+// injected SubjectResolver, and stamps Method onto the resolved principal. It
+// holds no storage of its own, so it composes with any backing store an
+// enterprise chooses without changing the bridge contract.
+type MappedIdentityBridge struct {
+	// AuthMethod is the label stamped onto resolved principals (e.g. "oidc").
+	AuthMethod string
+	// Resolver performs the external-subject → principal lookup.
+	Resolver SubjectResolver
+}
+
+// ResolveExternal validates the identity, runs the resolver, and stamps the
+// bridge's auth method onto the resolved principal.
+func (b MappedIdentityBridge) ResolveExternal(_ context.Context, ext ExternalIdentity) (Principal, error) {
+	if err := ext.Validate(); err != nil {
+		return Principal{}, err
+	}
+	if b.Resolver == nil {
+		return Principal{}, ErrSubjectNotMapped
+	}
+	p, ok := b.Resolver(ext)
+	if !ok || p.UserID == "" {
+		return Principal{}, ErrSubjectNotMapped
+	}
+	if p.AuthMethod == "" {
+		p.AuthMethod = b.Method()
+	}
+	return p, nil
+}
+
+// Method returns the configured auth method, defaulting to "sso" when unset.
+func (b MappedIdentityBridge) Method() string {
+	if b.AuthMethod == "" {
+		return "sso"
+	}
+	return b.AuthMethod
+}
+
+// Compile-time guarantees that the default and reference bridges satisfy the
+// interface, so an enterprise build can swap in its own without surprises.
+var (
+	_ IdentityBridge = LocalIdentityBridge{}
+	_ IdentityBridge = MappedIdentityBridge{}
+)

--- a/Levara/pkg/access/sso_test.go
+++ b/Levara/pkg/access/sso_test.go
@@ -1,0 +1,149 @@
+package access
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestLocalIdentityBridgeRejectsExternal(t *testing.T) {
+	var bridge IdentityBridge = LocalIdentityBridge{}
+	_, err := bridge.ResolveExternal(context.Background(), ExternalIdentity{
+		Issuer:  "https://idp.example",
+		Subject: "subject-1",
+	})
+	if !errors.Is(err, ErrExternalIdentityUnsupported) {
+		t.Fatalf("LocalIdentityBridge err=%v, want ErrExternalIdentityUnsupported", err)
+	}
+	if got := bridge.Method(); got != "local" {
+		t.Fatalf("LocalIdentityBridge.Method()=%q, want local", got)
+	}
+}
+
+func TestMappedIdentityBridgeResolvesSubject(t *testing.T) {
+	// The directory links external (issuer, subject) → a Levara principal.
+	bridge := MappedIdentityBridge{
+		AuthMethod: "oidc",
+		Resolver: func(ext ExternalIdentity) (Principal, bool) {
+			if ext.Issuer == "https://idp.example" && ext.Subject == "ext-42" {
+				return Principal{
+					UserID:    "user-a",
+					Email:     "a@example.com",
+					TenantIDs: []string{"tenant-1", "tenant-2"},
+					Superuser: true,
+				}, true
+			}
+			return Principal{}, false
+		},
+	}
+
+	p, err := bridge.ResolveExternal(context.Background(), ExternalIdentity{
+		Issuer:  "https://idp.example",
+		Subject: "ext-42",
+		Email:   "a@example.com",
+		Groups:  []string{"eng"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveExternal err=%v, want nil", err)
+	}
+	if p.UserID != "user-a" {
+		t.Fatalf("principal UserID=%q, want user-a", p.UserID)
+	}
+	if p.AuthMethod != "oidc" {
+		t.Fatalf("principal AuthMethod=%q, want oidc (stamped by bridge)", p.AuthMethod)
+	}
+	if len(p.TenantIDs) != 2 || !p.Superuser {
+		t.Fatalf("principal tenants/superuser not carried through: %+v", p)
+	}
+
+	// Actor() projects identity for policy code but never pins an active tenant
+	// (that is resolved per request), and carries the auth method + superuser.
+	actor := p.Actor()
+	if actor.UserID != "user-a" || actor.AuthMethod != "oidc" || !actor.Superuser {
+		t.Fatalf("Actor()=%+v, want user-a/oidc/superuser", actor)
+	}
+	if actor.TenantID != "" {
+		t.Fatalf("Actor().TenantID=%q, want empty (active tenant is per-request)", actor.TenantID)
+	}
+}
+
+func TestMappedIdentityBridgeUnmappedSubject(t *testing.T) {
+	bridge := MappedIdentityBridge{
+		AuthMethod: "saml",
+		Resolver:   func(ExternalIdentity) (Principal, bool) { return Principal{}, false },
+	}
+	_, err := bridge.ResolveExternal(context.Background(), ExternalIdentity{
+		Issuer:  "https://idp.example",
+		Subject: "unknown",
+	})
+	if !errors.Is(err, ErrSubjectNotMapped) {
+		t.Fatalf("unmapped subject err=%v, want ErrSubjectNotMapped", err)
+	}
+}
+
+func TestMappedIdentityBridgeRejectsEmptySubject(t *testing.T) {
+	// A resolver that would happily map anything must never be consulted when the
+	// external identity is missing its issuer/subject lookup key.
+	bridge := MappedIdentityBridge{
+		Resolver: func(ExternalIdentity) (Principal, bool) {
+			t.Fatal("resolver must not run for an invalid external identity")
+			return Principal{}, true
+		},
+	}
+	for _, ext := range []ExternalIdentity{
+		{Issuer: "https://idp.example"}, // no subject
+		{Subject: "ext-1"},              // no issuer
+		{},                              // neither
+	} {
+		if _, err := bridge.ResolveExternal(context.Background(), ext); !errors.Is(err, ErrInvalidExternalIdentity) {
+			t.Fatalf("ResolveExternal(%+v) err=%v, want ErrInvalidExternalIdentity", ext, err)
+		}
+	}
+}
+
+func TestMappedIdentityBridgeNilResolver(t *testing.T) {
+	bridge := MappedIdentityBridge{AuthMethod: "oidc"}
+	_, err := bridge.ResolveExternal(context.Background(), ExternalIdentity{
+		Issuer:  "https://idp.example",
+		Subject: "ext-1",
+	})
+	if !errors.Is(err, ErrSubjectNotMapped) {
+		t.Fatalf("nil resolver err=%v, want ErrSubjectNotMapped", err)
+	}
+}
+
+func TestMappedIdentityBridgeResolverEmptyUserID(t *testing.T) {
+	// A resolver that reports ok=true but yields no UserID is treated as unmapped:
+	// an empty principal must never reach policy code.
+	bridge := MappedIdentityBridge{
+		Resolver: func(ExternalIdentity) (Principal, bool) { return Principal{Email: "a@x"}, true },
+	}
+	_, err := bridge.ResolveExternal(context.Background(), ExternalIdentity{
+		Issuer:  "https://idp.example",
+		Subject: "ext-1",
+	})
+	if !errors.Is(err, ErrSubjectNotMapped) {
+		t.Fatalf("empty-UserID principal err=%v, want ErrSubjectNotMapped", err)
+	}
+}
+
+func TestMappedIdentityBridgeMethodDefault(t *testing.T) {
+	// An unset AuthMethod defaults to "sso", and that default is stamped onto a
+	// resolved principal that did not carry its own method.
+	bridge := MappedIdentityBridge{
+		Resolver: func(ExternalIdentity) (Principal, bool) { return Principal{UserID: "user-a"}, true },
+	}
+	if got := bridge.Method(); got != "sso" {
+		t.Fatalf("Method()=%q, want sso default", got)
+	}
+	p, err := bridge.ResolveExternal(context.Background(), ExternalIdentity{
+		Issuer:  "https://idp.example",
+		Subject: "ext-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.AuthMethod != "sso" {
+		t.Fatalf("resolved principal AuthMethod=%q, want sso default", p.AuthMethod)
+	}
+}

--- a/Levara/pkg/profile/profile.go
+++ b/Levara/pkg/profile/profile.go
@@ -20,6 +20,11 @@ type Config struct {
 	SyncTokenSet   bool
 	TenantEnforced bool
 	AuditSinkSet   bool
+	// SSOBridgeConfigured reports that an enterprise identity bridge (OIDC/SAML)
+	// is wired. It satisfies the enterprise auth requirement in lieu of local
+	// required auth: an SSO-fronted deployment authenticates at the bridge, so
+	// RequireAuth may be off without weakening the profile.
+	SSOBridgeConfigured bool
 }
 
 // Finding levels. Warnings are advisory; errors are fatal in strict mode.
@@ -100,7 +105,7 @@ func validate(cfg Config, level string) []Finding {
 		if !isPostgres(cfg) {
 			findings = append(findings, require("enterprise_requires_postgres", "enterprise profile should use Postgres or managed SQL"))
 		}
-		if !cfg.RequireAuth {
+		if !cfg.RequireAuth && !cfg.SSOBridgeConfigured {
 			findings = append(findings, require("enterprise_requires_auth", "enterprise profile should run with required auth or an SSO bridge"))
 		}
 		if !cfg.JWTSecretSet {

--- a/Levara/pkg/profile/profile_test.go
+++ b/Levara/pkg/profile/profile_test.go
@@ -86,6 +86,37 @@ func TestValidateStrictEnterpriseFailsFast(t *testing.T) {
 	}
 }
 
+func TestValidateEnterpriseSSOBridgeSatisfiesAuth(t *testing.T) {
+	// An SSO-fronted enterprise authenticates at the bridge, so a configured
+	// bridge satisfies the auth requirement even with RequireAuth off.
+	safe := ValidateStrict(Config{
+		Profile: Enterprise, DBProvider: "postgres", HasDB: true,
+		RequireAuth: false, SSOBridgeConfigured: true,
+		JWTSecretSet: true, TenantEnforced: true, AuditSinkSet: true,
+	})
+	if HasError(safe) {
+		t.Fatalf("enterprise with SSO bridge in lieu of required auth unexpectedly fatal: %+v", safe)
+	}
+
+	// With neither required auth nor an SSO bridge, the auth finding fires.
+	bad := ValidateStrict(Config{
+		Profile: Enterprise, DBProvider: "postgres", HasDB: true,
+		JWTSecretSet: true, TenantEnforced: true, AuditSinkSet: true,
+	})
+	if !HasError(bad) {
+		t.Fatalf("enterprise without auth or SSO bridge not fatal: %+v", bad)
+	}
+	foundAuth := false
+	for _, f := range bad {
+		if f.Code == "enterprise_requires_auth" {
+			foundAuth = true
+		}
+	}
+	if !foundAuth {
+		t.Fatalf("expected enterprise_requires_auth finding, got %+v", bad)
+	}
+}
+
 func TestValidateStrictSoloProSyncWithoutTokenFailsFast(t *testing.T) {
 	got := ValidateStrict(Config{Profile: SoloPro, SyncEnabled: true})
 	if !HasError(got) {

--- a/from_cod.md
+++ b/from_cod.md
@@ -111,8 +111,10 @@ Acceptance criteria:
 
 - [x] Policy code never reads Fiber locals directly.
 - [x] Tests can construct actors without HTTP requests.
-- [ ] Per-agent credentials can be modeled without adding handler-specific
-  branches.
+- [x] Per-agent credentials can be modeled without adding handler-specific
+  branches (Phase 4B: `access.Provisioner` provisions principals — including
+  per-agent ones — by mutating the shared `users`/`user_tenant` tables that
+  `SQLPolicy` already reads; no per-handler branch).
 
 ### Phase 3A: Runtime Profile Enforcement
 
@@ -214,19 +216,34 @@ Acceptance criteria:
 
 Goal: add enterprise identity as adapters, not as handler logic.
 
-- [ ] Define OIDC/SAML bridge interface that maps external subject to Levara
-  principal.
-- [ ] Define SCIM provisioning interface for users, groups, and tenant
-  memberships.
-- [ ] Add contract tests for external subject mapping and deactivation.
-- [ ] Keep JWT/API-key local auth as the default for `personal`, `solo_pro`,
-  and `team`.
+- [x] Define OIDC/SAML bridge interface that maps external subject to Levara
+  principal (`access.IdentityBridge` + `ExternalIdentity`→`Principal`;
+  `LocalIdentityBridge` default no-ops external auth, `MappedIdentityBridge` +
+  `SubjectResolver` is the reusable reference; protocol-agnostic so OIDC and
+  SAML share one seam).
+- [x] Define SCIM provisioning interface for users, groups, and tenant
+  memberships (`access.Provisioner`: `ProvisionUser`/`DeactivateUser`/
+  `SyncTenantMembership`; `NoopProvisioner` default, `SQLProvisioner` reference
+  reconciles `users`/`user_tenant` in a tx).
+- [x] Add contract tests for external subject mapping and deactivation
+  (`pkg/access/sso_test.go` subject mapping + validation; `provisioning_test.go`
+  deactivation denied through `AuthorizeWorkspace`/`Authorize` incl. superuser,
+  tenant set-diff sync).
+- [x] Keep JWT/API-key local auth as the default for `personal`, `solo_pro`,
+  and `team` (default deployment wires `LocalIdentityBridge` + `NoopProvisioner`;
+  no SSO unless `LEVARA_SSO_BRIDGE` is set).
 
 Acceptance criteria:
 
-- [ ] Enterprise SSO can be added without changing core search, memory,
-  workspace, or MCP tool code.
-- [ ] Deactivated users lose access through the shared policy layer.
+- [x] Enterprise SSO can be added without changing core search, memory,
+  workspace, or MCP tool code (the bridge/provisioner are constructed at the
+  auth/provisioning seam; the rest of the system keeps seeing a plain `Actor`
+  and the existing `users`/`user_tenant` tables — no new table/migration, so
+  the API contract is unchanged).
+- [x] Deactivated users lose access through the shared policy layer
+  (`SQLPolicy.IsActive` gate in `AuthorizeWorkspace` + the dataset branch of
+  `Authorize`; `users.is_active = false` denies with reason `user_inactive`
+  before ownership/share/superuser are considered).
 
 ### Phase 4C: Enterprise Storage And KMS
 


### PR DESCRIPTION
## Phase 4B — Enterprise Identity Adapters

Adds the enterprise identity **boundary** as pluggable adapters, so SSO/SCIM
can be wired in later without touching core search / memory / workspace / MCP
code. JWT + API-key local auth stays the default for personal/solo_pro/team.

### What's in
- **`pkg/access/sso.go` — OIDC/SAML bridge seam.** `IdentityBridge` maps a
  *verified* `ExternalIdentity` (OIDC `sub` / SAML `NameID`) to a Levara
  `Principal`. Protocol-agnostic, so OIDC and SAML share one interface.
  - `LocalIdentityBridge` — default no-op; rejects external identities
    (`ErrExternalIdentityUnsupported`), so local creds remain the only path.
  - `MappedIdentityBridge` + `SubjectResolver` — reusable reference impl;
    validates the assertion, resolves subject→principal, stamps `AuthMethod`.
  - The bridge **maps only** — it never verifies assertions or makes access
    decisions. `Principal.Actor()` carries no tenant (active tenant is
    per-request).
- **`pkg/access/provisioning.go` — SCIM provisioning seam.** `Provisioner`
  covers users/groups/tenant memberships.
  - `NoopProvisioner` — default; everything returns `ErrProvisioningDisabled`.
  - `SQLProvisioner` — reference impl reconciling the **shared**
    `users`/`user_tenant` tables `SQLPolicy` already reads (membership sync is
    a set-diff in one tx). A provisioned/deactivated principal therefore takes
    effect everywhere with **no per-handler branch**. Closes the Phase 2B
    per-agent-credentials tail.
- **Activation gate.** `SQLPolicy.IsActive` (`COALESCE(is_active,true)`,
  fail-open on missing row, mirrors `IsSuperuser`) is wired into
  `AuthorizeWorkspace` and the dataset branch of `Authorize`. A deactivated
  user is denied with reason `user_inactive` **before** ownership / share /
  superuser are considered — deactivation revokes access through the one shared
  policy layer.
- **Profile.** `SSOBridgeConfigured` satisfies the enterprise required-auth
  finding in lieu of local auth; bootstrap reads `LEVARA_SSO_BRIDGE` (the flag
  feeds *validation only* — no bridge is instantiated until protocol adapters
  land).

### Tests
- Subject-mapping + validation contracts (local rejects external; mapped
  resolves / rejects unmapped / empty subject / nil resolver / empty userID;
  method default).
- Deactivation end-to-end through **both** policy facades, including the
  superuser case (gate runs before the superuser bypass) and unknown-user
  fail-open.
- Tenant membership set-diff sync (add / drop / clear / provision-reconcile);
  Noop + no-DB guards.
- Profile SSO-satisfies-auth (and the neither-set → `enterprise_requires_auth`
  case); `LEVARA_SSO_BRIDGE` truth table.
- Mirrored `is_active` into the `internal/http` graph test schema (production
  `schema.go` already declares it).

### Scope guards
- **No new table/migration and no `APIConfig` field** → API contract unchanged
  (`make contract-check` clean), config-groups DeepEqual guard untouched.
- No live OIDC/SCIM endpoints — this is the interface + default + SQL reference
  + contract tests only.

### Acceptance
- ✅ Enterprise SSO becomes addable without changing core search/memory/
  workspace/MCP code (adapters only).
- ✅ Deactivated users lose access through the shared policy layer.
- ✅ Per-agent credentials modeled without handler-specific branches (Phase 2B
  tail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)