### PR TITLE
fix(mcp): cognify-chunk RBAC + sync memory index + MCP session adopt-on-restart

### DIFF
--- a/Levara/internal/http/api_cognify.go
+++ b/Levara/internal/http/api_cognify.go
@@ -8,6 +8,8 @@ package http
 
 import (
 	"bufio"
+	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -24,6 +26,36 @@ import (
 	"github.com/stek0v/levara/pkg/orchestrator"
 	"github.com/stek0v/levara/pkg/runreg"
 )
+
+// ensureCognifyDataset get-or-creates a per-(owner,collection) dataset owned
+// by the caller and returns its id, so chunks/graph rows this run stamps are
+// reachable through search's RBAC gate (filterByAllowedDatasets keeps a hit
+// only when its dataset_id is "" or in the caller's allowed-set). An
+// unregistered ephemeral runID belongs to neither, so without this every
+// cognified chunk is silently dropped on read-back. Mirrors the MCP-surface
+// helper ensureCognifyDatasetID (pkg/mcp/tool_cognify.go). Best-effort: any
+// DB error falls back to the ephemeral id unchanged.
+func ensureCognifyDataset(ctx context.Context, db *sql.DB, owner, collection, fallbackID string) string {
+	name := fmt.Sprintf("__cognify__:%s:%s", owner, collection)
+
+	var existing string
+	if err := db.QueryRowContext(ctx, Q(`SELECT id FROM datasets WHERE name = $1`), name).Scan(&existing); err == nil && existing != "" {
+		return existing
+	}
+
+	now := time.Now().UTC()
+	if _, err := db.ExecContext(ctx,
+		Q(`INSERT INTO datasets (id, name, owner_id, created_at, updated_at)
+		   VALUES ($1, $2, $3, $4, $5) ON CONFLICT (name) DO NOTHING`),
+		fallbackID, name, owner, now, now); err != nil {
+		return fallbackID
+	}
+	var resolved string
+	if err := db.QueryRowContext(ctx, Q(`SELECT id FROM datasets WHERE name = $1`), name).Scan(&resolved); err == nil && resolved != "" {
+		return resolved
+	}
+	return fallbackID
+}
 
 // cognifyHandler — POST /cognify. Kicks off an async pipeline and returns
 // a run ID immediately; progress is available via /cognify/:id/status
@@ -140,33 +172,40 @@ func cognifyHandler(cfg APIConfig) fiber.Handler {
 		}
 		userID, _ := c.Locals("user_id").(string)
 
+		// Resolve the dataset id chunks/graph rows are stamped with. An
+		// explicit dataset wins; otherwise register a per-(owner,collection)
+		// cognify dataset owned by the caller so search's RBAC gate
+		// (filterByAllowedDatasets) does not silently drop every chunk this
+		// run produces. A bare ephemeral runID is in no caller's allowed-set.
+		effectiveDatasetID := runID
+		if len(allDatasetIDs) > 0 {
+			effectiveDatasetID = allDatasetIDs[0]
+		} else if cfg.DB != nil {
+			effectiveDatasetID = ensureCognifyDataset(reqCtx, cfg.DB, userID, collection, runID)
+		}
+
 		// Build orchestrator config from server config + request overrides
 		pipeCfg := orchestrator.Config{
-			ChunkStrategy:    "merged",
-			MinChunkChars:    50,
-			MaxChunkChars:    2000,
-			LLMEndpoint:      os.Getenv("LLM_ENDPOINT"),
-			LLMModel:         os.Getenv("LLM_MODEL"),
-			LLMConcurrency:   1,
-			EmbedEndpoint:    cfg.EmbedEndpoint,
-			EmbedModel:       cfg.EmbedModel,
-			EmbedClient:      cfg.EmbedClient, // T3 follow-up: reuse shared TCP pool through the pipeline
-			Neo4jURL:         cfg.Neo4jCfg.Neo4jURL,
-			Neo4jUser:        cfg.Neo4jCfg.Neo4jUser,
-			Neo4jPassword:    cfg.Neo4jCfg.Neo4jPassword,
-			Neo4jDatabase:    cfg.Neo4jCfg.Neo4jDatabase,
-			Collection:       collection,
-			Collections:      cfg.Collections,
-			BM25Indexes:      cfg.BM25Indexes,
-			GenerateTriplets: !req.SkipGraph,
-			SkipGraph:        req.SkipGraph,
-			SystemPrompt:     sessionContext,
-			DatasetID: func() string {
-				if len(allDatasetIDs) > 0 {
-					return allDatasetIDs[0]
-				}
-				return runID
-			}(),
+			ChunkStrategy:       "merged",
+			MinChunkChars:       50,
+			MaxChunkChars:       2000,
+			LLMEndpoint:         os.Getenv("LLM_ENDPOINT"),
+			LLMModel:            os.Getenv("LLM_MODEL"),
+			LLMConcurrency:      1,
+			EmbedEndpoint:       cfg.EmbedEndpoint,
+			EmbedModel:          cfg.EmbedModel,
+			EmbedClient:         cfg.EmbedClient, // T3 follow-up: reuse shared TCP pool through the pipeline
+			Neo4jURL:            cfg.Neo4jCfg.Neo4jURL,
+			Neo4jUser:           cfg.Neo4jCfg.Neo4jUser,
+			Neo4jPassword:       cfg.Neo4jCfg.Neo4jPassword,
+			Neo4jDatabase:       cfg.Neo4jCfg.Neo4jDatabase,
+			Collection:          collection,
+			Collections:         cfg.Collections,
+			BM25Indexes:         cfg.BM25Indexes,
+			GenerateTriplets:    !req.SkipGraph,
+			SkipGraph:           req.SkipGraph,
+			SystemPrompt:        sessionContext,
+			DatasetID:           effectiveDatasetID,
 			DB:                  cfg.DB,
 			LLMCache:            cfg.LLMCache,
 			LLMProvider:         cfg.LLMProvider,

--- a/Levara/internal/http/api_cognify_dataset_test.go
+++ b/Levara/internal/http/api_cognify_dataset_test.go
@@ -1,0 +1,92 @@
+package http
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/ncruces/go-sqlite3/driver"
+)
+
+// cognifyDatasetDB opens an in-memory-ish sqlite DB with just the datasets
+// schema ensureCognifyDataset writes (name UNIQUE so ON CONFLICT(name) has an
+// index), and pins the dialect to SQLite for Q() placeholder rewriting.
+func cognifyDatasetDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite3", "file:"+filepath.Join(dir, "cog.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		os.RemoveAll(dir)
+	})
+	if _, err := db.Exec(`CREATE TABLE datasets (
+		id TEXT PRIMARY KEY,
+		name TEXT UNIQUE,
+		owner_id TEXT,
+		created_at TIMESTAMP,
+		updated_at TIMESTAMP
+	)`); err != nil {
+		t.Fatalf("create datasets: %v", err)
+	}
+	SetDBProvider(DBSQLite)
+	t.Cleanup(func() { SetDBProvider(DBPostgres) })
+	return db
+}
+
+// ensureCognifyDataset is the REST mirror of the MCP helper: it must
+// get-or-create exactly one caller-owned datasets row per (owner,collection)
+// so search's RBAC gate doesn't drop the chunks this run stamps. Without it,
+// an unregistered ephemeral runID is in no caller's allowed-set and every
+// cognified chunk reads back empty (the P2.1/Issue-2 regression).
+func TestEnsureCognifyDataset_GetOrCreateIsIdempotent(t *testing.T) {
+	db := cognifyDatasetDB(t)
+	ctx := context.Background()
+
+	id1 := ensureCognifyDataset(ctx, db, "alice", "docs", "run-1")
+	id2 := ensureCognifyDataset(ctx, db, "alice", "docs", "run-2")
+
+	if id1 != "run-1" {
+		t.Errorf("first id = %q, want fallback run-1 (created the row)", id1)
+	}
+	if id2 != id1 {
+		t.Errorf("second id = %q, want %q (reuse, not a fresh runID)", id2, id1)
+	}
+
+	var rows int
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM datasets WHERE name = '__cognify__:alice:docs'").Scan(&rows); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("datasets rows = %d, want exactly 1 (no per-run accretion)", rows)
+	}
+}
+
+func TestEnsureCognifyDataset_ScopesByOwnerAndCollection(t *testing.T) {
+	db := cognifyDatasetDB(t)
+	ctx := context.Background()
+
+	alice := ensureCognifyDataset(ctx, db, "alice", "docs", "r-a")
+	bob := ensureCognifyDataset(ctx, db, "bob", "docs", "r-b")
+	aliceOther := ensureCognifyDataset(ctx, db, "alice", "notes", "r-a2")
+
+	if alice == bob {
+		t.Errorf("alice and bob share dataset id %q; owner scoping broken", alice)
+	}
+	if alice == aliceOther {
+		t.Errorf("alice's docs and notes share id %q; collection scoping broken", alice)
+	}
+
+	var owner string
+	if err := db.QueryRow("SELECT owner_id FROM datasets WHERE id = ?", alice).Scan(&owner); err != nil {
+		t.Fatalf("select owner: %v", err)
+	}
+	if owner != "alice" {
+		t.Errorf("owner_id = %q, want alice (RBAC gate keys on ownership)", owner)
+	}
+}

--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -496,6 +496,18 @@ func (h *mcpHandler) createSession(userID string) string {
 	return sess.ID
 }
 
+// adoptSession re-establishes a session under a client-supplied id (e.g. one
+// replayed after a backend restart wiped the in-memory store), binding its
+// owner to userID when known. Returns the session — existing or freshly
+// adopted. See SessionStore.Adopt for the lifecycle rationale.
+func (h *mcpHandler) adoptSession(sessionID, userID string) *mcpSession {
+	sess := h.sessions.Adopt(sessionID)
+	if userID != "" {
+		sess.UserID = userID
+	}
+	return sess
+}
+
 func (h *mcpHandler) authenticateMCPRequest(c *fiber.Ctx) (string, error) {
 	if apiKey := firstNonEmpty(c.Get("X-API-Key"), c.Get("X-Api-Key")); apiKey != "" {
 		if h.cfg.DB == nil {
@@ -575,11 +587,23 @@ func (h *mcpHandler) handleRPC(c *fiber.Ctx) error {
 		return c.SendStatus(202)
 	}
 
-	// Session validation for non-initialize requests
+	// Session validation for non-initialize requests. A session-id the store
+	// doesn't recognise almost always means the in-memory store was reset (a
+	// backend restart) and the client is replaying a now-stale id. Bouncing it
+	// with a bare 404 is spec-correct ("re-initialize"), but the Claude Code
+	// MCP client doesn't auto-recover mid tool-call — it surfaces the 404 as a
+	// hang. So instead of 404 we adopt the replayed id and rebind its owner
+	// from the request's own JWT (authoritative, survives a store reset),
+	// making restarts transparent. Only fall back to 404 when we can't even
+	// establish an owner (auth error under require-auth).
 	sessionID := c.Get("Mcp-Session-Id")
 	if req.Method != "initialize" && sessionID != "" {
 		if h.getOrValidateSession(sessionID) == nil {
-			return c.SendStatus(404) // invalid session → client should re-initialize
+			userID, authErr := h.authenticateMCPRequest(c)
+			if authErr != nil {
+				return c.SendStatus(404) // can't re-establish owner → client should re-initialize
+			}
+			h.adoptSession(sessionID, userID)
 		}
 	}
 
@@ -666,12 +690,27 @@ func (h *mcpHandler) handleToolCall(c *fiber.Ctx, req jsonRPCRequest) error {
 		})
 	}
 
-	// Inject user ID from session for isolation
+	// Resolve the owner for isolation. Prefer the request's own JWT/API-key —
+	// it's authoritative and survives a session-store reset — and fall back to
+	// the session binding only when the request carries no identity. This also
+	// closes the owner_id='' footgun where a client that dropped its
+	// Mcp-Session-Id would otherwise write records with no owner.
 	toolCtx := context.Background()
 	sessionID := c.Get("Mcp-Session-Id")
 	sess := h.getOrValidateSession(sessionID)
-	if sess != nil && sess.UserID != "" {
-		toolCtx = context.WithValue(toolCtx, mcpUserIDKey, sess.UserID)
+	userID := ""
+	if uid, err := h.authenticateMCPRequest(c); err == nil && uid != "" {
+		userID = uid
+	} else if sess != nil {
+		userID = sess.UserID
+	}
+	if userID != "" {
+		toolCtx = context.WithValue(toolCtx, mcpUserIDKey, userID)
+		// Keep the session's owner in sync so audit/set_context agree with the
+		// identity the tool actually ran as.
+		if sess != nil && sess.UserID == "" {
+			sess.UserID = userID
+		}
 	}
 
 	result := h.executeTool(toolCtx, sess, params.Name, params.Arguments)

--- a/Levara/internal/http/mcp_session_adopt_test.go
+++ b/Levara/internal/http/mcp_session_adopt_test.go
@@ -1,0 +1,141 @@
+package http
+
+import (
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/stek0v/levara/pkg/mcp"
+)
+
+// mcpAdoptApp builds a Fiber app with just the /mcp routes wired to a fresh
+// session store, mirroring RegisterMCPAPI but returning the handler so a test
+// can inspect the store. The empty store stands in for the post-restart state
+// where a client's previously-issued Mcp-Session-Id is no longer known.
+func mcpAdoptApp(t *testing.T, cfg APIConfig) (*fiber.App, *mcpHandler) {
+	t.Helper()
+	app := fiber.New()
+	h := &mcpHandler{cfg: cfg, sessions: mcp.NewSessionStore()}
+	app.Post("/mcp", h.handleRPC)
+	return app, h
+}
+
+// postRPC issues a single JSON-RPC POST to /mcp and returns the status code
+// plus the (possibly empty) body. headers are applied verbatim.
+func postRPC(t *testing.T, app *fiber.App, body string, headers map[string]string) (int, string) {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(out)
+}
+
+const staleSessionID = "mcp-from-a-process-that-restarted"
+
+// A replayed (unknown) Mcp-Session-Id under require-auth=false is adopted
+// rather than 404'd: the request succeeds and the store now holds the id.
+func TestMCP_AdoptsStaleSession_NoAuth(t *testing.T) {
+	app, h := mcpAdoptApp(t, APIConfig{})
+
+	status, _ := postRPC(t, app,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
+		map[string]string{"Mcp-Session-Id": staleSessionID})
+
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200 (stale session adopted, not 404)", status)
+	}
+	if h.sessions.Get(staleSessionID) == nil {
+		t.Error("session not adopted into the store after a non-initialize call")
+	}
+}
+
+// Under require-auth=true a replayed id with a VALID JWT is adopted and its
+// owner is bound from the token's sub — restarts stay transparent and the
+// owner survives the store reset.
+func TestMCP_AdoptsStaleSession_BindsOwnerFromJWT(t *testing.T) {
+	const secret = "test-secret-adopt"
+	app, h := mcpAdoptApp(t, APIConfig{RequireAuth: true, JWTSecret: secret})
+	token := createJWT("owner-xyz", "o@example.com", secret)
+
+	status, _ := postRPC(t, app,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
+		map[string]string{
+			"Mcp-Session-Id": staleSessionID,
+			"Authorization":  "Bearer " + token,
+		})
+
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200 (adopted with JWT)", status)
+	}
+	sess := h.sessions.Get(staleSessionID)
+	if sess == nil {
+		t.Fatal("session not adopted")
+	}
+	if sess.UserID != "owner-xyz" {
+		t.Errorf("adopted session owner = %q, want owner-xyz (bound from JWT sub)", sess.UserID)
+	}
+}
+
+// Under require-auth=true a replayed id with NO credentials can't establish an
+// owner, so we keep the spec-correct 404 (client should re-initialize).
+func TestMCP_StaleSession_404WhenUnauthenticated(t *testing.T) {
+	app, h := mcpAdoptApp(t, APIConfig{RequireAuth: true, JWTSecret: "test-secret-adopt"})
+
+	status, _ := postRPC(t, app,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
+		map[string]string{"Mcp-Session-Id": staleSessionID})
+
+	if status != fiber.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (no auth → can't adopt)", status)
+	}
+	if h.sessions.Get(staleSessionID) != nil {
+		t.Error("session should NOT be adopted when auth fails")
+	}
+}
+
+// tools/call resolves the owner from the request JWT even when the session was
+// adopted empty — closing the owner_id='' footgun. We assert the response is a
+// well-formed JSON-RPC result (the tool runs) rather than a transport 404.
+func TestMCP_ToolCall_OwnerFromJWT(t *testing.T) {
+	const secret = "test-secret-adopt"
+	app, _ := mcpAdoptApp(t, APIConfig{RequireAuth: true, JWTSecret: secret})
+	token := createJWT("caller-1", "c@example.com", secret)
+
+	status, body := postRPC(t, app,
+		`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"levara_instructions","arguments":{}}}`,
+		map[string]string{
+			"Mcp-Session-Id": staleSessionID,
+			"Authorization":  "Bearer " + token,
+		})
+
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", status, body)
+	}
+	var rpc struct {
+		Result json.RawMessage `json:"result"`
+		Error  *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(body), &rpc); err != nil {
+		t.Fatalf("decode rpc: %v\n%s", err, body)
+	}
+	if rpc.Error != nil {
+		t.Fatalf("tool call returned rpc error: %s", rpc.Error.Message)
+	}
+	if len(rpc.Result) == 0 {
+		t.Error("expected a tool result for an owner-resolved call")
+	}
+}

--- a/Levara/pkg/mcp/session.go
+++ b/Levara/pkg/mcp/session.go
@@ -90,6 +90,37 @@ func (s *SessionStore) Create() *Session {
 	return sess
 }
 
+// Adopt returns the session for id, creating one under that exact id if it
+// doesn't already exist. Unlike Create (which mints a fresh server-side id),
+// Adopt honors a client-supplied id. It exists to transparently re-establish
+// a session after the in-memory store was reset — e.g. a backend restart wipes
+// every session, then a client replays its old Mcp-Session-Id. Without Adopt
+// that replay hits an unknown id and the handler 404s, which the Claude Code
+// MCP client surfaces as a hang mid tool-call instead of re-initializing. The
+// adopted session starts with an empty UserID; the caller rebinds the owner
+// from the request's JWT. Idempotent and thread-safe; an empty id falls back
+// to Create.
+func (s *SessionStore) Adopt(id string) *Session {
+	if id == "" {
+		return s.Create()
+	}
+	s.mu.Lock()
+	if existing, ok := s.sessions[id]; ok {
+		s.mu.Unlock()
+		return existing
+	}
+	sess := &Session{
+		ID:        id,
+		CreatedAt: time.Now(),
+		SSECh:     make(chan []byte, 100),
+	}
+	s.sessions[id] = sess
+	count := len(s.sessions)
+	s.mu.Unlock()
+	s.notifyCount(count)
+	return sess
+}
+
 // Delete removes the session and closes its SSECh. Calling on an absent ID
 // is a no-op (idempotent — lets callers retry cleanly on network hiccups).
 // OnCountChange fires only when the store size actually changed.

--- a/Levara/pkg/mcp/session_test.go
+++ b/Levara/pkg/mcp/session_test.go
@@ -33,6 +33,52 @@ func TestSessionStore_CreateGetDelete(t *testing.T) {
 	}
 }
 
+func TestSessionStore_Adopt_HonorsClientID(t *testing.T) {
+	s := NewSessionStore()
+	const clientID = "mcp-from-a-previous-process"
+	sess := s.Adopt(clientID)
+	if sess.ID != clientID {
+		t.Errorf("Adopt minted id %q, want the client-supplied %q", sess.ID, clientID)
+	}
+	if got := s.Get(clientID); got != sess {
+		t.Error("adopted session not retrievable by its id")
+	}
+	if s.Count() != 1 {
+		t.Errorf("Count = %d, want 1", s.Count())
+	}
+	// SSECh must be usable (non-nil, buffered) like a Create()d session.
+	select {
+	case sess.SSECh <- []byte("x"):
+	default:
+		t.Error("adopted session SSECh not writable")
+	}
+}
+
+func TestSessionStore_Adopt_Idempotent(t *testing.T) {
+	s := NewSessionStore()
+	const clientID = "mcp-replayed"
+	first := s.Adopt(clientID)
+	first.UserID = "alice"
+	second := s.Adopt(clientID)
+	if first != second {
+		t.Error("second Adopt of the same id returned a different session")
+	}
+	if second.UserID != "alice" {
+		t.Errorf("re-adopt clobbered owner: UserID = %q, want alice", second.UserID)
+	}
+	if s.Count() != 1 {
+		t.Errorf("Count = %d, want 1 (no accretion on re-adopt)", s.Count())
+	}
+}
+
+func TestSessionStore_Adopt_EmptyIDFallsBackToCreate(t *testing.T) {
+	s := NewSessionStore()
+	sess := s.Adopt("")
+	if !strings.HasPrefix(sess.ID, "mcp-") {
+		t.Errorf("Adopt(\"\") id = %q, want a freshly-minted mcp- id", sess.ID)
+	}
+}
+
 func TestSessionStore_GetEmptyIDReturnsNil(t *testing.T) {
 	s := NewSessionStore()
 	if s.Get("") != nil {

--- a/Levara/pkg/mcp/tool_cognify.go
+++ b/Levara/pkg/mcp/tool_cognify.go
@@ -67,7 +67,12 @@ func ToolCognify(ctx context.Context, deps Deps, args map[string]any) ToolResult
 	}
 
 	pipeCfg.Collection = collection
-	pipeCfg.DatasetID = runID
+	// Stamp chunks/graph rows with a dataset id that is *registered* in the
+	// `datasets` SQL table owned by the caller. A bare ephemeral runID is in
+	// no caller's RBAC allowed-set, so search's filterByAllowedDatasets would
+	// silently drop every chunk this run produces (the agent could not
+	// retrieve content it just cognified). See ensureCognifyDatasetID.
+	pipeCfg.DatasetID = ensureCognifyDatasetID(ctx, deps, runID, collection)
 	pipeCfg.GenerateTriplets = true
 	trueVal := true
 	pipeCfg.UseStructuredOutput = &trueVal
@@ -134,6 +139,49 @@ func ToolCognify(ctx context.Context, deps Deps, args map[string]any) ToolResult
 			Text: fmt.Sprintf("Cognify pipeline started. Run ID: %s. Use cognify_status tool to check progress.", runID),
 		}},
 	}
+}
+
+// ensureCognifyDatasetID returns the dataset id that cognify stamps onto
+// every chunk and graph row, guaranteeing it is registered in the `datasets`
+// SQL table owned by the calling user. Without registration, search's RBAC
+// gate (filterByAllowedDatasets) drops every freshly cognified chunk: an
+// unregistered id is in no caller's allowed-set, so an agent could never
+// retrieve content it just ingested (HTTP 200 + empty result, no error).
+//
+// One row is get-or-created per (owner, collection) — repeated cognify runs
+// into the same collection reuse it, so the datasets table does not accrete a
+// row per run. The "__cognify__:" name prefix avoids colliding with
+// human-created dataset names. Best-effort: any DB error (or a nil store,
+// where RBAC is inert and every chunk already passes) falls back to the
+// ephemeral id unchanged — no worse than the pre-fix behavior.
+func ensureCognifyDatasetID(ctx context.Context, deps Deps, fallbackID, collection string) string {
+	db := deps.DB()
+	if db == nil {
+		return fallbackID
+	}
+	owner := extractOwnerID(ctx)
+	name := fmt.Sprintf("__cognify__:%s:%s", owner, collection)
+
+	// Reuse an existing per-(owner,collection) cognify dataset if present.
+	var existing string
+	if err := db.QueryRowContext(ctx, deps.Q(`SELECT id FROM datasets WHERE name = $1`), name).Scan(&existing); err == nil && existing != "" {
+		return existing
+	}
+
+	now := time.Now().UTC()
+	// ON CONFLICT(name) DO NOTHING absorbs a concurrent create; the follow-up
+	// SELECT resolves whichever id won the race.
+	if _, err := db.ExecContext(ctx, deps.Q(
+		`INSERT INTO datasets (id, name, owner_id, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5) ON CONFLICT (name) DO NOTHING`),
+		fallbackID, name, owner, now, now); err != nil {
+		return fallbackID
+	}
+	var resolved string
+	if err := db.QueryRowContext(ctx, deps.Q(`SELECT id FROM datasets WHERE name = $1`), name).Scan(&resolved); err == nil && resolved != "" {
+		return resolved
+	}
+	return fallbackID
 }
 
 // runPipelineWithStatus drives the orchestrator to completion and

--- a/Levara/pkg/mcp/tool_cognify_test.go
+++ b/Levara/pkg/mcp/tool_cognify_test.go
@@ -2,7 +2,9 @@ package mcp
 
 import (
 	"context"
+	"database/sql"
 	"errors"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -347,6 +349,101 @@ func TestToolCognify_DefaultCollectionWhenEmpty(t *testing.T) {
 	}
 	if captured.DatasetID != runID {
 		t.Errorf("DatasetID=%q, want runID=%q", captured.DatasetID, runID)
+	}
+}
+
+// setupCognifyDatasetDB returns a fakeDeps backed by an in-memory sqlite DB
+// carrying the datasets schema ensureCognifyDatasetID writes (name UNIQUE so
+// the ON CONFLICT(name) clause has an index to fire against).
+func setupCognifyDatasetDB(t *testing.T) *fakeDeps {
+	t.Helper()
+	f, _ := os.CreateTemp("", "mcp-cognify-ds-*.db")
+	path := f.Name()
+	f.Close()
+
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		os.Remove(path)
+	})
+
+	if _, err := db.Exec(`CREATE TABLE datasets (
+		id TEXT PRIMARY KEY, name TEXT UNIQUE, owner_id TEXT,
+		created_at TEXT, updated_at TEXT
+	)`); err != nil {
+		t.Fatalf("create datasets: %v", err)
+	}
+	return &fakeDeps{db: db}
+}
+
+// ctxWithUser tags a context with the MCP user id the same way the HTTP
+// handler does on auth, so extractOwnerID(ctx) resolves to owner.
+func ctxWithUser(owner string) context.Context {
+	return context.WithValue(context.Background(), UserIDKey, owner)
+}
+
+func TestEnsureCognifyDatasetID_GetOrCreateIsIdempotent(t *testing.T) {
+	deps := setupCognifyDatasetDB(t)
+	ctx := ctxWithUser("alice")
+
+	// First call creates a row and returns the fallback id (the runID it
+	// was seeded with). Second call into the same (owner, collection) must
+	// reuse it — same id back, and no second datasets row accreted.
+	id1 := ensureCognifyDatasetID(ctx, deps, "run-1", "docs")
+	id2 := ensureCognifyDatasetID(ctx, deps, "run-2", "docs")
+
+	if id1 != "run-1" {
+		t.Errorf("first id = %q, want the fallback run-1 (it created the row)", id1)
+	}
+	if id2 != id1 {
+		t.Errorf("second id = %q, want %q (reuse, not a fresh runID)", id2, id1)
+	}
+
+	var rows int
+	if err := deps.db.QueryRow(
+		"SELECT COUNT(*) FROM datasets WHERE name = '__cognify__:alice:docs'").Scan(&rows); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("datasets rows = %d, want exactly 1 (no per-run accretion)", rows)
+	}
+}
+
+func TestEnsureCognifyDatasetID_ScopesByOwnerAndCollection(t *testing.T) {
+	deps := setupCognifyDatasetDB(t)
+
+	alice := ensureCognifyDatasetID(ctxWithUser("alice"), deps, "r-a", "docs")
+	bob := ensureCognifyDatasetID(ctxWithUser("bob"), deps, "r-b", "docs")
+	aliceOther := ensureCognifyDatasetID(ctxWithUser("alice"), deps, "r-a2", "notes")
+
+	if alice == bob {
+		t.Errorf("alice and bob share dataset id %q; owner scoping broken", alice)
+	}
+	if alice == aliceOther {
+		t.Errorf("alice's docs and notes share id %q; collection scoping broken", alice)
+	}
+
+	// The row alice created is owned by alice, not anonymous — without this
+	// the RBAC gate would still drop her chunks.
+	var owner string
+	if err := deps.db.QueryRow(
+		"SELECT owner_id FROM datasets WHERE id = ?", alice).Scan(&owner); err != nil {
+		t.Fatalf("select owner: %v", err)
+	}
+	if owner != "alice" {
+		t.Errorf("owner_id = %q, want alice", owner)
+	}
+}
+
+func TestEnsureCognifyDatasetID_NilDBFallsBack(t *testing.T) {
+	// No DB → RBAC is inert (every chunk already passes), so the helper
+	// returns the ephemeral id unchanged rather than touching a nil *sql.DB.
+	got := ensureCognifyDatasetID(context.Background(), nilDBDeps{}, "run-x", "docs")
+	if got != "run-x" {
+		t.Errorf("got %q, want fallback run-x when DB is nil", got)
 	}
 }
 

--- a/Levara/pkg/mcp/tool_consolidate.go
+++ b/Levara/pkg/mcp/tool_consolidate.go
@@ -142,7 +142,7 @@ func (n *collectionNeighbors) Edges(ctx context.Context, recs []consolidate.Memo
 	seen := make(map[string]struct{})
 	var edges []consolidate.SimEdge
 	for _, r := range recs {
-		// Embed key+value to match indexMemoryAsync (tool_save_recall_memory.go),
+		// Embed key+value to match indexMemorySync (tool_save_recall_memory.go),
 		// which indexes Embed(key+" "+value). A value-only query vector is
 		// asymmetric against the key+value stored vectors and systematically
 		// under-scores records whose key carries text, starving the clusterer.

--- a/Levara/pkg/mcp/tool_consolidate_test.go
+++ b/Levara/pkg/mcp/tool_consolidate_test.go
@@ -201,7 +201,7 @@ func newConsolidateDeps(t *testing.T) *fakeDeps {
 }
 
 // TestEdges_EmbedsKeyPlusValue guards F-quality.1: the edge-builder must embed
-// the same key+" "+value text that indexMemoryAsync indexes, otherwise the
+// the same key+" "+value text that indexMemorySync indexes, otherwise the
 // value-only query vector is asymmetric against the stored key+value vectors and
 // under-clusters records whose key carries text.
 func TestEdges_EmbedsKeyPlusValue(t *testing.T) {
@@ -225,7 +225,7 @@ func TestEdges_EmbedsKeyPlusValue(t *testing.T) {
 	}
 	want := "pi-potion-sidecar runs on port 9101"
 	if len(embedded) != 1 || embedded[0] != want {
-		t.Errorf("embedded = %q, want exactly [%q] (key+\" \"+value, matching indexMemoryAsync)", embedded, want)
+		t.Errorf("embedded = %q, want exactly [%q] (key+\" \"+value, matching indexMemorySync)", embedded, want)
 	}
 }
 

--- a/Levara/pkg/mcp/tool_save_recall_memory.go
+++ b/Levara/pkg/mcp/tool_save_recall_memory.go
@@ -25,8 +25,10 @@ const (
 	// recallMemoryVectorTopK is the topK passed to CollectionSearch in
 	// the vector-semantic path.
 	recallMemoryVectorTopK = 10
-	// saveMemoryEmbedTimeout caps the goroutine that runs after the
-	// tool returns. Decouples client latency from the embed service.
+	// saveMemoryEmbedTimeout is the hard ceiling on the synchronous
+	// embed+index step. A healthy local embed returns in milliseconds; this
+	// only bites when the embed service is stuck, bounding how long a save
+	// can block before it degrades to a divergence heartbeat.
 	saveMemoryEmbedTimeout = 30 * time.Second
 )
 
@@ -45,13 +47,15 @@ func memoryCollectionName(collectionName string) string {
 }
 
 // ToolSaveMemory upserts a memory into the memories table and, when
-// embedding is available, fires a background goroutine that vector-
-// indexes the key+value pair for later semantic recall.
+// embedding is available, vector-indexes the key+value pair synchronously
+// so the record is immediately recallable (including under a room/hall
+// filter — see indexMemorySync for why this is no longer a goroutine).
 //
-// The SQL path is the source of truth: the success message returns
-// after DB commit. The vector index is fire-and-forget with its own
-// context (decoupled from the client's ctx so a fast MCP return
-// doesn't cancel indexing mid-flight).
+// The SQL path is the source of truth: the row is committed before the
+// vector index step, and the save still succeeds even if indexing fails
+// (the failure surfaces as a divergence heartbeat, not an error). Indexing
+// runs under a detached, bounded context so a fast MCP client disconnect
+// can't cancel it mid-flight.
 //
 // Pre-refactor reused placeholders ($3, $4, $6, $7, $8, $9, $10, $12
 // in both VALUES and DO UPDATE SET). Rewrote to unique placeholders
@@ -131,7 +135,7 @@ func ToolSaveMemory(ctx context.Context, deps Deps, args map[string]any) ToolRes
 	}
 
 	if deps.EmbedAvailable() {
-		indexMemoryAsync(deps, collectionName, canonicalID, key, value, memType)
+		indexMemorySync(deps, collectionName, canonicalID, key, value, memType)
 	}
 
 	return ToolResult{Content: []Content{{
@@ -140,63 +144,70 @@ func ToolSaveMemory(ctx context.Context, deps Deps, args map[string]any) ToolRes
 	}}}
 }
 
-// indexMemoryAsync fires the vector-index side effect in a goroutine.
-// Uses context.Background() with a timeout so the embed call isn't
-// cancelled when the tool's ctx completes (MCP clients may close
-// connections immediately after receiving the save confirmation).
+// indexMemorySync vector-indexes the memory inline — before ToolSaveMemory
+// returns — so the fresh record is immediately discoverable by semantic
+// recall, including filtered recall_memory(query, room=…).
 //
-// The SQL row is already committed (source of truth); this goroutine
-// makes the vector match it. Every failure mode is verified rather than
-// swallowed: an embed error, an insert error, or a vector that isn't
-// present on read-back all emit a "memory_index_divergence" heartbeat
-// (mirrored to levara_memory_index_divergence_total) so the SQL↔vector
-// gap that motivated P1.4/Cause-B is observable instead of silent. The
-// insert+verify is retried once before giving up — the reconcile_memory
-// sweep is the durable backstop for whatever still slips through.
-func indexMemoryAsync(deps Deps, collectionName, id, key, value, memType string) {
-	go func() {
-		embedCtx, cancel := context.WithTimeout(context.Background(), saveMemoryEmbedTimeout)
-		defer cancel()
+// This used to run in a goroutine. The embed window between the synchronous
+// SQL commit and the asynchronous vector insert was a race: a recall fired
+// right after a save found nothing via the vector path (the vector wasn't in
+// the collection yet) and fell through to the literal SQL-LIKE fallback,
+// which misses any paraphrased/semantic query. Indexing synchronously closes
+// that window so recall stays on the fast vector path instead of leaning on
+// the slower SQL substring scan.
+//
+// A detached, bounded context decouples the embed/insert from the caller's
+// ctx so an MCP client that closes its connection on receipt of the save
+// confirmation cannot cancel indexing mid-flight (the property the old
+// goroutine bought, kept here without the race). The SQL row is already
+// committed (source of truth) and the save still succeeds regardless; every
+// failure mode is verified rather than swallowed: an embed error, an insert
+// error, or a vector absent on read-back each emit a
+// "memory_index_divergence" heartbeat (mirrored to
+// levara_memory_index_divergence_total). The insert+verify is retried once;
+// the reconcile_memory sweep is the durable backstop beyond that.
+func indexMemorySync(deps Deps, collectionName, id, key, value, memType string) {
+	embedCtx, cancel := context.WithTimeout(context.Background(), saveMemoryEmbedTimeout)
+	defer cancel()
 
-		sidecar := memoryCollectionName(collectionName)
+	sidecar := memoryCollectionName(collectionName)
 
-		vec, err := deps.Embed(embedCtx, key+" "+value)
-		if err != nil {
-			reportMemoryDivergence(deps, sidecar, id, "embed_failed", err.Error())
-			return
-		}
+	vec, err := deps.Embed(embedCtx, key+" "+value)
+	if err != nil {
+		reportMemoryDivergence(deps, sidecar, id, "embed_failed", err.Error())
+		return
+	}
 
-		meta, _ := json.Marshal(map[string]string{
-			"key":        key,
-			"value":      value,
-			"type":       memType,
-			"collection": collectionName,
-			"memory_id":  id,
-		})
+	meta, _ := json.Marshal(map[string]string{
+		"key":        key,
+		"value":      value,
+		"type":       memType,
+		"collection": collectionName,
+		"memory_id":  id,
+	})
 
-		// Insert, then verify the vector actually landed under the canonical
-		// id (synchronous index lookup, not a vector search — see
-		// CollectionHasRecord). Retry once on failure.
-		for attempt := 1; attempt <= memoryIndexMaxAttempts; attempt++ {
-			insErr := deps.CollectionInsert(sidecar, id, vec, meta)
-			if insErr != nil {
-				if attempt == memoryIndexMaxAttempts {
-					reportMemoryDivergence(deps, sidecar, id, "insert_failed", insErr.Error())
-				}
-				continue
-			}
-			if deps.CollectionHasRecord(sidecar, id) {
-				return // verified present — SQL and vector agree
-			}
+	// Insert, then verify the vector actually landed under the canonical
+	// id (synchronous index lookup, not a vector search — see
+	// CollectionHasRecord). Retry once on failure.
+	for attempt := 1; attempt <= memoryIndexMaxAttempts; attempt++ {
+		insErr := deps.CollectionInsert(sidecar, id, vec, meta)
+		if insErr != nil {
 			if attempt == memoryIndexMaxAttempts {
-				reportMemoryDivergence(deps, sidecar, id, "missing_after_insert", "vector absent on read-back")
+				reportMemoryDivergence(deps, sidecar, id, "insert_failed", insErr.Error())
 			}
+			continue
 		}
-	}()
+		if deps.CollectionHasRecord(sidecar, id) {
+			return // verified present — SQL and vector agree
+		}
+		if attempt == memoryIndexMaxAttempts {
+			reportMemoryDivergence(deps, sidecar, id, "missing_after_insert", "vector absent on read-back")
+		}
+	}
 }
 
 // memoryIndexMaxAttempts bounds the insert+verify retry loop in
-// indexMemoryAsync. One retry covers a transient collection/disk hiccup;
+// indexMemorySync. One retry covers a transient collection/disk hiccup;
 // reconcile_memory is the durable backstop beyond that.
 const memoryIndexMaxAttempts = 2
 

--- a/Levara/pkg/mcp/tool_save_recall_memory_test.go
+++ b/Levara/pkg/mcp/tool_save_recall_memory_test.go
@@ -176,10 +176,11 @@ func TestToolSaveMemory_TruncatesValueInMessage(t *testing.T) {
 	}
 }
 
-func TestToolSaveMemory_EmbedPathFiresGoroutine(t *testing.T) {
-	// With EmbedAvailable=true, a background goroutine calls Embed and
-	// CollectionInsert. The tool returns immediately; the indexing
-	// happens off the critical path. We poll briefly for the side effect.
+func TestToolSaveMemory_EmbedPathIndexesVector(t *testing.T) {
+	// With EmbedAvailable=true, ToolSaveMemory calls Embed and
+	// CollectionInsert synchronously, so the vector is in the collection by
+	// the time the tool returns (closing the recall-after-save race). We
+	// still poll defensively rather than asserting strict ordering.
 	deps := setupSaveRecallMemoryDB(t)
 	deps.embedAvailable = true
 	var embedCalled atomic.Bool


### PR DESCRIPTION
Bundles two already-deployed fixes (both live on Mac :8081 and Pi :8090 at `/version=b979e10`). `main` doesn't have them yet — this PR lands them.

## Commits

### 1. `79fcd48` — cognify-chunk RBAC + synchronous memory index
- **Cognify chunks were unsearchable.** The pipeline stamped each chunk with `dataset_id = ephemeral pipeline runID`, never registered in the `datasets` table. Search's RBAC gate (`filterByAllowedDatasets`) then silently dropped every chunk → HTTP 200 + `[]`. Fix: cognify get-or-creates one caller-owned `datasets` row per `(owner, collection)` (`__cognify__:<owner>:<collection>`, runID reused as the row id on first run) and stamps that id, so chunks pass RBAC. Both entry points: `ensureCognifyDatasetID` (MCP) / `ensureCognifyDataset` (REST).
- **Filtered recall missed fresh saves.** `save_memory` indexed the memory vector in a goroutine; a filtered `recall_memory` fired right after save raced the embed window, missed the vector path, and fell through to the literal SQL-LIKE fallback (so a semantic query missed). Fix: index synchronously (`indexMemorySync`) before returning.

### 2. `b979e10` — MCP session adopt-on-restart + owner from JWT
- **MCP wedged after a backend restart.** Sessions live in an in-memory `SessionStore`, wiped on restart. The client replays its now-stale `Mcp-Session-Id`; `handleRPC` returned a bare `404` on any non-`initialize` request with an unknown id. Spec-correct ("re-initialize"), but the Claude Code MCP client doesn't auto-recover mid tool-call — it surfaces the 404 as a hang (`set_context`/`save_memory` wedging).
- **Fix A — adopt-on-unknown.** New `SessionStore.Adopt(id)` re-establishes a session under a client-supplied id (idempotent, thread-safe). `handleRPC` adopts a replayed unknown id and rebinds owner from the request's JWT/API-key instead of 404'ing. Falls back to `404` only when no identity can be established (auth error under `require-auth`).
- **Fix B — owner from JWT per-request.** `handleToolCall` resolves the owner from the request JWT first, session binding as fallback — closes the `owner_id=''` footgun where a dropped session-id wrote records with no owner.

## Tests
- `pkg/mcp`: `SessionStore.Adopt` (honors id / idempotent / empty-id→Create).
- `internal/http`: cognify-dataset get-or-create idempotency + owner/collection scoping; MCP adopt (no-auth, owner-bind from JWT, 404-when-unauthenticated, tool-call owner from JWT).
- Full `pkg/mcp` + `internal/http` suites pass.

## Verification (live, both backends)
- `/version = b979e10` on Mac :8081 and Pi :8090.
- Adopt-proof: stale `Mcp-Session-Id` + Bearer → `HTTP 200` + valid `tools/list`; same stale id with no auth → `HTTP 404`.
- cognify(rag) → `search/text(CHUNKS, rerank=false)` returns the chunk (Mac 0.76 / Pi 0.82).
- Live self-heal on Mac: after `launchctl kickstart` my own `mcp__levara__*` calls succeeded with no `/mcp` reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)