### PR TITLE
Fix empty MCP array responses

### DIFF
--- a/internal/http/mcp_observability.go
+++ b/internal/http/mcp_observability.go
@@ -267,7 +267,7 @@ func (h *mcpHandler) toolSyncStatus(ctx context.Context, args map[string]any) mc
 		Types     json.RawMessage `json:"types,omitempty"`
 		At        string          `json:"at"`
 	}
-	var events []evt
+	events := []evt{}
 
 	for rows.Next() {
 		var id, payload, createdAt string

--- a/internal/http/mcp_observability_test.go
+++ b/internal/http/mcp_observability_test.go
@@ -172,6 +172,18 @@ func TestToolSyncStatus_NoDB(t *testing.T) {
 	}
 }
 
+func TestToolSyncStatus_NoEventsReturnsEmptyArray(t *testing.T) {
+	h, _ := observabilityTestHandler(t)
+	out := decodeText(t, h.toolSyncStatus(context.Background(), nil))
+	events, ok := out["events"].([]any)
+	if !ok {
+		t.Fatalf("events should be []any, got %T", out["events"])
+	}
+	if len(events) != 0 {
+		t.Fatalf("events len = %d, want 0", len(events))
+	}
+}
+
 func TestToolSyncStatus_GroupsByDirection(t *testing.T) {
 	h, db := observabilityTestHandler(t)
 	now := time.Now()

--- a/internal/http/response_meta.go
+++ b/internal/http/response_meta.go
@@ -26,7 +26,11 @@ func attachSearchDebugMetadata(c *fiber.Ctx, payload fiber.Map) fiber.Map {
 		debug["strategy"] = rd.SearchType
 		debug["confidence"] = rd.Confidence
 		debug["reason"] = rd.Reason
-		debug["alternatives"] = rd.Alternatives
+		alternatives := rd.Alternatives
+		if alternatives == nil {
+			alternatives = []router.Alternative{}
+		}
+		debug["alternatives"] = alternatives
 	}
 	payload["debug"] = debug
 	return payload

--- a/pkg/mcp/tool_search.go
+++ b/pkg/mcp/tool_search.go
@@ -367,11 +367,15 @@ func ToolSearch(ctx context.Context, deps Deps, args map[string]any) ToolResult 
 		response["results"] = results
 	}
 	if routingInfo != nil {
+		alternatives := routingInfo.Alternatives
+		if alternatives == nil {
+			alternatives = []router.Alternative{}
+		}
 		response["routing"] = map[string]any{
 			"selected_type": routingInfo.SearchType,
 			"reason":        routingInfo.Reason,
 			"confidence":    routingInfo.Confidence,
-			"alternatives":  routingInfo.Alternatives,
+			"alternatives":  alternatives,
 			"source":        "routed",
 		}
 	}

--- a/pkg/mcp/tool_search_test.go
+++ b/pkg/mcp/tool_search_test.go
@@ -494,6 +494,13 @@ func TestToolSearch_AUTORoutesThroughRouter(t *testing.T) {
 	if routing["source"] != "routed" {
 		t.Errorf("routing.source=%v, want 'routed'", routing["source"])
 	}
+	alternatives, ok := routing["alternatives"].([]any)
+	if !ok {
+		t.Fatalf("routing.alternatives should be []any, got %T", routing["alternatives"])
+	}
+	if len(alternatives) != 0 {
+		t.Errorf("routing.alternatives len=%d, want 0", len(alternatives))
+	}
 }
 
 func TestToolSearch_ModeRagCoercesGraphType(t *testing.T) {


### PR DESCRIPTION
### Motivation
- Avoid returning `null` for array fields in MCP/HTTP responses so clients and tools always receive an empty array (`[]`) when no items exist, fixing observed `null` results in `search` (`alternatives`) and `sync_status` (`events`).
- Prevent downstream consumers from having to special-case `null` vs `[]` and add regression coverage to prevent regressions.

### Description
- Normalize routed search alternatives in `ToolSearch` so `routing.alternatives` is `[]` instead of `null` when no alternatives are present by copying/normalizing `routingInfo.Alternatives` before building the response (`pkg/mcp/tool_search.go`).
- Normalize HTTP debug metadata `debug.alternatives` the same way when attaching routing debug info (`internal/http/response_meta.go`).
- Initialize the `events` slice in the sync status tool so `sync_status.events` serializes as an empty array when there are no heartbeats (`internal/http/mcp_observability.go`).
- Add regression tests for both cases: verify empty `routing.alternatives` in `ToolSearch` tests and empty `events` in `toolSyncStatus` tests (`pkg/mcp/tool_search_test.go` and `internal/http/mcp_observability_test.go`).

### Testing
- Ran `go test ./pkg/mcp ./internal/http` and the test suites passed for the modified packages. 
- New regression tests for empty search alternatives and empty sync events were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ddce41330832d8d5d7bd189ed46ee)