### PR TITLE
fix(mcp): gate auth on empty session-id + owner-scope memory reads

### DIFF
--- a/Levara/internal/http/mcp.go
+++ b/Levara/internal/http/mcp.go
@@ -587,22 +587,27 @@ func (h *mcpHandler) handleRPC(c *fiber.Ctx) error {
 		return c.SendStatus(202)
 	}
 
-	// Session validation for non-initialize requests. A session-id the store
-	// doesn't recognise almost always means the in-memory store was reset (a
-	// backend restart) and the client is replaying a now-stale id. Bouncing it
-	// with a bare 404 is spec-correct ("re-initialize"), but the Claude Code
-	// MCP client doesn't auto-recover mid tool-call — it surfaces the 404 as a
-	// hang. So instead of 404 we adopt the replayed id and rebind its owner
-	// from the request's own JWT (authoritative, survives a store reset),
-	// making restarts transparent. Only fall back to 404 when we can't even
-	// establish an owner (auth error under require-auth).
+	// Auth + session gate for non-initialize requests. Authenticate FIRST,
+	// unconditionally — a request that omits the session header is no more
+	// trusted than one replaying a stale id, so both must clear the same
+	// gate (otherwise an anonymous caller under require-auth could reach
+	// tools/list and tools/call simply by NOT sending a session id). When
+	// auth fails we 404 (client should re-initialize). `ping` is a transport
+	// liveness probe and stays unauthenticated like `initialize`.
+	//
+	// A session-id the store doesn't recognise almost always means the
+	// in-memory store was reset (a backend restart) and the client is
+	// replaying a now-stale id. Rather than 404 (which the Claude Code MCP
+	// client surfaces as a hang mid tool-call), we adopt the replayed id and
+	// rebind its owner from the just-verified identity, making restarts
+	// transparent.
 	sessionID := c.Get("Mcp-Session-Id")
-	if req.Method != "initialize" && sessionID != "" {
-		if h.getOrValidateSession(sessionID) == nil {
-			userID, authErr := h.authenticateMCPRequest(c)
-			if authErr != nil {
-				return c.SendStatus(404) // can't re-establish owner → client should re-initialize
-			}
+	if req.Method != "initialize" && req.Method != "ping" {
+		userID, authErr := h.authenticateMCPRequest(c)
+		if authErr != nil {
+			return c.SendStatus(404) // can't establish an owner → client should re-initialize
+		}
+		if sessionID != "" && h.getOrValidateSession(sessionID) == nil {
 			h.adoptSession(sessionID, userID)
 		}
 	}

--- a/Levara/internal/http/mcp_session_adopt_test.go
+++ b/Levara/internal/http/mcp_session_adopt_test.go
@@ -139,3 +139,57 @@ func TestMCP_ToolCall_OwnerFromJWT(t *testing.T) {
 		t.Error("expected a tool result for an owner-resolved call")
 	}
 }
+
+// ── Empty Mcp-Session-Id read-isolation gap ──
+//
+// A request that omits the session header entirely (not just a stale one)
+// must be subject to the same auth gate as one that replays a stale id.
+// Otherwise an anonymous caller under require-auth could reach tools/list
+// and tools/call simply by NOT sending a session id — the auth/adopt block
+// only ran when sessionID != "".
+
+// No session header + no credentials under require-auth must 404 (not leak
+// the tool catalogue to an anonymous caller).
+func TestMCP_NoSessionHeader_RejectsAnonUnderRequireAuth(t *testing.T) {
+	app, _ := mcpAdoptApp(t, APIConfig{RequireAuth: true, JWTSecret: "test-secret-adopt"})
+
+	status, _ := postRPC(t, app,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
+		map[string]string{}) // no Mcp-Session-Id, no Authorization
+
+	if status != fiber.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (anon tools/list with no session must be rejected)", status)
+	}
+}
+
+// No session header but a VALID Bearer under require-auth must still succeed —
+// dropping the session id is legitimate as long as the request authenticates.
+// Regression guard: this stays green before and after the fix.
+func TestMCP_NoSessionHeader_AllowsValidBearer(t *testing.T) {
+	const secret = "test-secret-adopt"
+	app, _ := mcpAdoptApp(t, APIConfig{RequireAuth: true, JWTSecret: secret})
+	token := createJWT("caller-2", "c2@example.com", secret)
+
+	status, body := postRPC(t, app,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
+		map[string]string{"Authorization": "Bearer " + token}) // no Mcp-Session-Id
+
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200 (valid Bearer, no session id); body=%s", status, body)
+	}
+}
+
+// No session header + no credentials under require-auth must also block
+// tools/call — closing the path where an anon caller ran a tool with
+// owner_id='' just by omitting the session id.
+func TestMCP_NoSessionHeader_RejectsAnonToolCall(t *testing.T) {
+	app, _ := mcpAdoptApp(t, APIConfig{RequireAuth: true, JWTSecret: "test-secret-adopt"})
+
+	status, _ := postRPC(t, app,
+		`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"levara_instructions","arguments":{}}}`,
+		map[string]string{}) // no Mcp-Session-Id, no Authorization
+
+	if status != fiber.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (anon tools/call with no session must be rejected)", status)
+	}
+}

--- a/Levara/pkg/mcp/tool_memory.go
+++ b/Levara/pkg/mcp/tool_memory.go
@@ -31,10 +31,17 @@ func ToolListMemories(ctx context.Context, deps Deps, args map[string]any) ToolR
 	collectionName, _ := args["collection"].(string)
 	room, _ := args["room"].(string)
 	hall, _ := args["hall"].(string)
+	ownerID := extractOwnerID(ctx)
 
 	var conds []string
 	var qargs []any
 	pos := 1
+	// Ownership scope: the caller's own rows plus shared (empty-owner) rows.
+	// Without this list_memories returned every owner's memories, leaking
+	// other users' rows on a shared deployment.
+	conds = append(conds, fmt.Sprintf("(owner_id = $%d OR owner_id = '')", pos))
+	qargs = append(qargs, ownerID)
+	pos++
 	if filterType != "" {
 		conds = append(conds, fmt.Sprintf("type = $%d", pos))
 		qargs = append(qargs, filterType)

--- a/Levara/pkg/mcp/tool_memory_test.go
+++ b/Levara/pkg/mcp/tool_memory_test.go
@@ -153,6 +153,43 @@ func TestToolListMemories_FormatsPinnedAsBool(t *testing.T) {
 	}
 }
 
+func TestToolListMemories_OwnershipScoped(t *testing.T) {
+	// list_memories must be scoped to the caller: it returns the caller's
+	// own rows plus shared (empty-owner) rows, never another owner's. The
+	// owner comes from the request context (set by the HTTP handler on auth).
+	deps := setupMemoryTestDB(t)
+	seedMemory(t, deps.db, "m1", "alice-only", "v", "fact", "alice", "", "", "", 0, 0)
+	seedMemory(t, deps.db, "m2", "bob-only", "v", "fact", "bob", "", "", "", 0, 0)
+	seedMemory(t, deps.db, "m3", "shared", "v", "fact", "", "", "", "", 0, 0)
+
+	ctx := context.WithValue(context.Background(), UserIDKey, "alice")
+	got := ToolListMemories(ctx, deps, map[string]any{})
+	if got.IsError {
+		t.Fatalf("IsError = true: %s", got.Content[0].Text)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal([]byte(got.Content[0].Text), &items); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	keys := map[string]bool{}
+	for _, it := range items {
+		keys[it["key"].(string)] = true
+	}
+	if !keys["alice-only"] {
+		t.Error("alice's own row missing")
+	}
+	if !keys["shared"] {
+		t.Error("shared (empty-owner) row missing")
+	}
+	if keys["bob-only"] {
+		t.Error("LEAK: bob's row visible to alice")
+	}
+	if len(items) != 2 {
+		t.Errorf("got %d items, want 2 (alice-only + shared)", len(items))
+	}
+}
+
 // ── ToolPinMemory ──
 
 func TestToolPinMemory_RequiresKey(t *testing.T) {

--- a/Levara/pkg/mcp/tool_save_recall_memory.go
+++ b/Levara/pkg/mcp/tool_save_recall_memory.go
@@ -264,49 +264,20 @@ func ToolRecallMemory(ctx context.Context, deps Deps, args map[string]any) ToolR
 		return ToolResult{Content: []Content{{Type: "text", Text: "[]"}}}
 	}
 
-	// Strategy 1: vector semantic search. The filtered variant hydrates
-	// hits through SQL so room/hall are enforced authoritatively without
-	// losing semantic recall.
+	// Strategy 1: vector semantic search, always hydrated through SQL so the
+	// owner scope (and any optional room/hall filter) is enforced
+	// authoritatively without losing semantic recall. The unfiltered path used
+	// to return vector hits' Data verbatim with no owner check, leaking other
+	// owners' rows; routing every recall through the SQL-hydrated path closes
+	// that. Empty/error is a soft miss → fall through to the SQL LIKE path.
 	if deps.EmbedAvailable() {
-		if room == "" && hall == "" {
-			if res, ok := recallViaVectorSearch(ctx, deps, collectionName, query); ok {
-				return res
-			}
-		} else if res, ok := recallViaVectorFiltered(ctx, deps, db, deps.Q, query, collectionName, room, hall, ownerID, includeSuperseded); ok {
+		if res, ok := recallViaVectorFiltered(ctx, deps, db, deps.Q, query, collectionName, room, hall, ownerID, includeSuperseded); ok {
 			return res
 		}
 	}
 
 	// Strategy 2: SQL LIKE.
 	return recallViaSQLLike(ctx, db, deps.Q, query, collectionName, room, hall, ownerID, includeSuperseded)
-}
-
-// recallViaVectorSearch attempts vector-semantic recall. Returns
-// (result, true) when results are found; (_, false) signals the
-// caller to fall through to the SQL path. Errors are treated as
-// soft misses — pre-refactor never surfaced embed/search errors.
-func recallViaVectorSearch(ctx context.Context, deps Deps, collectionName, query string) (ToolResult, bool) {
-	vec, err := deps.Embed(ctx, query)
-	if err != nil {
-		return ToolResult{}, false
-	}
-	results, err := deps.CollectionSearch(memoryCollectionName(collectionName), vec, recallMemoryVectorTopK)
-	if err != nil || len(results) == 0 {
-		return ToolResult{}, false
-	}
-
-	var items []map[string]string
-	for _, r := range results {
-		var meta map[string]string
-		if err := json.Unmarshal(r.Data, &meta); err == nil {
-			items = append(items, meta)
-		}
-	}
-	if len(items) == 0 {
-		return ToolResult{}, false
-	}
-	out, _ := json.MarshalIndent(items, "", "  ")
-	return ToolResult{Content: []Content{{Type: "text", Text: string(out)}}}, true
 }
 
 // memoryRowColumns is the SELECT list shared by the SQL recall paths so

--- a/Levara/pkg/mcp/tool_save_recall_memory_test.go
+++ b/Levara/pkg/mcp/tool_save_recall_memory_test.go
@@ -557,29 +557,96 @@ func TestToolRecallMemory_HallFilterUsesVectorHydration(t *testing.T) {
 	}
 }
 
-func TestToolRecallMemory_VectorPathReturnsMetaItems(t *testing.T) {
-	// No structural filter + embed available → vector path. Search
-	// results are unmarshalled from the Data field and returned.
+func TestToolRecallMemory_VectorPathHydratesFromSQL(t *testing.T) {
+	// No structural filter + embed available → vector path. The vector hit's
+	// id keys an authoritative SQL hydration (NOT a raw Data-field unmarshal),
+	// so the returned row carries the SQL columns and the owner/superseded
+	// guards apply uniformly with the filtered path.
 	deps := setupSaveRecallMemoryDB(t)
 	deps.embedAvailable = true
+	deps.embedFn = func(ctx context.Context, text string) ([]float32, error) {
+		return []float32{1, 2, 3}, nil
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	// Query is not a substring of the row → only a vector hit can find it.
+	deps.db.Exec(`INSERT INTO memories (id, key, value, type, owner_id, collection_name, room, hall, created_at, updated_at)
+		VALUES ('id1', 'hit', 'semantic match', 'fact', '', '', '', '', ?, ?)`, now, now)
 	deps.searchFn = func(collection string, q []float32, k int) ([]SearchResult, error) {
-		meta, _ := json.Marshal(map[string]string{
-			"key": "hit", "value": "semantic match", "type": "fact",
-		})
-		return []SearchResult{{ID: "id1", Score: 0.9, Data: meta}}, nil
+		return []SearchResult{{ID: "id1", Score: 0.9}}, nil
 	}
 
 	got := ToolRecallMemory(context.Background(), deps, map[string]any{"query": "anything"})
 	if got.IsError {
-		t.Fatalf("IsError = true")
+		t.Fatalf("IsError = true: %s", got.Content[0].Text)
 	}
 
-	var items []map[string]string
+	var items []map[string]any
 	if err := json.Unmarshal([]byte(got.Content[0].Text), &items); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if len(items) != 1 || items[0]["key"] != "hit" {
-		t.Errorf("got %+v, want single 'hit'", items)
+		t.Errorf("got %+v, want single 'hit' (SQL-hydrated)", items)
+	}
+}
+
+func TestToolRecallMemory_VectorPathOwnershipScoped(t *testing.T) {
+	// Regression: the unfiltered (no room/hall) vector path must be scoped
+	// to the caller. Before the fix it returned vector hits' Data verbatim
+	// with NO owner filter, leaking another owner's rows. After the fix the
+	// hits are hydrated through SQL with the owner scope applied, so the
+	// caller sees only their own rows plus shared (empty-owner) rows.
+	deps := setupSaveRecallMemoryDB(t)
+	deps.embedAvailable = true
+	deps.embedFn = func(ctx context.Context, text string) ([]float32, error) {
+		return []float32{1, 2, 3}, nil
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	// None of the values contain the query phrase — vector-only retrieval.
+	deps.db.Exec(`INSERT INTO memories (id, key, value, type, owner_id, collection_name, room, hall, created_at, updated_at)
+		VALUES ('m1', 'alice-secret', 'private note one', 'fact', 'alice', '', '', '', ?, ?)`, now, now)
+	deps.db.Exec(`INSERT INTO memories (id, key, value, type, owner_id, collection_name, room, hall, created_at, updated_at)
+		VALUES ('m2', 'bob-secret', 'private note two', 'fact', 'bob', '', '', '', ?, ?)`, now, now)
+	deps.db.Exec(`INSERT INTO memories (id, key, value, type, owner_id, collection_name, room, hall, created_at, updated_at)
+		VALUES ('m3', 'shared-note', 'private note three', 'fact', '', '', '', '', ?, ?)`, now, now)
+	// Vector search surfaces ALL three — owner isolation must happen in SQL.
+	// Data payloads mirror the rows so the pre-fix Data-unmarshal path would
+	// have leaked bob's row (making this test red before the fix).
+	deps.searchFn = func(collection string, q []float32, k int) ([]SearchResult, error) {
+		mk := func(key string) json.RawMessage {
+			b, _ := json.Marshal(map[string]string{"key": key, "value": "leaked", "type": "fact"})
+			return b
+		}
+		return []SearchResult{
+			{ID: "m1", Score: 0.9, Data: mk("alice-secret")},
+			{ID: "m2", Score: 0.85, Data: mk("bob-secret")},
+			{ID: "m3", Score: 0.8, Data: mk("shared-note")},
+		}, nil
+	}
+
+	ctx := context.WithValue(context.Background(), UserIDKey, "alice")
+	got := ToolRecallMemory(ctx, deps, map[string]any{"query": "anything semantic"})
+	if got.IsError {
+		t.Fatalf("IsError = true: %s", got.Content[0].Text)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal([]byte(got.Content[0].Text), &items); err != nil {
+		t.Fatalf("unmarshal: %v (content=%q)", err, got.Content[0].Text)
+	}
+	keys := map[string]bool{}
+	for _, it := range items {
+		keys[it["key"].(string)] = true
+	}
+	if keys["bob-secret"] {
+		t.Error("LEAK: bob's row visible to alice on the vector path")
+	}
+	if !keys["alice-secret"] {
+		t.Error("alice's own row missing")
+	}
+	if !keys["shared-note"] {
+		t.Error("shared (empty-owner) row missing")
+	}
+	if len(items) != 2 {
+		t.Errorf("got %d items, want 2 (alice + shared)", len(items))
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes two read-isolation gaps surfaced by live MCP probing against Mac :8081. Both are orthogonal to the adopt/owner fixes in `b979e10` (PR #98) — verified against `git show b979e10` (the empty-session bypass line was in unchanged context, not a regression).

### Gap 1 — auth bypass on empty `Mcp-Session-Id` (`internal/http/mcp.go`)
The non-`initialize` session guard only ran when `Mcp-Session-Id` was non-empty. A request that **omitted** the header skipped auth entirely — under `require-auth=true` an anonymous caller reached `tools/list` and `tools/call` (running with `owner_id=''`) simply by not sending a session id.

**Fix:** authenticate **unconditionally** for every method except `initialize`/`ping`; adopt a stale/unknown session only *after* identity is established. `ping` stays unauthenticated as a transport liveness probe.

### Gap 2a — `list_memories` not owner-scoped (`pkg/mcp/tool_memory.go`)
Returned every owner's rows. Now scoped to `(owner_id = caller OR owner_id = '')` — caller's own rows plus shared (empty-owner) rows.

### Gap 2b — unfiltered `recall_memory` vector path not owner-scoped (`pkg/mcp/tool_save_recall_memory.go`)
The `room=="" && hall==""` branch returned vector hits' `Data` verbatim with no owner check, leaking other owners' rows. Routed every recall through the SQL-hydrated `recallViaVectorFiltered` (owner scope enforced authoritatively); deleted the dead `recallViaVectorSearch`.

## Tests (TDD red→green)
- `TestMCP_NoSessionHeader_RejectsAnonUnderRequireAuth` / `_RejectsAnonToolCall` → 404
- `TestMCP_NoSessionHeader_AllowsValidBearer` → 200 (regression guard, green before+after)
- `TestToolListMemories_OwnershipScoped`
- `TestToolRecallMemory_VectorPathOwnershipScoped`; rewrote `_VectorPathReturnsMetaItems` → `_VectorPathHydratesFromSQL`
- Existing adopt + room/hall-hydration tests stay green

## Verification
`go test ./internal/http/ ./pkg/mcp/` — both `ok`; `go build ./...` OK; `go vet` OK; no stale references to the deleted function.

6 files changed, +202 / −61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)