### PR TITLE
fix(mcp): make stdio bridge survive a backend restart

### DIFF
--- a/Levara/cmd/server/mcp_stdio.go
+++ b/Levara/cmd/server/mcp_stdio.go
@@ -12,11 +12,28 @@
 //
 // Auth: --token flag overrides LEVARA_TOKEN env. Empty token means no
 // Authorization header is sent (dev-mode servers without -require-auth).
+//
+// Resilience to a backend restart (the "MCP call hangs ~forever after the
+// local :8081 backend is restarted" bug):
+//   - Keep-alives are disabled, so a backend restart can never strand the
+//     bridge on a dead pooled TCP socket. Each request opens a fresh
+//     connection — free on loopback — so it either succeeds promptly or
+//     fails fast with connection-refused.
+//   - Forwarding errors are echoed back with the *original* JSON-RPC request
+//     id (not id=null). An MCP client matches responses to requests by id, so
+//     an id=null error never unblocks the pending call — that mismatch, not
+//     the bridge itself, is what left "Calling levara…" spinning for an hour.
+//   - A transport failure drops the cached Mcp-Session-Id, so the next request
+//     (the client re-initializes) establishes a fresh session instead of
+//     replaying a session the restarted backend has never heard of.
+//   - A watchdog exits the process if our parent (the MCP client) dies, so
+//     abandoned bridges don't pile up across sessions.
 package main
 
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -60,13 +77,38 @@ func runMCPStdio(args []string) error {
 		return fmt.Errorf("--token and --api-key are mutually exclusive")
 	}
 
+	// Disable keep-alives: a pooled connection to the local backend goes dead
+	// the moment the backend restarts, and the next request would either hang
+	// until the timeout or fail — either way stranding the session. A fresh
+	// connection per request is negligible on loopback and immune to that.
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.DisableKeepAlives = true
+
 	br := &bridge{
 		backend: backend + "/mcp",
 		token:   token,
 		apiKey:  apiKey,
-		client:  &http.Client{Timeout: timeout},
+		client:  &http.Client{Timeout: timeout, Transport: tr},
 	}
+
+	// Exit if the MCP client that spawned us goes away, so we don't leak an
+	// orphaned bridge holding a session. stdin EOF is the normal shutdown
+	// signal; this covers the case where the parent dies without closing it.
+	go watchParent(os.Getppid())
+
 	return br.run(os.Stdin, os.Stdout)
+}
+
+// watchParent polls the parent PID and terminates the process once it changes,
+// which on Unix means the original parent exited and we were reparented (to
+// launchd/init). Cheap (a getppid syscall every 2s) and platform-portable.
+func watchParent(orig int) {
+	for {
+		time.Sleep(2 * time.Second)
+		if os.Getppid() != orig {
+			os.Exit(0)
+		}
+	}
 }
 
 type bridge struct {
@@ -93,12 +135,11 @@ func (b *bridge) run(in io.Reader, out io.Writer) error {
 		}
 		respBody, err := b.forward(line)
 		if err != nil {
-			// Forwarding errors are surfaced as JSON-RPC errors on stdout
-			// so the MCP client sees a structured failure instead of a
-			// dropped connection. The request ID is not recovered here —
-			// JSON-RPC permits id=null for transport-level errors.
-			fmt.Fprintf(writer, `{"jsonrpc":"2.0","id":null,"error":{"code":-32000,"message":%q}}`+"\n", err.Error())
-			writer.Flush()
+			// Surface forwarding failures as JSON-RPC errors on stdout so the
+			// client sees a structured failure instead of a dropped connection.
+			// Echo the *request* id: a client matches responses to requests by
+			// id, so an id=null error would never unblock the pending call.
+			writeRPCError(writer, requestID(line), err)
 			continue
 		}
 		writer.Write(respBody)
@@ -130,6 +171,12 @@ func (b *bridge) forward(payload []byte) ([]byte, error) {
 
 	resp, err := b.client.Do(req)
 	if err != nil {
+		// A transport failure means the connection (and, after a restart, the
+		// server-side session) is gone. Drop the cached session id so the next
+		// request re-establishes a fresh one instead of replaying a dead one.
+		b.mu.Lock()
+		b.sessionID = ""
+		b.mu.Unlock()
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -153,4 +200,29 @@ func truncate(b []byte, n int) string {
 		return string(b)
 	}
 	return string(b[:n]) + "…"
+}
+
+// requestID extracts the raw JSON-RPC id from a request line so failures can be
+// echoed back against the call the client is waiting on. Notifications (no id)
+// and unparseable lines yield null.
+func requestID(payload []byte) json.RawMessage {
+	var probe struct {
+		ID json.RawMessage `json:"id"`
+	}
+	if json.Unmarshal(payload, &probe) != nil || len(probe.ID) == 0 {
+		return json.RawMessage("null")
+	}
+	return probe.ID
+}
+
+// writeRPCError emits a JSON-RPC error response carrying the given id. id is raw
+// JSON (a number, string, or null) and the message is JSON-escaped so the line
+// is always valid regardless of what the underlying error text contains.
+func writeRPCError(w *bufio.Writer, id json.RawMessage, err error) {
+	if len(id) == 0 {
+		id = json.RawMessage("null")
+	}
+	msg, _ := json.Marshal(err.Error())
+	fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"error":{"code":-32000,"message":%s}}`+"\n", id, msg)
+	w.Flush()
 }

--- a/Levara/cmd/server/mcp_stdio_test.go
+++ b/Levara/cmd/server/mcp_stdio_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 // fakeMCPBackend captures forwarded requests and returns scripted bodies.
@@ -186,6 +187,83 @@ func TestBridge_BackendErrorSurfacesAsJSONRPCError(t *testing.T) {
 	msg, _ := errObj["message"].(string)
 	if !strings.Contains(msg, "503") {
 		t.Errorf("error.message = %q, want it to include 503 status", msg)
+	}
+}
+
+// Regression: the symptom that left "Calling levara…" spinning for an hour was
+// the bridge replying to a failed forward with id=null. An MCP client matches
+// responses to requests by id, so the pending call never resolves. The error
+// must carry the original request id.
+func TestBridge_ErrorResponseEchoesRequestID(t *testing.T) {
+	fake, srv := newFakeMCPBackend()
+	defer srv.Close()
+	fake.failStatus = 503
+	fake.responses = [][]byte{[]byte(`upstream down`)}
+
+	br := &bridge{backend: srv.URL + "/mcp", client: srv.Client()}
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":7,"method":"tools/call"}` + "\n")
+	var out bytes.Buffer
+	if err := br.run(in, &out); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var r map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &r); err != nil {
+		t.Fatalf("output not JSON: %v (%q)", err, out.String())
+	}
+	if id, _ := r["id"].(float64); id != 7 {
+		t.Errorf("error response id = %v (%T), want 7 — client matches by id", r["id"], r["id"])
+	}
+}
+
+// A string request id must round-trip unquoted-and-then-requoted correctly.
+func TestBridge_ErrorResponseEchoesStringID(t *testing.T) {
+	fake, srv := newFakeMCPBackend()
+	defer srv.Close()
+	fake.failStatus = 500
+	fake.responses = [][]byte{[]byte(`boom`)}
+
+	br := &bridge{backend: srv.URL + "/mcp", client: srv.Client()}
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":"abc-1","method":"ping"}` + "\n")
+	var out bytes.Buffer
+	_ = br.run(in, &out)
+	var r map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out.String())), &r); err != nil {
+		t.Fatalf("output not JSON: %v (%q)", err, out.String())
+	}
+	if id, _ := r["id"].(string); id != "abc-1" {
+		t.Errorf("error response id = %v, want \"abc-1\"", r["id"])
+	}
+}
+
+// After a transport failure (backend gone) the cached session id must be
+// cleared so the next request doesn't replay a session the restarted backend
+// has never heard of.
+func TestBridge_TransportErrorClearsSession(t *testing.T) {
+	br := &bridge{
+		backend: "http://127.0.0.1:1/mcp", // port 1: connection refused, fast
+		client:  &http.Client{Timeout: 2 * time.Second},
+	}
+	br.sessionID = "stale-session"
+	if _, err := br.forward([]byte(`{"jsonrpc":"2.0","id":1,"method":"ping"}`)); err == nil {
+		t.Fatal("expected a transport error against an unreachable backend")
+	}
+	if br.sessionID != "" {
+		t.Errorf("sessionID = %q, want cleared after transport error", br.sessionID)
+	}
+}
+
+func TestRequestID(t *testing.T) {
+	cases := map[string]string{
+		`{"id":42,"method":"x"}`:      "42",
+		`{"id":"s","method":"x"}`:     `"s"`,
+		`{"method":"notify"}`:         "null", // notification: no id
+		`not json at all`:             "null",
+		`{"id":null,"method":"ping"}`: "null",
+	}
+	for in, want := range cases {
+		if got := string(requestID([]byte(in))); got != want {
+			t.Errorf("requestID(%s) = %s, want %s", in, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

The `levara mcp serve` stdio↔HTTP bridge left an MCP client's call (`Calling levara…`) spinning for **over an hour** after the local backend was restarted (e.g. a `launchctl bootout/bootstrap` during a re-embed cutover). Root cause was **not** the embed model — it was the bridge.

## Root cause

After a backend restart the bridge's pooled keep-alive socket is dead. The next request hangs until the 30s timeout, then the bridge replies with `"id":null`. An MCP client matches responses to requests **by id**, so an `id:null` error never resolves the pending `id:N` call → the session hangs forever.

## Fix

- **Echo the request id** on forward failures (number/string/null) so the client actually unblocks. *(the visible-hang fix)*
- **Disable keep-alives** — a fresh connection per request is free on loopback and either succeeds promptly or fails fast, so a backend restart can't strand the bridge on a dead socket.
- **Clear the cached `Mcp-Session-Id`** on transport failure so the next request re-establishes a fresh session instead of replaying one the restarted backend never heard of.
- **Parent-death watchdog** exits the bridge when the MCP client that spawned it goes away, so orphaned bridges stop accumulating across sessions.

## Tests

`TestBridge_ErrorResponseEchoesRequestID` (numeric), `TestBridge_ErrorResponseEchoesStringID`, `TestBridge_TransportErrorClearsSession`, `TestRequestID`. Existing bridge tests unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)