### PR TITLE
perf(server): reduce idle memory index polling

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -41,6 +41,9 @@ POSTGRES_DSN=
 EMBEDDING_ENDPOINT=
 EMBEDDING_MODEL=text-embedding-3-small
 EMBEDDING_DIMENSIONS=1024
+# Poll interval for the durable memory embedding outbox. Lower values reduce
+# indexing latency but increase idle database polling. Go durations are valid.
+LEVARA_MEMORY_INDEX_WORKER_INTERVAL=250ms
 
 # LLM / cognify
 LLM_PROVIDER=

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -141,6 +141,10 @@ func durationEnv(key string, fallback time.Duration) time.Duration {
 	return fallback
 }
 
+func memoryIndexWorkerInterval() time.Duration {
+	return durationEnv("LEVARA_MEMORY_INDEX_WORKER_INTERVAL", 250*time.Millisecond)
+}
+
 func intEnv(key string, fallback int) int {
 	v := strings.TrimSpace(os.Getenv(key))
 	if v == "" {
@@ -715,7 +719,7 @@ func main() {
 	// MCP (Model Context Protocol) server — JSON-RPC 2.0 for AI agent integration
 	vectorHttp.RegisterMCPAPI(app, mcpCfg)
 	vectorHttp.StartConsolidationRecovery(mcpCfg)
-	stopMemoryIndexWorker := vectorHttp.StartMemoryIndexWorker(mcpCfg, 5*time.Millisecond)
+	stopMemoryIndexWorker := vectorHttp.StartMemoryIndexWorker(mcpCfg, memoryIndexWorkerInterval())
 	defer stopMemoryIndexWorker()
 
 	// Opt-in background memory-consolidation janitor. Off unless

--- a/cmd/server/memory_index_worker_config_test.go
+++ b/cmd/server/memory_index_worker_config_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMemoryIndexWorkerInterval(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{name: "default", want: 250 * time.Millisecond},
+		{name: "duration override", value: "1s", want: time.Second},
+		{name: "integer seconds", value: "2", want: 2 * time.Second},
+		{name: "invalid falls back", value: "not-a-duration", want: 250 * time.Millisecond},
+		{name: "non-positive falls back", value: "0", want: 250 * time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("LEVARA_MEMORY_INDEX_WORKER_INTERVAL", tt.value)
+			if got := memoryIndexWorkerInterval(); got != tt.want {
+				t.Fatalf("memoryIndexWorkerInterval() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- make the durable memory embedding outbox poll interval configurable
- raise the default interval from 5 ms to 250 ms
- document the environment variable and cover duration parsing and fallback behavior

## Why

`StartMemoryIndexWorker` starts 8 workers. Each worker owns a ticker and attempts to claim outbox work on every tick. With the server's previous hard-coded 5 ms interval, an idle instance could perform up to roughly 1,600 empty claim attempts per second against SQLite.

On a low-power Intel N100 host running the personal SQLite/standalone-embed setup, this showed up as approximately 51-52% of one CPU while Levara was idle.

## Impact

The 250 ms default reduces idle polling frequency by 50x while keeping indexing latency well below one second for the default configuration. Deployments that prefer lower latency can set a shorter interval; low-power deployments can choose a longer one with `LEVARA_MEMORY_INDEX_WORKER_INTERVAL`.

Observed idle CPU samples on the N100 host:

| Worker interval | Levara CPU samples |
| --- | --- |
| 5 ms (previous hard-coded value) | 51-52% |
| 250 ms (new default) | 3.28%, 5.81%, 3.34% |
| 1 s (configuration override) | 1.86%, 2.00%, 1.86% |

Semantic memory save and recall were also verified with the 1 s override.

## Validation

- changed Go files pass `gofmt`
- `go vet ./...`
- `go test -count=1 ./...`
- `go build ./...`
- `golangci-lint v2.12.2` (`0 issues`)

Note: a repository-wide `gofmt -l .` reports pre-existing formatting differences in untouched upstream files; both Go files changed by this PR are clean.
