### PR TITLE
feat(profile): config-check dry-run + AuditConfig consumer migration

### DIFF
--- a/Levara/Makefile
+++ b/Levara/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build run test test-commit test-release-candidate profile-config-check benchmark clean docker arm64 proto proto-go proto-python swag contract contract-check
+.PHONY: all build run test test-commit test-release-candidate profile-config-check profile-smoke benchmark clean docker arm64 proto proto-go proto-python swag contract contract-check
 
 # Regenerate OpenAPI spec from swaggo annotations (T13).
 # Requires `go install github.com/swaggo/swag/cmd/swag@latest` once.
@@ -87,7 +87,14 @@ test-release-candidate:
 # external services.
 profile-config-check:
 	@go test -count=1 ./pkg/profile
-	@go test -count=1 ./cmd/server -run 'Profile|BuildRuntimeProfileConfig'
+	@go test -count=1 ./cmd/server -run 'Profile|BuildRuntimeProfileConfig|ConfigCheck'
+
+# Operator-facing preset smoke: build the server and run each non-enterprise
+# preset (personal, solo_pro, team) through `-config-check`. Complements
+# profile-config-check (which unit-tests the decision core) by exercising the
+# real binary against the shipped deploy/profiles/*.env.example files.
+profile-smoke:
+	@bash deploy/profiles/smoke.sh
 
 # --- Cross-compile ---
 

--- a/Levara/cmd/server/bootstrap.go
+++ b/Levara/cmd/server/bootstrap.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -707,10 +708,21 @@ func runtimeDBProvider(db *sql.DB) string {
 // buried in startup wiring. It takes the already-resolved DB handle, the auth
 // flag, and the MCP audit path so the env reads stay co-located here.
 func buildRuntimeProfileConfig(db *sql.DB, requireAuth bool, mcpAuditPath string) profile.Config {
+	cfg := profileConfigEnvFacts(requireAuth, mcpAuditPath)
+	cfg.DBProvider = runtimeDBProvider(db)
+	cfg.HasDB = db != nil
+	return cfg
+}
+
+// profileConfigEnvFacts fills the profile.Config fields derived purely from env
+// vars plus the auth flag and the MCP audit path. It is the single env→profile
+// mapping shared by the live-startup path (buildRuntimeProfileConfig) and the
+// -config-check dry run (buildConfigCheckProfileConfig); the two differ only in
+// how the DB-derived fields (DBProvider, HasDB) are resolved, which the callers
+// set afterwards.
+func profileConfigEnvFacts(requireAuth bool, mcpAuditPath string) profile.Config {
 	return profile.Config{
 		Profile:             os.Getenv("LEVARA_PROFILE"),
-		DBProvider:          runtimeDBProvider(db),
-		HasDB:               db != nil,
 		RequireAuth:         requireAuth,
 		JWTSecretSet:        strings.TrimSpace(os.Getenv("JWT_SECRET")) != "",
 		SyncEnabled:         strings.TrimSpace(os.Getenv("LEVARA_SYNC_REMOTE_URL")) != "",
@@ -719,6 +731,50 @@ func buildRuntimeProfileConfig(db *sql.DB, requireAuth bool, mcpAuditPath string
 		AuditSinkSet:        auditSinkConfigured(mcpAuditPath),
 		SSOBridgeConfigured: ssoBridgeConfigured(),
 	}
+}
+
+// configCheckDBProvider derives the DB provider for the -config-check dry run
+// from env alone (no live handle): "sqlite" when explicitly selected, otherwise
+// "postgres" — the bootstrap default that initSQLRuntime would resolve.
+func configCheckDBProvider() string {
+	if os.Getenv("DB_PROVIDER") == "sqlite" {
+		return "sqlite"
+	}
+	return "postgres"
+}
+
+// buildConfigCheckProfileConfig assembles the profile.Config for the
+// -config-check dry run from env + flags only. Unlike buildRuntimeProfileConfig
+// it never opens a database: it validates the *declared* configuration
+// (DBProvider from DB_PROVIDER, HasDB assumed true) so an operator can verify a
+// profile preset before any service — DB, embedder, listeners — is brought up.
+func buildConfigCheckProfileConfig(requireAuth bool, mcpAuditPath string) profile.Config {
+	cfg := profileConfigEnvFacts(requireAuth, mcpAuditPath)
+	cfg.DBProvider = configCheckDBProvider()
+	cfg.HasDB = true
+	return cfg
+}
+
+// runConfigCheck implements the -config-check dry run: it resolves the runtime
+// profile config from env + flags, evaluates it (strict or warn-only), writes a
+// human-readable report to w, and returns a process exit code — 0 when the
+// configuration is acceptable, 1 when strict mode finds a fatal error. It opens
+// no listeners, no DB connection, and makes no network calls, so it is safe to
+// run anywhere, including CI and the `make profile-smoke` target.
+func runConfigCheck(w io.Writer, requireAuth bool, mcpAuditPath string, strict bool) int {
+	cfg := buildConfigCheckProfileConfig(requireAuth, mcpAuditPath)
+	findings, fatal := evaluateRuntimeProfile(cfg, strict)
+	fmt.Fprintf(w, "profile: %s (strict=%v, db_provider=%s, require_auth=%v)\n",
+		profile.Normalize(cfg.Profile), strict, cfg.DBProvider, cfg.RequireAuth)
+	for _, f := range findings {
+		fmt.Fprintf(w, "  [%s] %s: %s\n", f.Level, f.Code, f.Message)
+	}
+	if fatal {
+		fmt.Fprintln(w, "config-check: FAIL (strict-mode profile errors)")
+		return 1
+	}
+	fmt.Fprintln(w, "config-check: OK")
+	return 0
 }
 
 // ssoBridgeConfigured reports whether an enterprise identity bridge (OIDC/SAML)

--- a/Levara/cmd/server/config_check_test.go
+++ b/Levara/cmd/server/config_check_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// profileEnvKeys are every env var the profile-fact derivation reads. Tests
+// reset all of them so an ambient value in the developer's shell cannot leak
+// into a case and flip an assertion.
+var profileEnvKeys = []string{
+	"LEVARA_PROFILE",
+	"DB_PROVIDER",
+	"JWT_SECRET",
+	"LEVARA_SYNC_REMOTE_URL",
+	"LEVARA_TOKEN",
+	"LEVARA_TENANT_ENFORCED",
+	"LEVARA_WORKSPACE_AUDIT_EXPORT",
+	"LEVARA_SSO_BRIDGE",
+}
+
+func setProfileEnv(t *testing.T, overrides map[string]string) {
+	t.Helper()
+	for _, k := range profileEnvKeys {
+		t.Setenv(k, "")
+	}
+	for k, v := range overrides {
+		t.Setenv(k, v)
+	}
+}
+
+func TestRunConfigCheckPersonalOK(t *testing.T) {
+	setProfileEnv(t, map[string]string{
+		"LEVARA_PROFILE": "personal",
+		"DB_PROVIDER":    "sqlite",
+	})
+	var out strings.Builder
+	// Personal has no requirements, so even strict mode is clean.
+	if code := runConfigCheck(&out, false, "", true); code != 0 {
+		t.Fatalf("personal strict: exit code = %d, want 0\noutput:\n%s", code, out.String())
+	}
+	s := out.String()
+	if !strings.Contains(s, "profile: personal") {
+		t.Errorf("output missing profile line:\n%s", s)
+	}
+	if !strings.Contains(s, "config-check: OK") {
+		t.Errorf("output missing OK line:\n%s", s)
+	}
+}
+
+func TestRunConfigCheckTeamStrictFailsWithoutAuth(t *testing.T) {
+	setProfileEnv(t, map[string]string{
+		"LEVARA_PROFILE": "team",
+		"DB_PROVIDER":    "postgres",
+		"JWT_SECRET":     "stable-secret",
+	})
+	var out strings.Builder
+	// Team strict requires required auth; -require-auth flag is off here.
+	if code := runConfigCheck(&out, false, "", true); code != 1 {
+		t.Fatalf("team strict without auth: exit code = %d, want 1\noutput:\n%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "team_requires_auth") {
+		t.Errorf("expected team_requires_auth finding:\n%s", out.String())
+	}
+}
+
+func TestRunConfigCheckTeamStrictOKWithAuth(t *testing.T) {
+	setProfileEnv(t, map[string]string{
+		"LEVARA_PROFILE": "team",
+		"DB_PROVIDER":    "postgres",
+		"JWT_SECRET":     "stable-secret",
+	})
+	var out strings.Builder
+	if code := runConfigCheck(&out, true, "", true); code != 0 {
+		t.Fatalf("team strict with auth: exit code = %d, want 0\noutput:\n%s", code, out.String())
+	}
+}
+
+func TestRunConfigCheckTeamNonStrictNeverFatal(t *testing.T) {
+	setProfileEnv(t, map[string]string{
+		"LEVARA_PROFILE": "team",
+		"DB_PROVIDER":    "postgres",
+		"JWT_SECRET":     "stable-secret",
+	})
+	var out strings.Builder
+	// Warn-only mode surfaces the missing-auth finding but never fails.
+	if code := runConfigCheck(&out, false, "", false); code != 0 {
+		t.Fatalf("team non-strict: exit code = %d, want 0\noutput:\n%s", code, out.String())
+	}
+	if !strings.Contains(out.String(), "config-check: OK") {
+		t.Errorf("non-strict run should report OK:\n%s", out.String())
+	}
+}
+
+func TestBuildConfigCheckProfileConfigDerivesFromEnv(t *testing.T) {
+	setProfileEnv(t, map[string]string{"DB_PROVIDER": "sqlite"})
+	cfg := buildConfigCheckProfileConfig(false, "")
+	if !cfg.HasDB {
+		t.Error("config-check should assume a DB is declared (HasDB=true)")
+	}
+	if cfg.DBProvider != "sqlite" {
+		t.Errorf("DBProvider = %q, want sqlite", cfg.DBProvider)
+	}
+
+	setProfileEnv(t, map[string]string{"DB_PROVIDER": ""})
+	cfg = buildConfigCheckProfileConfig(false, "")
+	if cfg.DBProvider != "postgres" {
+		t.Errorf("DBProvider = %q, want postgres (bootstrap default)", cfg.DBProvider)
+	}
+}

--- a/Levara/cmd/server/main.go
+++ b/Levara/cmd/server/main.go
@@ -185,8 +185,17 @@ func main() {
 	raftPortBase := flag.Int("raft-port", 9000, "Base port for Raft (shard N listens on base+N)")
 	joinAddr := flag.String("join-addr", "", "Primary node address to join as replica (e.g. 10.23.0.53:8080)")
 	mcpAuditPath := flag.String("mcp-audit-log", "", "Directory for daily-rolled MCP audit logs (empty = stderr; '-' disables)")
+	configCheck := flag.Bool("config-check", false, "Validate the resolved profile/config from env + flags and exit (no listeners, no DB, no network)")
 
 	flag.Parse()
+
+	// Dry-run config validation: resolve and check the runtime profile, then
+	// exit. Runs before any external init (storage, vector, SQL, listeners) so
+	// an operator — or `make profile-smoke` — can verify a profile preset with
+	// no services up. Exit 0 = acceptable, 1 = strict-mode fatal.
+	if *configCheck {
+		os.Exit(runConfigCheck(os.Stdout, *requireAuth, *mcpAuditPath, truthyEnv("LEVARA_PROFILE_STRICT")))
+	}
 
 	// ---------------------------------------------------------------
 	// Structured logging + error tracker (P3.4)

--- a/Levara/deploy/profiles/smoke.sh
+++ b/Levara/deploy/profiles/smoke.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Profile smoke: run each non-enterprise preset through the server's
+# `-config-check` dry run (no listeners, no DB, no network). Proves every
+# shipped preset env is internally consistent for its tier before any deploy.
+#
+# Enterprise is intentionally excluded: its strict profile asserts corporate
+# tenant/audit/SSO/storage facts that belong to a real deployment, not a local
+# smoke. The team preset is strict and requires `-require-auth` (a CLI flag env
+# cannot set), so this script passes that flag for team only — matching
+# docs/profile-presets.md.
+#
+# Usage: make profile-smoke  (or: bash deploy/profiles/smoke.sh)
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+cd "$here/../.." # -> Levara/ (module root)
+
+bin="$(mktemp -t levara-smoke.XXXXXX)"
+trap 'rm -f "$bin"' EXIT
+
+echo "[smoke] building server..."
+go build -o "$bin" ./cmd/server/
+
+# resetProfileEnv clears every env var the profile-fact derivation reads so a
+# preset sourced in one subshell never leaks into the next, and an ambient value
+# from the operator's shell never colours the result.
+reset_profile_env() {
+	unset LEVARA_PROFILE LEVARA_PROFILE_STRICT DB_PROVIDER JWT_SECRET \
+		LEVARA_TOKEN LEVARA_SYNC_REMOTE_URL LEVARA_TENANT_ENFORCED \
+		LEVARA_WORKSPACE_AUDIT_EXPORT LEVARA_SSO_BRIDGE 2>/dev/null || true
+}
+
+# check NAME ENV_FILE [extra config-check args...]
+# Runs config-check in an isolated subshell with only the preset env loaded.
+check() {
+	local name="$1" file="$2"
+	shift 2
+	echo "[smoke] $name ($file)"
+	(
+		reset_profile_env
+		set -a
+		# shellcheck disable=SC1090
+		source "deploy/profiles/$file"
+		set +a
+		"$bin" -config-check "$@"
+	)
+}
+
+fail=0
+check personal personal.local.env.example || fail=1
+check solo_pro solo_pro.sync.env.example || fail=1
+check team team.postgres.env.example -require-auth || fail=1
+
+if [ "$fail" -ne 0 ]; then
+	echo "[smoke] FAILED: a preset did not pass config-check" >&2
+	exit 1
+fi
+echo "[smoke] personal/solo_pro/team presets pass config-check"

--- a/Levara/docs/adr/002-product-ladder-and-layering.md
+++ b/Levara/docs/adr/002-product-ladder-and-layering.md
@@ -1,7 +1,9 @@
 # ADR-002: Product Ladder And Layer Boundaries
 
 Date: 2026-06-05
-Status: accepted; implementation in progress
+Status: accepted; layer split, profile validation, and product presets complete.
+Concrete enterprise backends (raw OIDC/SAML/SCIM, KMS/BYOK, corporate object
+storage) remain follow-up — see Current Follow-up Decisions.
 
 ## Context
 
@@ -91,8 +93,9 @@ engineering boundary:
    into access-layer helpers.
 9. [x] Add enterprise storage, retention, and KMS/BYOK adapter contracts.
 10. [x] Add optional OIDC verified-claims adapter above `IdentityBridge`.
-11. [ ] Add product presets/runbooks for Personal, Solo Pro, Team, and
-    Enterprise.
+11. [x] Add product presets/runbooks for Personal, Solo Pro, Team, and
+    Enterprise (`deploy/profiles/*.env.example`, `docs/profile-presets.md`,
+    `server -config-check` / `make profile-smoke`).
 
 ## Acceptance Criteria
 
@@ -111,7 +114,7 @@ engineering boundary:
   search or indexing packages.
 - [x] OIDC adapter code stays outside core search, indexing, and workspace
   handlers.
-- [ ] Product presets prove each tier can be operated without reading unrelated
+- [x] Product presets prove each tier can be operated without reading unrelated
   tier documentation.
 
 ## Current Follow-up Decisions

--- a/Levara/docs/product-ladder.md
+++ b/Levara/docs/product-ladder.md
@@ -1,13 +1,15 @@
 # Levara Product Ladder
 
 Date: 2026-06-06
-Status: implemented foundation; concrete enterprise adapters and product presets pending
+Status: implemented foundation and product presets; concrete enterprise adapters pending
 
 This document translates the current Levara architecture into a product ladder.
 It started as a planning document. The foundation has since moved into code:
 access policy, runtime profile validation, audit export, and enterprise
-identity seams and storage/KMS adapter contracts now exist. The remaining work
-is product packaging and concrete enterprise protocol/storage integrations.
+identity seams and storage/KMS adapter contracts now exist, and each tier ships
+a runnable preset (`deploy/profiles/*.env.example` + `docs/profile-presets.md`,
+validated by `server -config-check` / `make profile-smoke`). The remaining work
+is concrete enterprise protocol/storage integrations.
 
 ## Goal
 
@@ -152,5 +154,6 @@ Remaining debt:
   extraction.
 - [x] Corporate storage/KMS/retention adapter contracts are implemented and
   tested.
-- [ ] Product presets make each tier runnable without reading unrelated tier
-  documentation.
+- [x] Product presets make each tier runnable without reading unrelated tier
+  documentation (`deploy/profiles/*.env.example` + `docs/profile-presets.md`,
+  validated per tier by `server -config-check` / `make profile-smoke`).

--- a/Levara/docs/profile-presets.md
+++ b/Levara/docs/profile-presets.md
@@ -102,8 +102,20 @@ Recommended checks before committing profile or deployment changes:
 
 ```bash
 make profile-config-check
+make profile-smoke
 make test-commit
 make test-release-candidate
+```
+
+`make profile-smoke` builds the server and runs each non-enterprise preset
+(`personal`, `solo_pro`, `team`) through `server -config-check` — a dry run that
+validates the resolved profile from env + flags and exits without opening
+listeners, a database, or any network connection. Use it to confirm a preset is
+internally consistent before deploying. For a single preset:
+
+```bash
+set -a; source deploy/profiles/personal.local.env.example; set +a
+./levara-server -config-check
 ```
 
 `make test-release-candidate` does not replace manual Pi and multi-node sync

--- a/Levara/internal/http/workspace_audit.go
+++ b/Levara/internal/http/workspace_audit.go
@@ -221,23 +221,34 @@ func recordWorkspaceAuditEvent(cfg APIConfig, event workspaceAuditEvent) error {
 		return err
 	}
 	metrics.WorkspaceAuditEventsTotal.WithLabelValues(event.Source, event.Operation, event.Result).Inc()
-	if cfg.WorkspaceAuditSink != nil {
-		cfg.WorkspaceAuditSink.LogEvent(audit.Event{
-			TS:      event.At,
-			Source:  "workspace." + event.Source,
-			Type:    event.Operation,
-			Subject: event.ProjectID,
-			ActorID: event.UserID,
-			Outcome: event.Result,
-			Metadata: map[string]any{
-				"branch": event.Branch,
-				"access": event.Access,
-				"status": event.Status,
-				"error":  event.Error,
-			},
-		})
-	}
+	mirrorWorkspaceAuditEvent(cfg.Audit(), event)
 	return nil
+}
+
+// mirrorWorkspaceAuditEvent forwards a workspace-domain audit event to the
+// optional generic enterprise-export sink, mapping domain fields onto the
+// transport-independent audit.Event shape. It consumes only the narrow
+// AuditConfig group (not the full APIConfig) so enterprise audit wiring does
+// not depend on the flat compatibility wrapper (from_cod.md C3). A nil sink —
+// the default Personal/Solo Pro case — is a no-op.
+func mirrorWorkspaceAuditEvent(ac AuditConfig, event workspaceAuditEvent) {
+	if ac.WorkspaceAuditSink == nil {
+		return
+	}
+	ac.WorkspaceAuditSink.LogEvent(audit.Event{
+		TS:      event.At,
+		Source:  "workspace." + event.Source,
+		Type:    event.Operation,
+		Subject: event.ProjectID,
+		ActorID: event.UserID,
+		Outcome: event.Result,
+		Metadata: map[string]any{
+			"branch": event.Branch,
+			"access": event.Access,
+			"status": event.Status,
+			"error":  event.Error,
+		},
+	})
 }
 
 func listWorkspaceAuditEvents(cfg APIConfig, req workspaceAuditListRequest) (workspaceAuditLogResponse, error) {

--- a/Levara/internal/http/workspace_audit_mirror_test.go
+++ b/Levara/internal/http/workspace_audit_mirror_test.go
@@ -1,0 +1,84 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/stek0v/levara/pkg/audit"
+)
+
+// TestMirrorWorkspaceAuditEventForwardsToSink pins the field mapping from the
+// workspace-domain event onto the generic audit.Event handed to the enterprise
+// export sink. The helper takes only the narrow AuditConfig group (from_cod.md
+// C3), never the full APIConfig.
+func TestMirrorWorkspaceAuditEventForwardsToSink(t *testing.T) {
+	var got []audit.Event
+	ac := AuditConfig{
+		WorkspaceAuditSink: audit.EventSinkFunc(func(e audit.Event) {
+			got = append(got, e)
+		}),
+	}
+
+	mirrorWorkspaceAuditEvent(ac, workspaceAuditEvent{
+		At:        "2026-06-06T10:00:00Z",
+		Source:    "write",
+		Operation: "commit",
+		ProjectID: "proj-1",
+		Branch:    "main",
+		UserID:    "user-7",
+		Access:    "write",
+		Result:    "ok",
+		Status:    200,
+		Error:     "",
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 forwarded event, got %d", len(got))
+	}
+	e := got[0]
+	if e.TS != "2026-06-06T10:00:00Z" {
+		t.Errorf("TS: got %q", e.TS)
+	}
+	if e.Source != "workspace.write" {
+		t.Errorf("Source: got %q want %q", e.Source, "workspace.write")
+	}
+	if e.Type != "commit" {
+		t.Errorf("Type: got %q want %q", e.Type, "commit")
+	}
+	if e.Subject != "proj-1" {
+		t.Errorf("Subject: got %q want %q", e.Subject, "proj-1")
+	}
+	if e.ActorID != "user-7" {
+		t.Errorf("ActorID: got %q want %q", e.ActorID, "user-7")
+	}
+	if e.Outcome != "ok" {
+		t.Errorf("Outcome: got %q want %q", e.Outcome, "ok")
+	}
+	if e.Metadata["branch"] != "main" {
+		t.Errorf("Metadata[branch]: got %v", e.Metadata["branch"])
+	}
+	if e.Metadata["access"] != "write" {
+		t.Errorf("Metadata[access]: got %v", e.Metadata["access"])
+	}
+	if e.Metadata["status"] != 200 {
+		t.Errorf("Metadata[status]: got %v", e.Metadata["status"])
+	}
+	if _, ok := e.Metadata["error"]; !ok {
+		t.Errorf("Metadata[error] key missing")
+	}
+}
+
+// TestMirrorWorkspaceAuditEventNilSinkNoop confirms the common Personal/Solo Pro
+// path — no enterprise sink configured — is a safe no-op rather than a panic.
+func TestMirrorWorkspaceAuditEventNilSinkNoop(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("nil sink must be a no-op, got panic: %v", r)
+		}
+	}()
+	mirrorWorkspaceAuditEvent(AuditConfig{WorkspaceAuditSink: nil}, workspaceAuditEvent{
+		Source:    "read",
+		Operation: "context",
+		ProjectID: "proj-2",
+		Result:    "ok",
+	})
+}

--- a/from_cod.md
+++ b/from_cod.md
@@ -44,8 +44,10 @@ enterprise storage/KMS boundaries, and keep docs aligned with runtime behavior.
 - [x] Enterprise identity adapter seams are implemented.
 - [x] Enterprise storage, object-retention, and KMS/BYOK adapter contracts are
   implemented; concrete corporate backends remain C6 packaging/adapter work.
-- [ ] Product packaging by audience is incomplete: profiles exist, but there is
-  no one-command preset/runbook bundle per target audience.
+- [x] Product packaging by audience is complete: `deploy/profiles/*.env.example`
+  presets plus `docs/profile-presets.md` runbooks cover each tier, and
+  `server -config-check` / `make profile-smoke` give a one-command
+  per-audience validation path.
 - [x] Canonical docs were stale: `product-ladder.md` and ADR-002 still
   describe implemented behavior as future/proposed unless updated in this
   completion pass.
@@ -129,8 +131,11 @@ audience.
   - [x] storage mode;
   - [x] audit mode;
   - [x] startup failure conditions.
-- [ ] Add a lightweight local smoke script or Make target that starts each
+- [x] Add a lightweight local smoke script or Make target that starts each
   non-enterprise profile in dry-run/config-check mode once such mode exists.
+  `server -config-check` is the dry-run mode (resolves + validates the profile
+  from env/flags, opens no listeners/DB/network); `deploy/profiles/smoke.sh`
+  (`make profile-smoke`) runs personal/solo_pro/team presets through it.
 - [x] Add explicit guidance for single developer + AI agents:
   local MCP, no required auth, SQLite, workspace root, memory palace.
 - [x] Add explicit guidance for corporate teams:
@@ -179,22 +184,24 @@ Goal: move from "flat service locator with projections" to handlers/adapters
 accepting narrow groups.
 
 - [x] Pick one low-risk surface and migrate it first:
-  - [ ] workspace audit exporter wiring uses `AuditConfig`;
+  - [x] workspace audit exporter wiring uses `AuditConfig`
+    (`mirrorWorkspaceAuditEvent(cfg.Audit(), event)`);
   - [x] tenant middleware/access helpers use `AccessConfig`;
   - [x] sync manifest uses `IdentityConfig` plus narrow `AccessConfig` and
     `SearchConfig` inputs.
-- [ ] Avoid a big-bang rewrite. Migrate one group at a time and keep tests
+- [x] Avoid a big-bang rewrite. Migrate one group at a time and keep tests
   focused.
 - [x] Add a convention: new handlers/adapters must accept a narrow config group
   unless they genuinely need multiple groups.
-- [ ] Keep `APIConfig` as compatibility wrapper until call sites shrink
+- [x] Keep `APIConfig` as compatibility wrapper until call sites shrink
   naturally.
 
 Acceptance criteria:
 
 - [x] At least one production handler path no longer accepts full `APIConfig`
   when it only needs one concern.
-- [ ] New enterprise adapters do not depend on full `APIConfig`.
+- [x] New enterprise adapters do not depend on full `APIConfig`: the
+  workspace audit-export consumer takes the narrow `AuditConfig` group.
 
 ### C4: Enterprise Storage/KMS Boundary
 


### PR DESCRIPTION
Closes the remaining product-ladder / layer-split items (`from_cod.md` C1 + C3). With this, every checkbox in `from_cod.md`, `docs/product-ladder.md`, and ADR-002 is `[x]`.

## C3 — workspace audit export consumes the narrow `AuditConfig` group
- Extract `mirrorWorkspaceAuditEvent(cfg.Audit(), event)` in `internal/http/workspace_audit.go`; `recordWorkspaceAuditEvent` no longer builds `audit.Event` inline.
- The enterprise-export consumer no longer depends on the flat `APIConfig`. Nil sink (Personal/Solo Pro default) stays a no-op.
- Satisfies `from_cod.md` C3 ("workspace audit exporter wiring uses `AuditConfig`") and "new enterprise adapters do not depend on full `APIConfig`".

## C1 — `server -config-check` dry run + preset smoke
- New `-config-check` flag (runs before any external init): resolves + validates the runtime profile from env + flags, opens **no** listeners / DB / network, exits `0`=ok / `1`=strict-fatal.
- `runConfigCheck` / `buildConfigCheckProfileConfig` in `bootstrap.go`; shared `profileConfigEnvFacts` seam with the live path. Validates the *declared* config (`DBProvider` from `DB_PROVIDER`, `HasDB=true`).
- `deploy/profiles/smoke.sh` + `make profile-smoke` run personal/solo_pro/team presets through it (team with `-require-auth`; enterprise intentionally excluded).

## Tests (TDD)
- `internal/http/workspace_audit_mirror_test.go` — field-mapping forward + nil-sink no-op.
- `cmd/server/config_check_test.go` — personal ok, team strict fail/ok, non-strict never fatal, env derivation.
- `make profile-config-check` now also runs the `ConfigCheck` tests.

## Docs synced
`from_cod.md` (C1/C3 items), `docs/adr/002-product-ladder-and-layering.md` (roadmap #11 + acceptance + status), `docs/product-ladder.md`, `docs/profile-presets.md`.

## Gates (security-diff-checklist)
- `git diff --check` — clean
- `make profile-config-check` — green
- `make test-commit` (S0–S4) — green
- `go test ./docs` — green
- `make profile-smoke` — personal/solo_pro/team all OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)