### PR TITLE
Enforce MCP tool OutputSchema and return structured status for delete_memory & consolidate

### DIFF
--- a/pkg/mcp/tool_consolidate.go
+++ b/pkg/mcp/tool_consolidate.go
@@ -446,5 +446,5 @@ func errResult(msg string) ToolResult {
 }
 
 func okResult(msg string) ToolResult {
-	return ToolResult{Content: []Content{{Type: "text", Text: msg}}}
+	return statusResult(true, msg)
 }

--- a/pkg/mcp/tool_delete_memory.go
+++ b/pkg/mcp/tool_delete_memory.go
@@ -2,7 +2,7 @@ package mcp
 
 import (
 	"context"
-	"fmt"
+	"strconv"
 )
 
 // ToolDeleteMemory permanently removes a memory by key — both the SQL row
@@ -100,8 +100,5 @@ func ToolDeleteMemory(ctx context.Context, deps Deps, args map[string]any) ToolR
 		}
 	}
 
-	return ToolResult{Content: []Content{{
-		Type: "text",
-		Text: fmt.Sprintf("Deleted %s (%d record(s))", key, len(targets)),
-	}}}
+	return statusResult(true, "Deleted "+key+" ("+strconv.Itoa(len(targets))+" record(s))")
 }

--- a/pkg/mcp/tools_test.go
+++ b/pkg/mcp/tools_test.go
@@ -90,54 +90,19 @@ func TestToolDescriptors_JSONMarshalsCleanly(t *testing.T) {
 	}
 }
 
-// Tools that return structured JSON in Content[0].Text should carry an
-// OutputSchema so MCP clients can validate the payload (T14). This test
-// enforces coverage on a curated set — new additions should either supply
-// OutputSchema or be justified here. Plain-text tools (codify verbose
-// prose, doctor human-readable report) aren't required to have one.
+// Every advertised tool must carry an OutputSchema so MCP clients can validate
+// the structuredContent returned from tools/call. This intentionally uses
+// tools/list as the source of truth: adding a new tool without a schema should
+// fail at the registry-contract layer before any client-specific smoke test.
 func TestToolDescriptors_OutputSchemaCoverage(t *testing.T) {
-	mustHaveSchema := []string{
-		// Original 18 (T14):
-		"cognify", "search", "cognify_status", "list_data", "delete",
-		"prune", "list_communities", "add", "save_memory", "recall_memory",
-		"list_memories", "wake_up", "pin_memory", "unpin_memory",
-		"query_entity", "cross_search", "sync", "get_feedback_stats",
-		// Docs polish (post-20.04): the previously plain-text tools
-		// gained schemas so MCP clients can validate every structured
-		// response. analyze_commits / git_search / codify produce search-
-		// shaped output; check_drift / prune_graph / doctor / heartbeat
-		// produce status / event lists; the chat + diary surfaces are
-		// the missing read paths from F-4 wave 3o.
-		"check_drift", "prune_graph", "analyze_commits", "git_search",
-		"diary_write", "diary_read",
-		"save_chat", "recall_chat", "search_chats",
-		"get_project_context", "set_context", "add_feedback",
-		"codify", "doctor", "heartbeat",
-		"workspace_access_check", "workspace_context", "workspace_audit_log", "workspace_context_artifacts",
-		"workspace_reindex_artifacts", "workspace_ops_status", "workspace_conflicts",
-		"workspace_search", "workspace_index", "workspace_delete", "workspace_gc", "workspace_manifest",
-		"workspace_read", "workspace_write", "workspace_reindex_paths",
-		"workspace_reconcile", "workspace_index_jobs", "workspace_enqueue_index_job", "workspace_retry_index_job",
-		"workspace_watch_status", "workspace_run_start", "workspace_run_get",
-		"workspace_commit", "workspace_log", "workspace_revert",
-	}
-	byName := make(map[string]Tool)
 	for _, tool := range ToolDescriptors() {
-		byName[tool.Name] = tool
-	}
-	for _, name := range mustHaveSchema {
-		tool, ok := byName[name]
-		if !ok {
-			t.Errorf("%q is in the coverage list but missing from the registry", name)
-			continue
-		}
 		if tool.OutputSchema == nil {
-			t.Errorf("tool %q lacks OutputSchema", name)
+			t.Errorf("tool %q lacks OutputSchema", tool.Name)
 			continue
 		}
 		if tool.OutputSchema["type"] != "object" {
 			t.Errorf("tool %q OutputSchema.type = %v, want 'object'",
-				name, tool.OutputSchema["type"])
+				tool.Name, tool.OutputSchema["type"])
 		}
 	}
 }
@@ -196,6 +161,7 @@ func TestToolOutputsMatchRegisteredSchemas_RoundTrip(t *testing.T) {
 	}
 
 	wakeDeps := setupWakeUpTestDB(t)
+	consolidateDeps := newConsolidateDeps(t)
 	dataDeps := &fakeDeps{
 		db:          setupListDataTestDB(t),
 		hasColls:    true,
@@ -259,6 +225,8 @@ func TestToolOutputsMatchRegisteredSchemas_RoundTrip(t *testing.T) {
 		{"pin_memory", ToolPinMemory(context.Background(), memoryDeps, map[string]any{"key": "alpha"})},
 		{"unpin_memory", ToolUnpinMemory(context.Background(), memoryDeps, map[string]any{"key": "alpha"})},
 		{"wake_up", ToolWakeUp(context.Background(), wakeDeps, map[string]any{})},
+		{"delete_memory", ToolDeleteMemory(context.Background(), memoryDeps, map[string]any{"key": "alpha"})},
+		{"consolidate", ToolConsolidate(context.Background(), consolidateDeps, map[string]any{"collection": "levara", "dry_run": true})},
 		{"diary_write", ToolDiaryWrite(context.Background(), diaryDeps, map[string]any{"agent": "reviewer", "key": "other", "value": "body"})},
 		{"diary_read", ToolDiaryRead(context.Background(), diaryDeps, map[string]any{"agent": "reviewer"})},
 		{"search", ToolSearch(context.Background(), searchDeps, map[string]any{"search_query": "hello", "search_type": "CHUNKS_LEXICAL"})},


### PR DESCRIPTION
### Motivation

- Tighten the MCP registry contract so every advertised tool provides an `outputSchema` that MCP clients can rely on for payload validation. 
- Expand the structured round-trip regression to cover previously-plain-text memory tools so schema drift is detected early. 

### Description

- Require that every tool returned by `ToolDescriptors()` has a non-nil `OutputSchema` with `type: "object"` by changing `TestToolDescriptors_OutputSchemaCoverage` in `pkg/mcp/tools_test.go`. 
- Extend the `TestToolOutputsMatchRegisteredSchemas_RoundTrip` regression to include `delete_memory` and `consolidate` (add `consolidateDeps` and add both tool calls). 
- Make `ToolDeleteMemory` return a structured `{ok, message}` payload via `statusResult(true, ...)` and use `strconv.Itoa` for formatting so it matches the registered `statusMessageSchema`. 
- Change `okResult` in `ToolConsolidate` to return `statusResult(true, msg)` so `consolidate` success responses validate against its `OutputSchema`. 
- Modified files: `pkg/mcp/tools_test.go`, `pkg/mcp/tool_delete_memory.go`, and `pkg/mcp/tool_consolidate.go`.

### Testing

- Ran `go test ./pkg/mcp -run 'TestToolDescriptors_OutputSchemaCoverage|TestToolOutputsMatchRegisteredSchemas_RoundTrip' -timeout 60s -v` and the targeted tests passed. 
- Ran the package test `go test ./pkg/mcp -timeout 120s` and the package tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dd157aa50832d9cdd75fc7b688c27)