### PR TITLE
test: add MCP auth regression tests for -require-auth=false

### DIFF
--- a/internal/http/mcp_auth_test.go
+++ b/internal/http/mcp_auth_test.go
@@ -1,0 +1,43 @@
+package http
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/stek0v/levara/pkg/mcp"
+)
+
+// TestMCPInitializeNoAuthRequired verifies that initialize succeeds with
+// RequireAuth=false and no auth headers.
+func TestMCPInitializeNoAuthRequired(t *testing.T) {
+	app := fiber.New()
+	h := &mcpHandler{cfg: APIConfig{RequireAuth: false}, sessions: mcp.NewSessionStore()}
+	app.Post("/mcp", h.handleRPC)
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+	code, resp := postRPC(t, app, body, nil)
+
+	if code != 200 {
+		t.Errorf("expected 200, got %d. Response: %s", code, resp)
+	}
+}
+
+// TestMCPInitializeAuthRequired verifies that initialize fails with
+// RequireAuth=true and no auth headers.
+func TestMCPInitializeAuthRequired(t *testing.T) {
+	app := fiber.New()
+	h := &mcpHandler{cfg: APIConfig{RequireAuth: true, JWTSecret: "test-secret"}, sessions: mcp.NewSessionStore()}
+	app.Post("/mcp", h.handleRPC)
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+	code, resp := postRPC(t, app, body, nil)
+
+	if code != 401 {
+		t.Errorf("expected 401, got %d. Response: %s", code, resp)
+	}
+	if !strings.Contains(resp, "authorization required") {
+		t.Errorf("expected 'authorization required' in response, got: %s", resp)
+	}
+}


### PR DESCRIPTION
## Summary

Adds test coverage for the MCP `initialize` endpoint authentication behavior, closing #101.

## Changes

- `internal/http/mcp_auth_test.go` — two new tests:

| Test | RequireAuth | Auth header | Expected |
|------|-------------|-------------|----------|
| `TestMCPInitializeNoAuthRequired` | `false` | none | `200` |
| `TestMCPInitializeAuthRequired` | `true` | none | `401` + "authorization required" |

## Background

The code in `authenticateMCPRequest` already correctly returns `("", nil)` when `RequireAuth=false` and no token is provided (line 528-531). The unit tests confirm this behaviour. The original bug report (#101) was caused by a stale binary / environment issue, not a code defect.

These tests serve as regression protection so future refactoring of the MCP auth layer doesn't accidentally break the dev-mode no-auth path.
